### PR TITLE
gum resolution demo: fix double include

### DIFF
--- a/samples/web/content/getusermedia/resolution/index.html
+++ b/samples/web/content/getusermedia/resolution/index.html
@@ -74,8 +74,6 @@
 
     <video id="gum-res-local" autoplay></video>
 
-    <script src="js/main.js"></script>
-
     <p>For more information, see <a href="http://www.html5rocks.com/en/tutorials/getusermedia/intro/" title="Media capture article by Eric Bidelman on HTML5 Rocks">Capturing Audio &amp; Video in HTML5</a> on HTML5 Rocks.</p>
 
     <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/getusermedia/resolution" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>


### PR DESCRIPTION
js/main.js is currently included twice. Not sure why jshint did not catch that.
