### PR TITLE
Remove http: scheme from googlefonts links to avoid HTTPS/HTTP mismatches

### DIFF
--- a/samples/web/content/constraints/index.html
+++ b/samples/web/content/constraints/index.html
@@ -12,8 +12,8 @@
 
 <title>Constraints and statistics</title>
 
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
-<link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
 
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />

--- a/samples/web/content/datachannel/index.html
+++ b/samples/web/content/datachannel/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>RTCDataChannel</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />
 </head>

--- a/samples/web/content/dtmf/index.html
+++ b/samples/web/content/dtmf/index.html
@@ -12,8 +12,8 @@
 
 <title>DTMF</title>
 
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
-<link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
 
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />

--- a/samples/web/content/getusermedia-canvas/index.html
+++ b/samples/web/content/getusermedia-canvas/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>getUserMedia to canvas</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 </head>
 <body>

--- a/samples/web/content/getusermedia-filter/index.html
+++ b/samples/web/content/getusermedia-filter/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>getUserMedia + CSS filters</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
   <style>
   .blur {

--- a/samples/web/content/getusermedia-resolution/index.html
+++ b/samples/web/content/getusermedia-resolution/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>getUserMedia: select resolution</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 
   <style>

--- a/samples/web/content/getusermedia-source/index.html
+++ b/samples/web/content/getusermedia-source/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>Select audio and video sources</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel='stylesheet' href='../../css/main.css' />
 

--- a/samples/web/content/getusermedia/index.html
+++ b/samples/web/content/getusermedia/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>getUserMedia</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 </head>
 <body>

--- a/samples/web/content/munge-sdp/index.html
+++ b/samples/web/content/munge-sdp/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>Munge SDP</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />
 </head>

--- a/samples/web/content/peerconnection-audio/index.html
+++ b/samples/web/content/peerconnection-audio/index.html
@@ -12,8 +12,8 @@
 
 <title>Peer connection: audio only</title>
 
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
-<link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
 
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />

--- a/samples/web/content/peerconnection-states/index.html
+++ b/samples/web/content/peerconnection-states/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>Peer connection: states</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />
 </head>

--- a/samples/web/content/peerconnection/index.html
+++ b/samples/web/content/peerconnection/index.html
@@ -12,7 +12,7 @@
 
 <title>Peer connection</title>
 
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel="stylesheet" href="css/main.css" />

--- a/samples/web/content/trickle-ice/index.html
+++ b/samples/web/content/trickle-ice/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="chrome=1" />
 <base target="_blank">
 <title>Trickle ICE</title>
-<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="../../css/main.css" />
 <link rel='stylesheet' href="css/main.css" />
 </head>


### PR DESCRIPTION
@juberti please review

Compare the JS console at
https://googlechrome.github.io/webrtc/samples/web/content/getusermedia/
to the JS console for
https://fischman.github.io/webrtc/samples/web/content/getusermedia/

(hint, the former should show a "blocked" message and the font is wrong)
