### PR TITLE
data channel sample creates an audio-mline

### DIFF
--- a/samples/web/content/datachannel/js/main.js
+++ b/samples/web/content/datachannel/js/main.js
@@ -91,7 +91,8 @@ function createConnection() {
   remoteConnection.onicecandidate = iceCallback2;
   remoteConnection.ondatachannel = receiveChannelCallback;
 
-  localConnection.createOffer(gotDescription1, onCreateSessionDescriptionError);
+  localConnection.createOffer(gotDescription1, onCreateSessionDescriptionError,
+    { mandatory: { OfferToReceiveAudio: false, OfferToReceiveVideo: false }});
   startButton.disabled = true;
   closeButton.disabled = false;
 }


### PR DESCRIPTION
the data channel sample creates an extra audio m-line which isn't necessary.

Needs to be changed again in the future when https://code.google.com/p/webrtc/issues/detail?id=3282 is everywhere (FF 33 seems to support the RTCOfferOptions already)
