### PR TITLE
trickle demo: use bundle in gathering

### DIFF
--- a/samples/web/content/peerconnection/trickle-ice/index.html
+++ b/samples/web/content/peerconnection/trickle-ice/index.html
@@ -85,7 +85,7 @@
         <input id="ipv6" type="checkbox" checked>
       </div>
       <div>
-        <label for="unbundle">Gather unbundled RTCP candidates:</label>
+        <label for="unbundle">Gather bundled candidates:</label>
         <input id="unbundle" type="checkbox" checked>
       </div>
 

--- a/samples/web/content/peerconnection/trickle-ice/js/main.js
+++ b/samples/web/content/peerconnection/trickle-ice/js/main.js
@@ -93,7 +93,7 @@ function start() {
   // Whether we gather IPv6 candidates.
   pcConstraints.optional = [{'googIPv6': ipv6Check.checked}];
   // Whether we only gather a single set of candidates for RTP and RTCP.
-  offerConstraints.optional = [{'googUseRtpMUX': !unbundleCheck.checked}];
+  offerConstraints.optional = [{'googUseRtpMUX': unbundleCheck.checked}];
 
   trace('Creating new PeerConnection with config=' + JSON.stringify(config) +
         ', constraints=' + JSON.stringify(pcConstraints));


### PR DESCRIPTION
The description "Gather unbundled RTCP candidates" is slightly misleading since googUseRtpMUX only affects bundle, not rtcp-mux. Also changes the default semantics so one has to turn this off.