### PR TITLE
Fixed broken link for Canvas demo source code

### DIFF
--- a/samples/web/content/getusermedia/canvas/index.html
+++ b/samples/web/content/getusermedia/canvas/index.html
@@ -31,7 +31,7 @@
 
   <p>The variables <code>canvas</code>, <code>video</code> and <code>stream</code> are in global scope, so you can inspect them from the console.</p>
 
-  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/canvas" title="View source for this page on Github" id="viewSource">View source on Github</a>
+  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/canvas" title="View source for this page on Github" id="viewSource">View source on Github</a>
   </div>
 
   <script src="js/main.js"></script>


### PR DESCRIPTION
Due to structure refactoring some of the links to source code is broken
