### PR TITLE
Added desktop capture via extension capability

### DIFF
--- a/samples/web/content/manual-test/peer2peer/index.html
+++ b/samples/web/content/manual-test/peer2peer/index.html
@@ -16,8 +16,6 @@
   <script src="js/main.js"></script>
   <link rel="stylesheet" href="../css/main.css">
 
-  <meta charset="utf-8">
-
 </head>
 <body>
 
@@ -61,8 +59,7 @@
               onclick="updateGetUserMediaConstraints();"/></label>
           <label>Video<input type="checkbox" id="video" checked
               onclick="updateGetUserMediaConstraints();"/></label>
-          <label>Screen capture<input type="checkbox" id="screencapture"
-              onclick="updateGetUserMediaConstraints();"/></label>
+          <button id="start-screencapture">Screen capture</button>
           <button onclick="editConstraints('getusermedia-constraints');">
               Edit constraints</button>
           <button class="green" id="re-request"


### PR DESCRIPTION
- Removed the deprecated "screen" screencapture via gum.
- Added screencapture capability using desktop capture via an [extension](https://github.com/GoogleChrome/webrtc/tree/master/samples/web/content/getusermedia/desktopcapture/extension).
- Removed "<"meta charset="utf-8"">" as it's not needed.
- Fixes #219 
