### PR TITLE
AppRTC: Add new modules for logging and pubsub.

### DIFF
--- a/samples/web/content/apprtc/js/logging.js
+++ b/samples/web/content/apprtc/js/logging.js
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+'use strict';
+
+var apprtc = apprtc || {};
+apprtc.Log = apprtc.Log || {};
+
+(function() {
+
+var Log = apprtc.Log;
+
+Log.ERROR_TOPIC = 'LOG_ERROR';
+
+Log.info = function(message) {
+  trace(message);
+};
+
+Log.warn = function(message) {
+  trace('WARNING: ' + message);
+};
+
+Log.error = function(message) {
+  trace('ERROR: ' + message);
+  apprtc.pubsub.publish(Log.ERROR_TOPIC, { error: message });
+};
+
+})();

--- a/samples/web/content/apprtc/js/pubsub.js
+++ b/samples/web/content/apprtc/js/pubsub.js
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+'use strict';
+
+var apprtc = apprtc || {};
+
+(function() {
+
+var Log = apprtc.Log;
+
+/*
+ * Simple implementation of a topic-based publish/subscribe pattern.
+ */
+var Pubsub = function() {
+  this.topics = {};
+};
+
+// Subscribe to the topic with a function that takes a single dictionary
+// argument as its paramter.
+Pubsub.prototype.subscribe = function(topic, fn) {
+  if (!topic || !fn) {
+    Log.error('Missing topic or fn!');
+    return;
+  }
+  var subscriptions = this.topics[topic];
+  if (!subscriptions) {
+    subscriptions = this.topics[topic] = [];
+  }
+  if (subscriptions.indexOf(fn) === -1) {
+    subscriptions.push(fn);
+  } else {
+    Log.warn('Already subscribed to topic.');
+  }
+};
+
+// Subscribe to all topic pair keyvals in the given dictionary.
+Pubsub.prototype.subscribeAll = function(subscriptions) {
+  for (var topic in subscriptions) {
+    this.subscribe(topic, subscriptions[topic]);
+  }
+};
+
+// Unsubscribe function from the topic.
+Pubsub.prototype.unsubscribe = function(topic, fn) {
+  var subscriptions = this.topics[topic];
+  if (subscriptions) {
+    var i = subscriptions.indexOf(fn);
+    if (i !== -1) {
+      subscriptions.splice(i, 1);
+    }
+    if (subscriptions.length === 0) {
+      delete this.topics[topic];
+    }
+  }
+};
+
+// Unsubscribe all topic pair keyvals in the given dictionary.
+Pubsub.prototype.unsubscribeAll = function(subscriptions) {
+  for (var topic in subscriptions) {
+    this.unsubscribe(topic, subscriptions[topic]);
+  }
+};
+
+// Publish to the given topic with args dictionary. Calls the subscribed
+// function using args.
+Pubsub.prototype.publish = function(topic, args) {
+  if (!topic) {
+    Log.error('Missing topic!');
+    return;
+  }
+  var subscriptions = this.topics[topic];
+  // Bail if nothing subscribed.
+  if (!subscriptions || subscriptions.length === 0) {
+    return;
+  }
+  subscriptions.forEach(function(fn) {
+    // Execute the function.
+    fn(args || {});
+  });
+};
+
+// Clears all subscriptions.
+Pubsub.prototype.clear = function() {
+  this.topics = {};
+};
+
+// Create an instance for use in apprtc.
+apprtc.pubsub = new Pubsub();
+
+})();


### PR DESCRIPTION
The logging module will publish an error topic when using Log.error in addition to logging to console. Other interested modules will eventually subscribe to the error topic (e.g. the infobox, which will then display the message).