### PR TITLE
stop polling if peerconnection is deleted, closed or ice failed

### DIFF
--- a/samples/web/content/apprtc/js/main.js
+++ b/samples/web/content/apprtc/js/main.js
@@ -526,6 +526,9 @@ function waitForRemoteVideo() {
   if (remoteVideo.currentTime > 0) {
     transitionToActive();
   } else {
+    if (!pc || pc.iceConnectionState === 'failed' || pc.iceConnectionState === 'closed') {
+      return;
+    }
     setTimeout(waitForRemoteVideo, 10);
   }
 }


### PR DESCRIPTION
when connectivity fails, this currently keeps polling forever. 

Canary now goes to failed when TURN/TCP is blocked (https://code.google.com/p/webrtc/issues/detail?id=3249), at least on the initiator (see https://code.google.com/p/webrtc/issues/detail?id=1414).
