### PR TITLE
Fix display sharing info

### DIFF
--- a/samples/web/content/apprtc/js/main.js
+++ b/samples/web/content/apprtc/js/main.js
@@ -27,7 +27,7 @@
 /* globals connectToRoom, hasReceivedOffer:true, isSignalingChannelReady:true,
    messageQueue, sendWSSMessage, startSignaling */
 /* exported gatheredIceCandidateTypes, sdpConstraints, onRemoteHangup,
-   waitForRemoteVideo */
+   waitForRemoteVideo, displaySharingInfo */
 
 // Variables defined in and used from loopback.js.
 /* globals setupLoopback */
@@ -114,9 +114,6 @@ function onUserMediaSuccess(stream) {
   localStream = stream;
   // Caller creates PeerConnection.
   displayStatus('');
-  if (params.isInitiator) {
-    displaySharingInfo();
-  }
   localVideo.classList.add('active');
 }
 

--- a/samples/web/content/apprtc/js/signaling.js
+++ b/samples/web/content/apprtc/js/signaling.js
@@ -18,7 +18,7 @@
    onUserMediaError, onUserMediaSuccess, params, parseJSON, pc:true,
    remoteStream:true, remoteVideo, requestTurnServers, sendAsyncUrlRequest,
    requestUserMedia, sdpConstraints, sharingDiv, webSocket:true, startTime:true,
-   transitionToActive, updateInfoDiv, waitForRemoteVideo */
+   transitionToActive, updateInfoDiv, waitForRemoteVideo, displaySharingInfo */
 /* exported connectToRoom, openSignalingChannel */
 
 'use strict';
@@ -262,6 +262,10 @@ function createPeerConnection(config, constraints) {
 }
 
 function startSignaling() {
+  if (params.isInitiator) {
+    displaySharingInfo();
+  }
+
   trace('Starting signaling.');
   startTime = window.performance.now();
   createPeerConnection(params.peerConnectionConfig,


### PR DESCRIPTION
The new signaling model does not get the "isInitiator" info until after the register POST. So we need to call displaySharingInfo after that, instead of in the callback of getUserMedia.
This also fixes the case when the remote side hangs up and the sharing info should be shown again.

TBR= @juberti 
