### PR TITLE
adapter.js: also check for mozRTCPeerConnection

### DIFF
--- a/samples/web/js/adapter.js
+++ b/samples/web/js/adapter.js
@@ -45,7 +45,7 @@ function maybeFixConfiguration(pcConfig) {
   }
 }
 
-if (navigator.mozGetUserMedia) {
+if (navigator.mozGetUserMedia && mozRTCPeerConnection) {
   console.log('This appears to be Firefox');
 
   webrtcDetectedBrowser = 'firefox';


### PR DESCRIPTION
apparently there are some custom builds of FF that have disabled webrtc peerconnections but allow GUM. Checking both mozGetUserMedia and mozRTCPeerConnection should catch those as well.

Arguably the same could be done for chromium but...