### PR TITLE
adding maxplaybackrate as a codec parameter

### DIFF
--- a/samples/web/content/apprtc/apprtc.py
+++ b/samples/web/content/apprtc/apprtc.py
@@ -430,8 +430,8 @@ class MainPage(webapp2.RequestHandler):
     # Set opusfec to false by default.
     opusfec = self.request.get('opusfec', default_value = 'true')
 
-    # Read url param for max_playback_rate
-    max_playback_rate = self.request.get('maxplaybackrate', default_value = '')
+    # Read url param for opusmaxpbr
+    opusmaxpbr = self.request.get('opusmaxpbr', default_value = '')
 
     # Read url params audio send bitrate (asbr) & audio receive bitrate (arbr)
     asbr = self.request.get('asbr', default_value = '')
@@ -552,7 +552,7 @@ class MainPage(webapp2.RequestHandler):
       'turn_url': turn_url,
       'stereo': stereo,
       'opusfec': opusfec,
-      'max_playback_rate': max_playback_rate,
+      'opusmaxpbr': opusmaxpbr,
       'arbr': arbr,
       'asbr': asbr,
       'vrbr': vrbr,

--- a/samples/web/content/apprtc/index.html
+++ b/samples/web/content/apprtc/index.html
@@ -38,7 +38,7 @@
   var turnUrl = '{{ turn_url }}';
   var stereo = {{ stereo }};
   var opusfec = {{ opusfec }};
-  var maxPlaybackRate = '{{ max_playback_rate }}';
+  var opusMaxPbr = '{{ opusmaxpbr }}';
   var audioSendBitrate = '{{ asbr }}';
   var audioRecvBitrate = '{{ arbr }}';
   var videoSendBitrate = '{{ vsbr }}';

--- a/samples/web/content/apprtc/js/main.js
+++ b/samples/web/content/apprtc/js/main.js
@@ -272,9 +272,9 @@ function setRemote(message) {
     message.sdp = addCodecParam(message.sdp, 'opus/48000', 'useinbandfec=1');
   }
   // Set Opus maxplaybackrate, if requested.
-  if (maxPlaybackRate) {
+  if (opusMaxPbr) {
     message.sdp = addCodecParam(message.sdp, 'opus/48000', 'maxplaybackrate=' +
-        maxPlaybackRate);
+        opusMaxPbr);
   }
   message.sdp = maybePreferAudioSendCodec(message.sdp);
   message.sdp = maybeSetAudioSendBitRate(message.sdp);


### PR DESCRIPTION
This is to add maxplaybackrate for Opus as is defined in RTP Payload Format for Opus Speech and Audio Codec (draft-spittka-payload-rtp-opus-03).
