### PR TITLE
Use optional constraints for HD default.

### DIFF
--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -374,6 +374,12 @@ class MainPage(webapp2.RequestHandler):
     #
     # Keys starting with "goog" will be added to the "optional" key; all others
     # will be added to the "mandatory" key.
+    # To override this default behavior, add a "mandatory" or "optional" prefix
+    # to each key, e.g. 
+    #   "?video=optional:minWidth=1280,optional:minHeight=720,
+    #           mandatory:googNoiseReduction=true"
+    #   (Try to do 1280x720, but be willing to live with less; enable
+    #    noise reduction or die trying.)
     #
     # The audio keys are defined here: talk/app/webrtc/localaudiosource.cc
     # The video keys are defined here: talk/app/webrtc/videosource.cc


### PR DESCRIPTION
If HD is not explicitly specified, make the track constraints optional
instead of mandatory, so that we work with non-HD cameras.
Fix bug where the video= URL param no longer worked.
