### PR TITLE
Send full room response down as JSON, if t=json

### DIFF
--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -505,8 +505,12 @@ class MainPage(webapp2.RequestHandler):
         initiator = 1
       else:
         # 2 occupants (full).
-        write_response(self.response, response_type,
-                       'full.html', { 'room_key': room_key })
+        params = {
+          'error': 'full',
+          'error_messages': ['The room is full.'],
+          'room_key': room_key
+        }
+        write_response(self.response, response_type, 'full.html', params)
         logging.info('Room ' + room_key + ' is full')
         return
 


### PR DESCRIPTION
@fischman PTAL. Let me know how you'd like me to indicate the room full state in the response - was thinking about reusing error_messages for this, although it might be better to have an explicit 'error' : 'full' state that would be for machine consumption.
