### PR TITLE
Add support for websocket reconnect and sending BYE to apprtc

### DIFF
--- a/samples/web/content/apprtc/collider/collider/client_test.go
+++ b/samples/web/content/apprtc/collider/collider/client_test.go
@@ -90,13 +90,13 @@ func TestClientSend(t *testing.T) {
 	}
 }
 
-// Tests that closing the client will close the ReadWriteCloser.
-func TestClientClose(t *testing.T) {
+// Tests that deregistering the client will close the ReadWriteCloser.
+func TestClientDeregister(t *testing.T) {
 	c := newClient("abc", nil)
 	rwc := collidertest.MockReadWriteCloser{Closed: false}
 
 	c.register(&rwc)
-	c.close()
+	c.deregister()
 	if !rwc.Closed {
 		t.Errorf("After client.close(), rwc.Closed = %t, want true", rwc.Closed)
 	}

--- a/samples/web/content/apprtc/collider/collider/collider.go
+++ b/samples/web/content/apprtc/collider/collider/collider.go
@@ -15,6 +15,12 @@ import (
 	"strings"
 )
 
+const maxQueuedMsgCount = 1024
+const maxRoomCapacity = 2
+const registerTimeoutSec = 5
+
+var roomServerUrlBase string
+
 var rooms *roomTable
 
 // httpHandler is a HTTP handler that handles POST/DELETE requests.
@@ -56,7 +62,7 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // wsHandler is a WebSocket server that handles requests from the WebSocket client in the form of:
-// 1. { 'cmd': 'register', 'room': $ROOM, 'client': $CLIENT' },
+// 1. { 'cmd': 'register', 'roomid': $ROOM, 'clientid': $CLIENT' },
 // which binds the WebSocket client to a client ID and room ID.
 // A client should send this message only once right after the connection is open.
 // or
@@ -67,6 +73,7 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 // Unexpected messages will cause the WebSocket connection to be closed.
 func wsHandler(ws *websocket.Conn) {
 	var rid, cid string
+
 	registered := false
 
 	var msg wsClientMsg
@@ -94,7 +101,7 @@ loop:
 			}
 			registered, rid, cid = true, msg.RoomID, msg.ClientID
 
-			defer rooms.remove(msg.RoomID, msg.ClientID)
+			defer rooms.deregister(rid, cid)
 			break
 		case "send":
 			if !registered {
@@ -114,8 +121,10 @@ loop:
 	}
 }
 
-func Start(tls bool, port int) {
-	log.Printf("Starting servers: tls = %t, port = %d", tls, port)
+func Start(tls bool, port int, roomSrv string) {
+	log.Printf("Starting servers: tls = %t, port = %d, room-server=%s", tls, port, roomSrv)
+
+	roomServerUrlBase = roomSrv
 
 	http.Handle("/ws", websocket.Handler(wsHandler))
 	http.HandleFunc("/", httpHandler)

--- a/samples/web/content/apprtc/collider/collider/collider_test.go
+++ b/samples/web/content/apprtc/collider/collider/collider_test.go
@@ -21,7 +21,7 @@ var serverAddr string
 var once sync.Once
 
 func startServers() {
-	go Start(false, 8089)
+	go Start(false, 8089, "http://localhost")
 	serverAddr = "localhost:8089"
 	fmt.Println("Test WebSocket server listening on ", serverAddr)
 }
@@ -252,6 +252,65 @@ func TestRoomCleanedUpAfterTimeout(t *testing.T) {
 	time.Sleep((registerTimeoutSec + 1) * time.Second)
 
 	if l := len(rooms.rooms); l != 0 {
-		t.Errorf("After clientRegistereTimeoutInSeconds without registering the new client, len(rooms.rooms) = %d, want 0", l)
+		t.Errorf("After timeout without registering the new client, len(rooms.rooms) = %d, want 0", l)
+	}
+}
+
+func TestDeregisteredClientNotRemovedUntilTimeout(t *testing.T) {
+	setup()
+
+	rid, cid := "abc", "1"
+	conn := addWsClient(t, rid, cid)
+	c, _ := rooms.room(rid).client(cid)
+
+	conn.Close()
+
+	// Waits for the client to deregister.
+	if !waitForCondition(func() bool { return !c.registered() }) {
+		t.Errorf("After websockt.Connection.Close(), client.registered() = true, want false")
+	}
+
+	// Checks that the client is still in the room.
+	if actual, _ := rooms.room(rid).client(cid); actual != c {
+		t.Errorf("After websockt.Connection.Close(), rooms.room[rid].client[cid] = %v, want %v", actual, c)
+	}
+
+	// Checks that the client and room are removed after the timeout.
+	time.Sleep((registerTimeoutSec + 1) * time.Second)
+	if l := len(rooms.rooms); l != 0 {
+		t.Errorf("After timeout without re-registering the new client, len(rooms.rooms) = %d, want 0", l)
+	}
+}
+
+func TestReregisterClientBeforeTimeout(t *testing.T) {
+	setup()
+
+	rid, cid := "abc", "1"
+	conn := addWsClient(t, rid, cid)
+	c, _ := rooms.room(rid).client(cid)
+
+	conn.Close()
+
+	// Waits for the client to deregister.
+	if !waitForCondition(func() bool { return !c.registered() }) {
+		t.Errorf("After websockt.Connection.Close(), client.registered() = true, want false")
+	}
+
+	// Checks that the client is still in the room.
+	if actual, _ := rooms.room(rid).client(cid); actual != c {
+		t.Errorf("After websockt.Connection.Close(), rooms.room[rid].client[cid] = %v, want %v", actual, c)
+	}
+
+	// Reregister the client.
+	conn = addWsClient(t, rid, cid)
+
+	// Waits for the client to be registered.
+	if !waitForCondition(func() bool { return c.registered() }) {
+		t.Errorf("After addWsClient(...) again, client.registered() = false, want true")
+	}
+
+	// Checks that the timer has been stopped.
+	if c.timer != nil {
+		t.Errorf("After addWsClient() again, client.timer = %v, want nil", c.timer)
 	}
 }

--- a/samples/web/content/apprtc/collider/collider/room_test.go
+++ b/samples/web/content/apprtc/collider/collider/room_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewRoom(t *testing.T) {
 	id := "abc"
-	r := newRoom(id)
+	r := newRoom(nil, id)
 	if r.id != id {
 		t.Errorf("newRoom(%q).id = %q, want %q", id, r.id, id)
 	}
@@ -22,7 +22,7 @@ func TestNewRoom(t *testing.T) {
 }
 
 func TestGetOrCreateClient(t *testing.T) {
-	r := newRoom("ab")
+	r := newRoom(nil, "ab")
 	id1 := "1"
 	c1, err := r.client(id1)
 	if err != nil {
@@ -49,7 +49,7 @@ func TestGetOrCreateClient(t *testing.T) {
 
 // Tests that registering a client will deliver the queued message from the first client.
 func TestRoomRegister(t *testing.T) {
-	r := newRoom("a")
+	r := newRoom(nil, "a")
 	id1 := "1"
 	c1, _ := r.client(id1)
 	c1.enqueue("hello")
@@ -72,7 +72,7 @@ func TestRoomRegister(t *testing.T) {
 
 // Tests that the message sent before the second client joins will be queued.
 func TestRoomSendQueued(t *testing.T) {
-	r := newRoom("a")
+	r := newRoom(nil, "a")
 	id := "1"
 	m := "hi"
 	if err := r.send(id, m); err != nil {
@@ -87,7 +87,7 @@ func TestRoomSendQueued(t *testing.T) {
 
 // Tests that the message sent after the second client joins will be delivered.
 func TestRoomSendImmediately(t *testing.T) {
-	r := newRoom("a")
+	r := newRoom(nil, "a")
 	rwc := collidertest.MockReadWriteCloser{Closed: false}
 	id1, id2, m := "1", "2", "hi"
 	r.register(id2, &rwc)
@@ -106,7 +106,7 @@ func TestRoomSendImmediately(t *testing.T) {
 
 // Tests that the client is closed and removed by room.remove.
 func TestRoomDelete(t *testing.T) {
-	r := newRoom("a")
+	r := newRoom(nil, "a")
 	rwc := collidertest.MockReadWriteCloser{Closed: false}
 	id := "1"
 	r.register(id, &rwc)

--- a/samples/web/content/apprtc/collider/collidermain/main.go
+++ b/samples/web/content/apprtc/collider/collidermain/main.go
@@ -12,8 +12,9 @@ import (
 
 var tls = flag.Bool("tls", true, "whether TLS is used")
 var port = flag.Int("port", 8089, "The TCP port that the server listens on")
+var roomSrv = flag.String("room-server", "https://apprtc.appspot.com", "The origin of the room server")
 
 func main() {
 	flag.Parse()
-	collider.Start(*tls, *port)
+	collider.Start(*tls, *port, *roomSrv)
 }


### PR DESCRIPTION
Major changes:
1. Do not remove the client when the websocket is closed, instead start a timer and remove the client only if it does not reconnect within the timeout.
2. When removing a client, send a POST to https://apprtc.appspot.com/bye/roomid/clientid to help GAE clean up the room. 

Minor changes:
Moved the constants to collider.go for easier management.
Renamed some var to shorter names.
