### PR TITLE
Fix in adapter.js for chromium builds on Mac which don't have version info.

### DIFF
--- a/samples/web/js/adapter.js
+++ b/samples/web/js/adapter.js
@@ -125,9 +125,9 @@ if (navigator.mozGetUserMedia) {
   webrtcDetectedBrowser = "chrome";
   // Temporary fix until crbug/374263 is fixed.
   // Setting Chrome version to 999, if version is unavailable.
-  if (navigator.userAgent.search(/Chrom(e|ium)\/([0-9]+)\./) !== -1) {
-    webrtcDetectedVersion =
-        parseInt(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2], 10);
+  var result = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+  if (result !== null) {
+    webrtcDetectedVersion = parseInt(result[2], 10);
   } else {
     webrtcDetectedVersion = 999;
   }


### PR DESCRIPTION
Fix in adapter.js for chromium builds on Mac that don't have version
info available. See http://crbug.com/374263.
