### PR TITLE
Fixed broken links to source codes

### DIFF
--- a/samples/web/content/getusermedia/canvas/index.html
+++ b/samples/web/content/getusermedia/canvas/index.html
@@ -31,7 +31,7 @@
 
   <p>The variables <code>canvas</code>, <code>video</code> and <code>stream</code> are in global scope, so you can inspect them from the console.</p>
 
-  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/canvas" title="View source for this page on Github" id="viewSource">View source on Github</a>
+  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/canvas" title="View source for this page on Github" id="viewSource">View source on Github</a>
   </div>
 
   <script src="js/main.js"></script>

--- a/samples/web/content/getusermedia/filter/index.html
+++ b/samples/web/content/getusermedia/filter/index.html
@@ -52,7 +52,7 @@
 
   <p>The variables <code>canvas</code>, <code>video</code> and <code>stream</code> are in global scope, so you can inspect them from the console.</p>
 
-<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/filter" title="View source for this page on Github" id="viewSource">View source on Github</a>
+<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/filter" title="View source for this page on Github" id="viewSource">View source on Github</a>
 </div>
 
 <script src="js/main.js"></script>

--- a/samples/web/content/getusermedia/gum/index.html
+++ b/samples/web/content/getusermedia/gum/index.html
@@ -29,7 +29,7 @@
 
   <p>The <code>MediaStream</code> object <code>stream</code> passed to the <code>getUserMedia()</code> callback is in global scope, so you can inspect it from the console.</p>
 
-<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia" title="View source for this page on Github" id="viewSource">View source on Github</a>
+<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/gum" title="View source for this page on Github" id="viewSource">View source on Github</a>
 </div>
 
 <script src="js/main.js"></script>

--- a/samples/web/content/getusermedia/resolution/index.html
+++ b/samples/web/content/getusermedia/resolution/index.html
@@ -73,7 +73,7 @@
 
   <p>For more information, see <a href="http://www.html5rocks.com/en/tutorials/getusermedia/intro/" title="Media capture article by Eric Bidelman on HTML5 Rocks">Capturing Audio &amp; Video in HTML5</a> on HTML5 Rocks.</p>
 
-<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/resolution" title="View source for this page on Github" id="viewSource">View source on Github</a>
+<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/resolution" title="View source for this page on Github" id="viewSource">View source on Github</a>
 </div>
 
 <script src="js/main.js"></script>

--- a/samples/web/content/getusermedia/source/index.html
+++ b/samples/web/content/getusermedia/source/index.html
@@ -46,7 +46,7 @@
 
   <video muted autoplay></video>
 
- <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/sources" title="View source for this page on Github" id="viewSource">View source on Github</a>
+ <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/sources" title="View source for this page on Github" id="viewSource">View source on Github</a>
 </div>
 
 <script src="js/main.js"></script>

--- a/samples/web/content/peerconnection/audio/index.html
+++ b/samples/web/content/peerconnection/audio/index.html
@@ -47,7 +47,7 @@
     <button id="hangupButton">Hang Up</button>
   </div>
 
-  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection-audio" title="View source for this page on Github" id="viewSource">View source on Github</a>
+  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/audio" title="View source for this page on Github" id="viewSource">View source on Github</a>
 
 </div>
 

--- a/samples/web/content/peerconnection/constraints/index.html
+++ b/samples/web/content/peerconnection/constraints/index.html
@@ -102,7 +102,7 @@
     <div id="receiverStats"></div>
   </section>
 
-  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/constraints" title="View source for this page on Github" id="viewSource">View source on Github</a>
+  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/constraints" title="View source for this page on Github" id="viewSource">View source on Github</a>
 
 </div>
 

--- a/samples/web/content/peerconnection/dtmf/index.html
+++ b/samples/web/content/peerconnection/dtmf/index.html
@@ -76,7 +76,7 @@
     <button id="hangupButton">Hang up</button>
   </div>
 
-  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/dtmf" title="View source for this page on Github" id="viewSource">View source on Github</a>
+  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/dtmf" title="View source for this page on Github" id="viewSource">View source on Github</a>
 
 </div>
 

--- a/samples/web/content/peerconnection/munge-sdp/index.html
+++ b/samples/web/content/peerconnection/munge-sdp/index.html
@@ -69,7 +69,7 @@
 
   <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/#toc-rtcpeerconnection" title="RTCPeerConnection section of HTML5 Rocks article about WebRTC">Getting Started With WebRTC</a>.</p>
 
-<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/munge-sdp" title="View source for this page on Github" id="viewSource">View source on Github</a>
+<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/munge-sdp" title="View source for this page on Github" id="viewSource">View source on Github</a>
 </div>
 
 <script src="../../../js/adapter.js"></script>

--- a/samples/web/content/peerconnection/pc1/index.html
+++ b/samples/web/content/peerconnection/pc1/index.html
@@ -46,7 +46,7 @@
   <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/" title="HTML5 Rocks article about WebRTC by Sam Dutton">Getting Started With WebRTC</a>.</p>
 
 
-<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection" title="View source for this page on Github" id="viewSource">View source on Github</a>
+<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/peerconnection" title="View source for this page on Github" id="viewSource">View source on Github</a>
 
 </div>
 

--- a/samples/web/content/peerconnection/states/index.html
+++ b/samples/web/content/peerconnection/states/index.html
@@ -53,7 +53,7 @@
   <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/" title="HTML5 Rocks article about WebRTC by Sam Dutton">Getting Started With WebRTC</a>.</p>
 
 
-<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection" title="View source for this page on Github" id="viewSource">View source on Github</a>
+<a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/states" title="View source for this page on Github" id="viewSource">View source on Github</a>
 
 </div>
 

--- a/samples/web/content/peerconnection/trickle-ice/index.html
+++ b/samples/web/content/peerconnection/trickle-ice/index.html
@@ -102,7 +102,7 @@
 
 
 
- <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/trickleice" title="View source for this page on Github" id="viewSource">View source on Github</a>
+ <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/trickleice" title="View source for this page on Github" id="viewSource">View source on Github</a>
 </div>
 
 <script src="../../../js/adapter.js"></script>


### PR DESCRIPTION
After the change in folder structures, the links to the respective source codes were broken. 
Eg:

```
  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/dtmf" title="View source for this page on Github" id="viewSource">View source on Github</a>
```

Changed to:

```
  <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/dtmf" title="View source for this page on Github" id="viewSource">View source on Github</a>

```

I fixed the following:

GetUserMedia
- Canvas
- Resolution
- GUM
- Sources

RTCPeerConnection
- Audio
- Constraints
- DTMF
- Munge SDP
- Basic peer connection
- Display peer connection states
- Trickle ice
