### PR TITLE
bandwidth_test - Call stop() method on localStream to release camera

### DIFF
--- a/samples/web/content/testrtc/js/bandwidth_test.js
+++ b/samples/web/content/testrtc/js/bandwidth_test.js
@@ -118,10 +118,10 @@ function testVideoBandwidth(config) {
   doGetUserMedia({audio: false, video: true}, gotStream, reportFatal);
 
   function gotStream(stream) {
-     call.pc1.addStream(stream);
-     call.establishConnection();
-     startTime = new Date();
-     setTimeout(gatherStats, statStepMs);
+    call.pc1.addStream(stream);
+    call.establishConnection();
+    startTime = new Date();
+    setTimeout(gatherStats, statStepMs);
   }
 
   function gatherStats() {
@@ -146,6 +146,7 @@ function testVideoBandwidth(config) {
   }
 
   function completed() {
+    call.pc1.getLocalStreams()[0].getVideoTracks()[0].stop();
     call.close();
     reportSuccess("RTT average: " + rttStats.getAverage() + " ms");
     reportSuccess("RTT max: " + rttStats.getMax() + " ms");


### PR DESCRIPTION
The camera remains on because peerconnection.close() does not terminate the local stream. Added a call to the stop() method on the localStream + fixed indentation.
