### PR TITLE
figure out the local type preference of the active candidate

### DIFF
--- a/samples/web/content/apprtc/js/infobox.js
+++ b/samples/web/content/apprtc/js/infobox.js
@@ -65,16 +65,25 @@ function updateInfoDiv() {
       localAddr = activeCandPair.stat('googLocalAddress');
       remoteAddr = activeCandPair.stat('googRemoteAddress');
       localAddrType = activeCandPair.stat('googLocalCandidateType');
-      remoteAddrType = activeCandPair.stat('googRemoteCandidateType');
+      remoteAddrType = activeCandPair.stat('googRemoteCandidateType')
     }
     if (localAddr && remoteAddr) {
-      var localTypePref = getCandidateTypePreference(pc, activeCandPair);
-      var remoteTypePref = getCandidateTypePreference(pc, activeCandPair, true);
+      var localCandId = activeCandPair.stat('localCandidateId');
+      var remoteCandId = activeCandPair.stat('remoteCandidateId');
+      var localCand, remoteCand;
+      var localTypePref, remoteTypePref;
+      if (localCandId && remoteCandId) {
+        localCand = getStatsReport(stats, 'localcandidate', 'id', localCandId);
+        remoteCand = getStatsReport(stats, 'remotecandidate', 'id', remoteCandId);
+        localTypePref = localCand.stat('priority') >> 24;
+        remoteTypePref = remoteCand.stat('priority') >> 24;
+        // remoteAddrType = remoteCand.stat('candidateType'); // relayED
+      }
       contents += buildLine('LocalAddr', localAddr +
-          ' (' + localAddrType + (localAddrType === 'relay' ?
+          ' (' + localAddrType + (localTypePref !== undefined ?
             ' ' + formatTypePreference(localTypePref) : '') + ')');
       contents += buildLine('RemoteAddr', remoteAddr +
-          ' (' + remoteAddrType + (remoteAddrType === 'relay' ?
+          ' (' + remoteAddrType + (remoteTypePref !== undefined ?
             ' ' + formatTypePreference(remoteTypePref) : '') + ')');
     }
     contents += buildLine();

--- a/samples/web/content/apprtc/js/infobox.js
+++ b/samples/web/content/apprtc/js/infobox.js
@@ -40,6 +40,19 @@ function refreshStats() {
   }
 }
 
+function formatTypePreference(pref) {
+  switch(pref) {
+    case 0:
+      return 'TURN/TLS';
+    case 1:
+      return 'TURN/TCP';
+    case 2:
+      return 'TURN/UDP';
+  }
+  return '';
+}
+
+
 function updateInfoDiv() {
   var contents = '<pre id=\"stats\" style=\"line-height: initial\">';
 
@@ -59,18 +72,35 @@ function updateInfoDiv() {
 
     var activeCandPair = getStatsReport(stats, 'googCandidatePair',
         'googActiveConnection', 'true');
-    var localAddr, remoteAddr, localAddrType, remoteAddrType;
+    var localAddr, remoteAddr, localAddrType, remoteAddrType,
+      ipv6, localTypePreference;
     if (activeCandPair) {
       localAddr = activeCandPair.stat('googLocalAddress');
       remoteAddr = activeCandPair.stat('googRemoteAddress');
       localAddrType = activeCandPair.stat('googLocalCandidateType');
       remoteAddrType = activeCandPair.stat('googRemoteCandidateType');
+      ipv6 = localAddr.indexOf('[') === 0;
+      pc.localDescription.sdp.split('\r\n').filter(function (line) {
+        return line.indexOf('a=candidate:') === 0;
+      }).forEach(function (line) {
+        var fields = line.split(' ');
+        var candidateAddr = (ipv6 ? ['[', fields[4], ']:', fields[5]]
+             : [fields[4], ':', fields[5]]).join('');
+        if (fields[1] === '1' && // we dont really care about RTCP
+            candidateAddr === localAddr) {
+          localTypePreference = fields[3] >> 24;
+        }
+      });
     }
     if (localAddr && remoteAddr) {
       contents += buildLine('LocalAddr', localAddr +
           ' (' + localAddrType + ')');
       contents += buildLine('RemoteAddr', remoteAddr +
           ' (' + remoteAddrType + ')');
+    }
+    if (localTypePreference >= 0 && localTypePreference <= 2) {
+      contents += buildLine('TURN type', 
+          formatTypePreference(localTypePreference));
     }
     contents += buildLine();
 

--- a/samples/web/content/apprtc/js/signaling.js
+++ b/samples/web/content/apprtc/js/signaling.js
@@ -289,29 +289,6 @@ function onIceConnectionStateChanged() {
       trace('ICE complete time: ' +
           (window.performance.now() - startTime).toFixed(0) + 'ms.');
     }
-    if (pc.iceConnectionState === 'connected') {
-      pc.getStats(function (response) {
-        var stats = response.result();
-        var activeCandPair = getStatsReport(stats, 'googCandidatePair',
-          'googActiveConnection', 'true');
-        if (activeCandPair) {
-          var localAddress = activeCandPair.stat('googLocalAddress');
-          pc.localDescription.sdp.split('\r\n').filter(function (line) {
-            return line.indexOf('a=candidate:') === 0;
-          }).forEach(function (line) {
-            var fields = line.split(' ');
-            if (fields[1] === '1' && // we dont really care about RTCP
-                [fields[4], fields[5]].join(':') === localAddress) {
-              // happens more than once with bundled candidates
-              // not sure if it can be different...
-              // for relay candidates: 2=>udp, 1=>tcp, 0=>tls
-              trace('Local active candidate priority ' + (fields[3] >> 24));
-              return;
-            }
-          });
-        }
-      });
-    }
   }
   updateInfoDiv();
 }

--- a/samples/web/content/apprtc/js/signaling.js
+++ b/samples/web/content/apprtc/js/signaling.js
@@ -289,6 +289,29 @@ function onIceConnectionStateChanged() {
       trace('ICE complete time: ' +
           (window.performance.now() - startTime).toFixed(0) + 'ms.');
     }
+    if (pc.iceConnectionState === 'connected') {
+      pc.getStats(function (response) {
+        var stats = response.result();
+        var activeCandPair = getStatsReport(stats, 'googCandidatePair',
+          'googActiveConnection', 'true');
+        if (activeCandPair) {
+          var localAddress = activeCandPair.stat('googLocalAddress');
+          pc.localDescription.sdp.split('\r\n').filter(function (line) {
+            return line.indexOf('a=candidate:') === 0;
+          }).forEach(function (line) {
+            var fields = line.split(' ');
+            if (fields[1] === '1' && // we dont really care about RTCP
+                [fields[4], fields[5]].join(':') === localAddress) {
+              // happens more than once with bundled candidates
+              // not sure if it can be different...
+              // for relay candidates: 2=>udp, 1=>tcp, 0=>tls
+              trace('Local active candidate priority ' + (fields[3] >> 24));
+              return;
+            }
+          });
+        }
+      });
+    }
   }
   updateInfoDiv();
 }

--- a/samples/web/content/apprtc/js/stats.js
+++ b/samples/web/content/apprtc/js/stats.js
@@ -51,7 +51,7 @@ function getStatsReport(stats, statObj, statName, statVal) {
         // If |statName| is present, ensure |report| has that stat.
         // If |statVal| is present, ensure the value matches.
         if (statName) {
-          var val = report.stat(statName);
+          var val = statName === 'id' ? report.id : report.stat(statName);
           found = (statVal !== undefined) ? (val === statVal) : val;
         }
         if (found) {


### PR DESCRIPTION
mostly to find out if we're using turn/udp, turn/tcp or turn/tls. Will be useful for logging in #265.
This uses the same trick as the trickle-page to determine the local type preference, based on the comment in https://groups.google.com/d/msg/discuss-webrtc/NfCgW-8FhkE/3chOYjjPcboJ

It's probably in the wrong place and should be done in the completed event (which somehow I don't get?) but this should be enough to get the idea. Currently doesn't properly work for IPv6 (I think) since the local ip will have [] in the stats but not in the candidate line.

I'd still prefer getting the serverUrl in the candidate stats, but until then this hack allows gathering the data