### PR TITLE
Add semi-colon to stereo=1 param appended to SDP in workaround code

### DIFF
--- a/samples/web/content/apprtc/js/main.js
+++ b/samples/web/content/apprtc/js/main.js
@@ -969,7 +969,7 @@ function addStereo(sdp) {
     return sdp;
 
   // Append stereo=1 to fmtp line.
-  sdpLines[fmtpLineIndex] = sdpLines[fmtpLineIndex].concat(' stereo=1');
+  sdpLines[fmtpLineIndex] = sdpLines[fmtpLineIndex].concat('; stereo=1');
 
   sdp = sdpLines.join('\r\n');
   return sdp;


### PR DESCRIPTION
```
The draft for RTP Payload Format for Opus Speech and Audio Codec (http://tools.ietf.org/html/draft-spittka-payload-rtp-opus-03)
says that the fmtp params should be separated with a semi-colon
This 1 character patch adds aforementioned semi-colon to make the SDP compatible with other parsers following this draft.
```
