### PR TITLE
Fixing bug in setDefaultCodec; added unit test for bug

### DIFF
--- a/samples/web/content/apprtc/js/sdputils.js
+++ b/samples/web/content/apprtc/js/sdputils.js
@@ -249,19 +249,15 @@ function getCodecPayloadType(sdpLine) {
 // Returns a new m= line with the specified codec as the first one.
 function setDefaultCodec(mLine, payload) {
   var elements = mLine.split(' ');
-  var newLine = [];
-  var index = 0;
 
   // Just copy the first three parameters; codec order starts on fourth.
-  newLine[index++] = elements[0];
-  newLine[index++] = elements[1];
-  newLine[index++] = elements[2];
+  var newLine = elements.slice(0, 3);
 
   // Put target payload first and copy in the rest.
-  newLine[index++] = payload;
+  newLine.push(payload);
   for (var i = 3; i < elements.length; i++) {
     if (elements[i] !== payload) {
-      newLine[index++] = elements[i];
+      newLine.push(elements[i]);
     }
   }
   return newLine.join(' ');

--- a/samples/web/content/apprtc/js/sdputils_test.js
+++ b/samples/web/content/apprtc/js/sdputils_test.js
@@ -14,12 +14,12 @@
 
 var SDP_WITH_AUDIO_CODECS =
     ['v=0',
-     'm=audio 8 RTP/SAVPF 111 103 104 0 8',
+     'm=audio 9 RTP/SAVPF 111 103 104 0 9',
      'a=rtcp-mux',
      'a=rtpmap:111 opus/48000/2',
      'a=fmtp:111 minptime=10',
      'a=rtpmap:103 ISAC/16000',
-     'a=rtpmap:104 ISAC/32000',
+     'a=rtpmap:9 G722/8000',
      'a=rtpmap:0 PCMU/8000',
      'a=rtpmap:8 PCMA/8000',
     ].join('\r\n');
@@ -31,7 +31,7 @@ SdpUtilsTest.prototype.testMovesIsac16KToDefaultWhenPreferred = function() {
                                 'iSAC/16000');
   var audioLine = result.split('\r\n')[1];
   assertEquals('iSAC 16K (of type 103) should be moved to front.',
-               'm=audio 8 RTP/SAVPF 103 111 104 0 8',
+               'm=audio 9 RTP/SAVPF 103 111 104 0 9',
                audioLine);
 };
 
@@ -46,9 +46,9 @@ SdpUtilsTest.prototype.testDoesNothingIfPreferredCodecNotFound = function() {
 
 SdpUtilsTest.prototype.testMovesCodecEvenIfPayloadTypeIsSameAsUdpPort = function() {
   var result = maybePreferCodec(SDP_WITH_AUDIO_CODECS, 'audio', 'send',
-                                'PCMA/8000');
+                                'G722/8000');
   var audioLine = result.split('\r\n')[1];
-  assertEquals('PCMA/8000 (of type 8) should be moved to front.',
-               'm=audio 8 RTP/SAVPF 8 111 103 104 0',
+  assertEquals('G722/8000 (of type 9) should be moved to front.',
+               'm=audio 9 RTP/SAVPF 9 111 103 104 0',
                audioLine);
 };

--- a/samples/web/content/peerconnection/audio/js/main.js
+++ b/samples/web/content/peerconnection/audio/js/main.js
@@ -203,19 +203,15 @@ function getCodecPayloadType(sdpLine) {
 // Returns a new m= line with the specified codec as the first one.
 function setDefaultCodec(mLine, payload) {
   var elements = mLine.split(' ');
-  var newLine = [];
-  var index = 0;
 
   // Just copy the first three parameters; codec order starts on fourth.
-  newLine[index++] = elements[0];
-  newLine[index++] = elements[1];
-  newLine[index++] = elements[2];
+  var newLine = elements.slice(0, 3);
 
   // Put target payload first and copy in the rest.
-  newLine[index++] = payload;
+  newLine.push(payload);
   for (var i = 3; i < elements.length; i++) {
     if (elements[i] !== payload) {
-      newLine[index++] = elements[i];
+      newLine.push(elements[i]);
     }
   }
   return newLine.join(' ');


### PR DESCRIPTION
Fixes a bug where setDefaultCodec clobbered the number before RTP/SAVPF in the m= line (that's the UDP port I believe?)

Essentially, it returned

m=audio RTP/SAVPF 111 8 103 104 0

but it should have returned

m=audio 8 RTP/SAVPF 8 111 103 104 0

Also adding a unit test for this and fixing the duplicated implementation in the audio example.
