### PR TITLE
AppRTC: full-screen after just one click instead of a double-click.

### DIFF
--- a/samples/web/content/apprtc/index.html
+++ b/samples/web/content/apprtc/index.html
@@ -39,7 +39,7 @@
   var audioRecvCodec = '{{ audio_receive_codec }}';
   setTimeout(initialize, 1);
 </script>
-<div id="container" ondblclick="enterFullScreen()">
+<div id="container" onclick="enterFullScreen()">
   <div id="card">
     <div id="local">
       <video id="localVideo" autoplay="autoplay" muted="true"/>


### PR DESCRIPTION
This is required to be usable on mobile chrome, where the dblclick event doesn't
exist (http://crbug.com/234986).

@juberti PTAL
