### PR TITLE
Configuration for adapter.js registered on Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,39 @@
+{
+  "name": "adapter.js",
+  "description": "A shim to insulate apps from WebRTC spec changes and prefix differences",
+  "homepage": "http://googlechrome.github.io/webrtc/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleChrome/webrtc.git"
+  },
+  "authors": [
+    "The WebRTC project authors (http://www.webrtc.org/)",
+    "Jesús Leganés Combarro \"piranna\" <piranna@gmail.com>"
+  ],
+  "main": "samples/web/js/adapter.js",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "WebRTC",
+    "PeerConnection",
+    "RTCPeerConnection",
+    "getUserMedia",
+    "Chrome",
+    "Chromium",
+    "Firefox"
+  ],
+  "license": "BSD-3-Clause",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "index.html",
+    "samples/web/content",
+    "samples/web/css",
+    "samples/web/js/lib",
+    "samples/web/js/videopipe.js"
+  ]
+}


### PR DESCRIPTION
[Bower](http://bower.io/) is a package manager for browser-side Javascript. This allow to manage dependencies and libraries as easily as with Node.js [npm](https://github.com/npm/npm). It also has a central [package registry](http://bower.io/search/), too.

[To register a package in Bower](http://bower.io/docs/creating-packages/#register) don't require any aditional permission since it works mostly as a URL shortener pointing to git repositories and it can be done by anybody, so I've already register [adapter.js](https://github.com/GoogleChrome/webrtc/blob/master/samples/web/js/adapter.js) and [it's already available](http://bower.io/search/?q=adapter.js). Once a package/repository is registered, it's not necesary to maintain it since works by using directly the repository git tags.

This pull-request has a bower.json file that contains the metadata required by the Bower registry so the package can be easily indexable and also only download the required adapter.js file and no other files from this repo.

This fix issue #104.
