### PR TITLE
Directly call initialize() to save ~20ms in startup

### DIFF
--- a/samples/web/content/apprtc/index.html
+++ b/samples/web/content/apprtc/index.html
@@ -77,7 +77,8 @@
       videoRecvBitrate: '{{ vrbr }}',
       videoRecvCodec: '{{ video_receive_codec }}',
     };
-    setTimeout(initialize, 1);
+
+    initialize();
   </script>
 
   <script>


### PR DESCRIPTION
Using setTimeout delayed initialize() by about 10-30ms on my local server. We can directly call it to remove the delay.
