### PR TITLE
Adding ID tags to the gum and resolutions sample.

### DIFF
--- a/samples/web/content/getusermedia/gum/index.html
+++ b/samples/web/content/getusermedia/gum/index.html
@@ -29,7 +29,7 @@
 
     <h1><a href="https://googlechrome.github.io/webrtc/" title="WebRTC samples homepage">WebRTC samples</a> <span>getUserMedia</span></h1>
 
-    <video autoplay></video>
+    <video id="gum-local" autoplay></video>
 
     <p>Display the video stream from <code>getUserMedia()</code> in a video element.</p>
 

--- a/samples/web/content/getusermedia/resolution/index.html
+++ b/samples/web/content/getusermedia/resolution/index.html
@@ -72,7 +72,7 @@
 
     <p id="dimensions"></p>
 
-    <video autoplay></video>
+    <video id="gum-res-local" autoplay></video>
 
     <script src="js/main.js"></script>
 


### PR DESCRIPTION
We're pulling these pages into Telemetry. However, since we're now measuring things per video tag (like decoded frames, width and so on), Telemetry can't tell the tags apart because they have no unique IDs. This makes telemetry take the average of all values. However, we do run getusermedia for both HD and VGA, and reporting the average stream width doesn't make sense (e.g. the width is reported as 960, the average of 1280 and 640). This patch will make the values be reported separately rather than averaged.

AFAIK there are no real downsides to adding an ID, anyway.
