### PR TITLE
Add iceTransports control via URL parameter.

### DIFF
--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -407,8 +407,7 @@ class MainPage(webapp2.RequestHandler):
     vsibr = self.request.get('vsibr', default_value = '')
     
     # Reads the ice transport from url param 'it'.
-    # Defaulting to 'all'.
-    ice_transports = self.request.get('it', default_value = 'all')
+    ice_transports = self.request.get('it', default_value = '')
 
     # Options for making pcConstraints
     dtls = self.request.get('dtls')

--- a/samples/web/content/apprtc/js/main.js
+++ b/samples/web/content/apprtc/js/main.js
@@ -392,7 +392,7 @@ function onIceCandidate(event) {
   if (event.candidate) {
     if (pcConfig.iceTransports === 'relay') {
       // Filter out non relay Candidates, if iceTransports is set to relay.
-      if (event.candidate.candidate.search('relay') < 0) {
+      if (event.candidate.candidate.search('relay') === -1) {
         return;
       }
     }


### PR DESCRIPTION
For Chrome version <=36, we filter non relay candidates if url param it
= relay is specified.  For Chrome 37, we should be able to provide relay
candidates if user specified in pcConstraints relay.
