### PR TITLE
Update adapter.js / autoplay for webkit browsers

### DIFF
--- a/samples/web/js/adapter.js
+++ b/samples/web/js/adapter.js
@@ -214,10 +214,12 @@ if (navigator.mozGetUserMedia) {
     } else {
       console.log('Error attaching stream to element.');
     }
+    element.play();
   };
 
   reattachMediaStream = function(to, from) {
     to.src = from.src;
+    to.play();
   };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');


### PR DESCRIPTION
Video "freezes" in webkit (Chrome & Opera), but in fact the play() method is missing on (re)attachMediaStream.

EDIT:
From some discussion with @ns_schoe on twitter, I found out that setting autoplay to video element solve this issue.
So, there are two options: remove autoplay for moz and let user set this within html attribute or add my 2 lines to support webkit.
