### PR TITLE
Fixed stereo input and comparison

### DIFF
--- a/samples/web/content/testrtc/js/mictest.js
+++ b/samples/web/content/testrtc/js/mictest.js
@@ -18,7 +18,7 @@ function MicTest() {
   this.lowVolumeThreshold = -60;
   // Buffer size set to 0 to let Chrome choose based on the platform.
   this.bufferSize = 0;
-  this.inputBuffer = [];
+  this.lastInputBuffer = [];
   // Turning off echoCancellation constraint enables stereo input.
   this.constraints = {
     audio: {
@@ -77,7 +77,7 @@ MicTest.prototype = {
   },
 
   collectAudio: function(event) {
-    this.inputBuffer = event.inputBuffer;
+    this.lastInputBuffer = event.inputBuffer;
   },
 
   stopCollectingAudio: function() {
@@ -85,7 +85,7 @@ MicTest.prototype = {
     this.audioSource.disconnect(this.scriptNode);
     this.scriptNode.disconnect(audioContext.destination);
     // Start analyzing the audio buffer.
-    this.testNumberOfActiveChannels(this.inputBuffer);
+    this.testNumberOfActiveChannels(this.lastInputBuffer);
     testFinished();
   },
 


### PR DESCRIPTION
- Finally figured out how to get stereo input. Turned out the master constraint echoCancellation=false was all that was needed.
- testInputVolume() now returns the calculated db or volume for the provided buffer and channel.
- Rounded the db value as we do not more accuracy than a float without decimals.
