### PR TITLE
AppRTC speed improvements, default to HD

### DIFF
--- a/samples/web/content/apprtc/css/main.css
+++ b/samples/web/content/apprtc/css/main.css
@@ -29,7 +29,7 @@ footer {
   -webkit-perspective: 1000;
 }
 #card {
-  -webkit-transition-duration: 2s;
+  -webkit-transition-duration: 0.8s;
   -webkit-transform-style: preserve-3d;
 }
 #local {

--- a/samples/web/content/apprtc/index.html
+++ b/samples/web/content/apprtc/index.html
@@ -32,6 +32,7 @@
   var audioRecvBitrate = '{{ arbr }}';
   var videoSendBitrate = '{{ vsbr }}';
   var videoRecvBitrate = '{{ vrbr }}';
+  var videoSendInitialBitrate = '{{ vsibr }}';
   var audioSendCodec = '{{ audio_send_codec }}';
   var audioRecvCodec = '{{ audio_receive_codec }}';
   setTimeout(initialize, 1);


### PR DESCRIPTION
Turn on HD by default on Chrome desktop.
Turn on improved BWE by default.
Allow the start bitrate to be set from a URL param.
Allow the ICE transports value to be set from a URL param.
Speed up the call connect transition.
Rewrite a bunch of SDP-munging JS to be simpler.

@fischman, @dutton: PTAL
