### PR TITLE
Changed stopCollectingAudio timeout from 1 to 2 seconds to ensure there is ...

### DIFF
--- a/samples/web/content/testrtc/js/mictest.js
+++ b/samples/web/content/testrtc/js/mictest.js
@@ -73,7 +73,7 @@ MicTest.prototype = {
     this.audioSource.connect(this.scriptNode);
     this.scriptNode.connect(audioContext.destination);
     this.scriptNode.onaudioprocess = this.collectAudio.bind(this);
-    this.setTimeoutWithProgressBar(this.stopCollectingAudio.bind(this), 1000);
+    this.setTimeoutWithProgressBar(this.stopCollectingAudio.bind(this), 2000);
   },
 
   collectAudio: function(event) {


### PR DESCRIPTION
...actual audio data in the buffer. The time it takes to actually capture audio data varies and this ensure the last buffer which we look at actually contains audio data. Potentially it could still be empty if for some reason the capture path takes too long to start.
