### PR TITLE
Add links for manual test pages to index.html and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,28 @@ Patches and issues welcome!
 
 [Complete video chat client (based on Google App Engine)](https://apprtc.appspot.com)
 
+## Test pages ##
+
+[Audio and Video streams](https://googlechrome.github.io/webrtc/samples/web/content/manual/audio-and-video)
+
+[Constraints](https://googlechrome.github.io/webrtc/samples/web/content/manual/constraints)
+
+[Iframe apprtc](https://googlechrome.github.io/webrtc/samples/web/content/manual/iframe-apprtc)
+
+[Iframe video](https://googlechrome.github.io/webrtc/samples/web/content/manual/iframe-video)
+
+[Multiple audio streams](https://googlechrome.github.io/webrtc/samples/web/content/manual/multiple-audio)
+
+[Multiple peerconnections](https://googlechrome.github.io/webrtc/samples/web/content/manual/multiple-peerconnections)
+
+[Multiple video streams](https://googlechrome.github.io/webrtc/samples/web/content/manual/multiple-video)
+
+[Peer2peer](https://googlechrome.github.io/webrtc/samples/web/content/manual/peer2peer)
+
+[Peer2peer iframe](https://googlechrome.github.io/webrtc/samples/web/content/manual/peer2peer-iframe)
+
+[Single audio stream](https://googlechrome.github.io/webrtc/samples/web/content/manual/single-audio)
+
+[Single video stream](https://googlechrome.github.io/webrtc/samples/web/content/manual/single-video)
+
+[Two video devices](https://googlechrome.github.io/webrtc/samples/web/content/manual/two-video-devices)

--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
 
     <section>
 
-
       <p>This is a repository for client-side WebRTC code samples and the <a href="https://apprtc.appspot.com" title="AppRTC video chat client">AppRTC</a> video chat client. The source for these samples is available at <a href="//github.com/GoogleChrome/webrtc" title="View Github repositry for these files">github.com/GoogleChrome/webrtc</a>.</p>
 
       <p>Some of the samples use new browser features. They may only work in <a href="//www.google.co.uk/intl/en/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a> and/or <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a>, and may require flags to be set.</p>
@@ -106,6 +105,34 @@
       <h3 id="videoChat">Video chat</h3>
 
       <p><a href="//apprtc.appspot.com">AppRTC video chat client (based on Google App Engine)</a></p>
+
+    </section>
+
+    <section>
+
+      <h2 id="test-pages">Test pages</h2>
+
+      <p><a href="samples/web/content/manual-test/audio-and-video">Audio and video streams</a></p>
+
+      <p><a href="samples/web/content/manual-test/constraints">Constraints</a></p>
+
+      <p><a href="samples/web/content/manual-test/iframe-apprtc">Iframe apprtc</a></p>
+
+      <p><a href="samples/web/content/manual-test/iframe-video">Iframe video</a></p>
+
+      <p><a href="samples/web/content/manual-test/multiple-audio">Multiple audio streams</a></p>
+
+      <p><a href="samples/web/content/manual-test/multiple-peerconnections">Multiple peerconnections</a></p>
+
+      <p><a href="samples/web/content/manual-test/peer2peer">Peer2peer</a></p>
+
+      <p><a href="samples/web/content/manual-test/peer2peer-iframe">Peer2peer iframe</a></p>
+
+      <p><a href="samples/web/content/manual-test/single-audio">Single audio stream</a></p>
+
+      <p><a href="samples/web/content/manual-test/single-video">Single video streaḿ</a></p>
+
+      <p><a href="samples/web/content/manual-test/two-video-devices">Two video devices</a></p>
 
     </section>
 


### PR DESCRIPTION
Want to make the test pages more accessible.
