### PR TITLE
another trickle demo: measuring setup time

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,8 @@
 
       <p><a href="samples/web/content/peerconnection/trickle-ice">ICE candidate gathering from STUN/TURN servers</a></p>
 
+      <p><a href="samples/web/content/peerconnection/trickle-effect">Examine the effects of Trickle ICE</a></p>
+
       <p><a href="samples/web/content/peerconnection/webaudio-input">Web Audio output as input to peer connection</a></p>
 
       <h3 id="datachannel">RTCDataChannel</h3>

--- a/samples/web/content/peerconnection/trickle-effect/css/main.css
+++ b/samples/web/content/peerconnection/trickle-effect/css/main.css
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+button {
+  margin: 0 20px 20px 0;
+  vertical-align: top;
+  width: 155px;
+}
+div#buttons {
+  border-bottom: 1px solid #eee;
+  margin: 1em 0 1em 0;
+  padding: 0 0 1em 0;
+}
+div#local {
+  margin: 0 20px 0 0;
+}
+div#preview {
+  border-bottom: 1px solid #eee;
+  margin: 0 0 1em 0;
+  padding: 0 0 0.5em 0;
+}
+div#preview > div {
+  display: inline-block;
+  vertical-align: top;
+  width: calc(50% - 12px);
+}
+div#select {
+  margin: 0 0 1em 0;
+}
+div#selectSource {
+  margin: 0 0 1em 0;
+}
+div.source {
+  display: inline-block;
+  margin: 0 0 1em 0;
+}
+form {
+  margin: 0 0 1em 0;
+  white-space: nowrap;
+}
+h2 {
+  margin: 0 0 0.5em 0;
+}
+label {
+  margin: 0 0.4em 0 0;
+}
+textarea {
+  color: #444;
+  font-size: 0.9em;
+  font-weight: 300;
+  height: 7.0em;
+  padding: 5px;
+  width: calc(100% - 10px);
+}
+video {
+  height: 225px;
+}
+
+@media screen and (max-width: 550px) {
+  button {
+    font-weight: 500;
+    height: 56px;
+    line-height: 1.3em;
+    margin: 0 7px 15px 0;
+    width: 86px;
+  }
+  button:nth-child(3n+0) {
+    margin: 0 0 15px 0;
+  }
+  video {
+    height: 96px;
+  }
+}
+
+@media screen and (max-width: 800px) {
+  button {
+    margin: 0 15px 15px 0;
+    width: 155px;
+  }
+  div#selectSource {
+    margin: 0 0 0.5em 0;
+  }
+  div.source {
+    margin: 0 0 .2em 0;
+  }
+  select {
+    margin: 0 1.5em 0 0;
+  }
+  textarea {
+    font-size: 0.7em;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  textarea {
+    font-size: 0.5em;
+  }
+}

--- a/samples/web/content/peerconnection/trickle-effect/css/main.css
+++ b/samples/web/content/peerconnection/trickle-effect/css/main.css
@@ -15,27 +15,7 @@ div#buttons {
   margin: 1em 0 1em 0;
   padding: 0 0 1em 0;
 }
-div#local {
-  margin: 0 20px 0 0;
-}
-div#preview {
-  border-bottom: 1px solid #eee;
-  margin: 0 0 1em 0;
-  padding: 0 0 0.5em 0;
-}
-div#preview > div {
-  display: inline-block;
-  vertical-align: top;
-  width: calc(50% - 12px);
-}
 div#select {
-  margin: 0 0 1em 0;
-}
-div#selectSource {
-  margin: 0 0 1em 0;
-}
-div.source {
-  display: inline-block;
   margin: 0 0 1em 0;
 }
 form {
@@ -56,9 +36,6 @@ textarea {
   padding: 5px;
   width: calc(100% - 10px);
 }
-video {
-  height: 225px;
-}
 
 @media screen and (max-width: 550px) {
   button {
@@ -71,21 +48,12 @@ video {
   button:nth-child(3n+0) {
     margin: 0 0 15px 0;
   }
-  video {
-    height: 96px;
-  }
 }
 
 @media screen and (max-width: 800px) {
   button {
     margin: 0 15px 15px 0;
     width: 155px;
-  }
-  div#selectSource {
-    margin: 0 0 0.5em 0;
-  }
-  div.source {
-    margin: 0 0 .2em 0;
   }
   select {
     margin: 0 1.5em 0 0;

--- a/samples/web/content/peerconnection/trickle-effect/index.html
+++ b/samples/web/content/peerconnection/trickle-effect/index.html
@@ -74,6 +74,8 @@
       <div>
         <label for="trickle">Use Trickle ICE:</label>
         <input id="trickle" type="checkbox" checked>
+        <label for="halftrickle">Use Half Trickle:</label>
+        <input id="halftrickle" type="checkbox">
       </div>
       <div id="iceTransports">
         <span>IceTransports value:</span>

--- a/samples/web/content/peerconnection/trickle-effect/index.html
+++ b/samples/web/content/peerconnection/trickle-effect/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+
+  <meta name="keywords" content="WebRTC, HTML5, JavaScript">
+  <meta name="description" content="Client-side WebRTC code samples.">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1">
+
+  <base target="_blank">
+
+  <title>Trickle ICE optimization</title>
+
+  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="../../../css/main.css">
+  <link rel="stylesheet" href="css/main.css" />
+
+</head>
+
+<body>
+
+  <div id="container">
+
+    <h1><a href="https://googlechrome.github.io/webrtc/" title="WebRTC samples homepage">WebRTC samples</a> <span>To Trickle or Not</span></h1>
+
+    <section>
+
+      <p>This page shows why trickle ICE is an important optimization. Test this with various combinations of TURN servers and see how this affects the connection setup time.</p>
+
+      <p>Individual STUN and TURN servers can be added using the Add server / Remove server controls below; in addition, the type of candidates released to the application can be controlled via the IceTransports constraint.</p>
+
+    </section>
+
+    <section id="iceServers">
+
+      <h2>ICE servers</h2>
+
+      <select id="servers" size="4">
+        <option value="{&quot;url&quot;:&quot;stun:stun.l.google.com:19302&quot;}" ondblclick="selectServer(event);">stun:stun.l.google.com:19302</option>
+      </select>
+
+      <div>
+        <label for="url">STUN or TURN URI:</label>
+        <input id="url">
+      </div>
+
+      <div>
+        <label for="username">TURN username:</label>
+        <input id="username">
+      </div>
+
+      <div>
+        <label for="password">TURN password:</label>
+        <input id="password">
+      </div>
+
+      <div>
+        <button id="add">Add Server</button>
+        <button id="remove">Remove Server</button>
+      </div>
+
+    </section>
+
+    <section id="iceOptions">
+
+      <h2>ICE options</h2>
+      <div>
+        <label for="trickle">Use Trickle ICE:</label>
+        <input id="trickle" type="checkbox" checked>
+      </div>
+      <div id="iceTransports">
+        <span>IceTransports value:</span>
+        <input type="radio" name="transports" value="all" id="all" checked><label for="all">all</label>
+        <input type="radio" name="transports" value="relay" id="relay">
+        <label for="relay">relay</label>
+        <input type="radio" name="transports" value="none" id="none">
+        <label for="none">none</label>
+      </div>
+      <div>
+        <label for="ipv6">Gather IPv6 candidates:</label>
+        <input id="ipv6" type="checkbox" checked>
+      </div>
+      <div>
+        <label for="unbundle">Gather bundled candidates:</label>
+        <input id="unbundle" type="checkbox" checked>
+      </div>
+
+    </section>
+
+    <section id="buttons">
+      <button id="start">Start</button>
+    </section>
+
+    <section id="results">
+      <div>Took: <span id="result">0</span> seconds.</div>
+    </section>
+
+    <a href="https://github.com/GoogleChrome/webrtc/tree/gh-pages/samples/web/content/peerconnection/nontrickle" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+  </div>
+
+  <script src="../../../js/adapter.js"></script>
+  <script src="js/main.js"></script>
+
+  <script src="../../../js/lib/ga.js"></script>
+
+</body>
+</html>

--- a/samples/web/content/peerconnection/trickle-effect/js/main.js
+++ b/samples/web/content/peerconnection/trickle-effect/js/main.js
@@ -81,6 +81,7 @@ function start() {
   startButton.disabled = true;
   createPeerConnection();
   useTrickle = trickle.checked;
+  useHalfTrickle = halfTrickle.checked;
   createOffer();
 }
 
@@ -104,7 +105,6 @@ function createPeerConnection() {
   // on whether the unbundle RTCP checkbox is checked.
   var config = {'iceServers': iceServers };
   var pcConstraints = {'mandatory': {'IceTransports': iceTransports}};
-  var offerConstraints = {'mandatory': {'OfferToReceiveAudio': true}};
   // Whether we gather IPv6 candidates.
   pcConstraints.optional = [{'googIPv6': ipv6Check.checked}];
 
@@ -114,7 +114,6 @@ function createPeerConnection() {
   remotePeerConnection = new RTCPeerConnection(config, pcConstraints);
   trace('Created remote peer connection object remotePeerConnection');
   remotePeerConnection.onicecandidate = iceCallback2;
-  remotePeerConnection.onaddstream = gotRemoteStream;
 
   localPeerConnection.oniceconnectionstatechange = onIceConnectionStateChange;
 
@@ -179,12 +178,6 @@ function onIceConnectionStateChange() {
       startButton.disabled = false;
       break;
   }
-}
-
-function gotRemoteStream(e) {
-  // Call the polyfill wrapper to attach the media stream to this element.
-  attachMediaStream(remoteVideo, e.stream);
-  trace('Received remote stream');
 }
 
 function iceCallback1(event) {

--- a/samples/web/content/peerconnection/trickle-effect/js/main.js
+++ b/samples/web/content/peerconnection/trickle-effect/js/main.js
@@ -19,6 +19,7 @@ var usernameInput = document.querySelector('input#username');
 var ipv6Check = document.querySelector('input#ipv6');
 var unbundleCheck = document.querySelector('input#unbundle');
 var trickle = document.querySelector('input#trickle');
+var halfTrickle = document.querySelector('input#halftrickle');
 
 startButton.onclick = start;
 addButton.onclick = addServer;
@@ -33,6 +34,7 @@ var sdpConstraints = {
 };
 
 var useTrickle = false;
+var useHalfTrickle = false;
 var begin;
 
 
@@ -199,11 +201,11 @@ function iceCallback1(event) {
 }
 
 function iceCallback2(event) {
-  if (event.candidate && useTrickle) {
+  if (event.candidate && (useTrickle || useHalfTrickle)) {
     localPeerConnection.addIceCandidate(new RTCIceCandidate(event.candidate),
       onAddIceCandidateSuccess, onAddIceCandidateError);
     trace('Remote ICE candidate: \n ' + event.candidate.candidate);
-  } else if (!event.candidate && !useTrickle) {
+  } else if (!event.candidate && !(useTrickle || useHalfTrickle)) {
     localPeerConnection.setRemoteDescription(
       remotePeerConnection.localDescription,
       onSetSessionDescriptionSuccess,

--- a/samples/web/content/peerconnection/trickle-effect/js/main.js
+++ b/samples/web/content/peerconnection/trickle-effect/js/main.js
@@ -1,0 +1,220 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+'use strict';
+
+var result = document.querySelector('span#result');
+var startButton = document.querySelector('button#start');
+var addButton = document.querySelector('button#add');
+var passwordInput = document.querySelector('input#password');
+var removeButton = document.querySelector('button#remove');
+var servers = document.querySelector('select#servers');
+var urlInput = document.querySelector('input#url');
+var usernameInput = document.querySelector('input#username');
+var ipv6Check = document.querySelector('input#ipv6');
+var unbundleCheck = document.querySelector('input#unbundle');
+var trickle = document.querySelector('input#trickle');
+
+startButton.onclick = start;
+addButton.onclick = addServer;
+removeButton.onclick = removeServer;
+
+var localPeerConnection, remotePeerConnection;
+var sdpConstraints = {
+  'mandatory': {
+    'OfferToReceiveAudio': true,
+    'OfferToReceiveVideo': true
+  }
+};
+
+var useTrickle = false;
+var begin;
+
+
+function selectServer(event) {
+  var option = event.target;
+  var value = JSON.parse(option.value);
+  urlInput.value = value.url;
+  usernameInput.value = value.username || '';
+  passwordInput.value = value.credential || '';
+}
+
+function addServer() {
+  var scheme = urlInput.value.split(':')[0];
+  if (scheme !== 'stun' && scheme !== 'turn' && scheme !== 'turns') {
+    alert('URI scheme ' + scheme + ' is not valid');
+    return;
+  }
+
+  // Store the ICE server as a stringified JSON object in option.value.
+  var option = document.createElement('option');
+  var iceServer = createIceServer(urlInput.value, usernameInput.value, passwordInput.value);
+  option.value = JSON.stringify(iceServer);
+  option.text = urlInput.value + ' ';
+  var username = usernameInput.value;
+  var password = passwordInput.value;
+  if (username || password) {
+    option.text += (' [' + username + ':' + password + ']');
+  }
+  option.ondblclick = selectServer;
+  servers.add(option);
+  urlInput.value = usernameInput.value = passwordInput.value = '';
+}
+
+function removeServer() {
+  for (var i = servers.options.length - 1; i >= 0; --i) {
+    if (servers.options[i].selected) {
+      servers.remove(i);
+    }
+  }
+}
+
+
+function start() {
+  startButton.disabled = true;
+  createPeerConnection();
+  useTrickle = trickle.checked;
+  createOffer();
+}
+
+function createPeerConnection() {
+  // Read the values from the input boxes.
+  var iceServers = [];
+  for (var i = 0; i < servers.length; ++i) {
+     iceServers.push(JSON.parse(servers[i].value));
+  }
+  var transports = document.getElementsByName('transports');
+  var iceTransports;
+  for (i = 0; i < transports.length; ++i) {
+    if (transports[i].checked) {
+      iceTransports = transports[i].value;
+      break;
+    }
+  }
+
+  // Create a PeerConnection with no streams, but force a m=audio line.
+  // This will gather candidates for either 1 or 2 ICE components, depending
+  // on whether the unbundle RTCP checkbox is checked.
+  var config = {'iceServers': iceServers };
+  var pcConstraints = {'mandatory': {'IceTransports': iceTransports}};
+  var offerConstraints = {'mandatory': {'OfferToReceiveAudio': true}};
+  // Whether we gather IPv6 candidates.
+  pcConstraints.optional = [{'googIPv6': ipv6Check.checked}];
+
+  localPeerConnection = new RTCPeerConnection(config, pcConstraints);
+  trace('Created local peer connection object localPeerConnection');
+  localPeerConnection.onicecandidate = iceCallback1;
+  remotePeerConnection = new RTCPeerConnection(config, pcConstraints);
+  trace('Created remote peer connection object remotePeerConnection');
+  remotePeerConnection.onicecandidate = iceCallback2;
+  remotePeerConnection.onaddstream = gotRemoteStream;
+
+  localPeerConnection.oniceconnectionstatechange = onIceConnectionStateChange;
+
+  sdpConstraints.optional = [{'googUseRtpMUX': unbundleCheck.checked}];
+}
+
+function onSetSessionDescriptionSuccess() {
+  trace('Set session description success.');
+}
+
+function onSetSessionDescriptionError(error) {
+  trace('Failed to set session description: ' + error.toString());
+}
+
+function createOffer() {
+  begin = window.performance.now();
+  localPeerConnection.createOffer(setOffer,
+    onCreateSessionDescriptionError,
+    sdpConstraints);
+}
+
+function onCreateSessionDescriptionError(error) {
+  trace('Failed to create session description: ' + error.toString());
+}
+
+function setOffer(offer) {
+  localPeerConnection.setLocalDescription(offer,
+    onSetSessionDescriptionSuccess,
+    onSetSessionDescriptionError);
+  if (useTrickle) {
+    remotePeerConnection.setRemoteDescription(offer,
+      createAnswer,
+      onSetSessionDescriptionError);
+  }
+}
+
+function createAnswer() {
+  // Since the 'remote' side has no media stream we need
+  // to pass in the right constraints in order for it to
+  // accept the incoming offer of audio and video.
+  remotePeerConnection.createAnswer(setAnswer,
+    onCreateSessionDescriptionError,
+    sdpConstraints);
+}
+
+function setAnswer(answer) {
+  remotePeerConnection.setLocalDescription(answer,
+    onSetSessionDescriptionSuccess,
+    onSetSessionDescriptionError);
+  if (useTrickle) {
+    localPeerConnection.setRemoteDescription(answer,
+      onSetSessionDescriptionSuccess,
+      onSetSessionDescriptionError);
+  }
+}
+
+function onIceConnectionStateChange() {
+  trace('Transition to ' + localPeerConnection.iceConnectionState);
+  switch(localPeerConnection.iceConnectionState) {
+    case 'connected':
+      result.innerHTML = (window.performance.now() - begin) / 1000.0;
+      startButton.disabled = false;
+      break;
+  }
+}
+
+function gotRemoteStream(e) {
+  // Call the polyfill wrapper to attach the media stream to this element.
+  attachMediaStream(remoteVideo, e.stream);
+  trace('Received remote stream');
+}
+
+function iceCallback1(event) {
+  if (event.candidate && useTrickle) {
+    remotePeerConnection.addIceCandidate(new RTCIceCandidate(event.candidate),
+      onAddIceCandidateSuccess, onAddIceCandidateError);
+    trace('Local ICE candidate: \n' + event.candidate.candidate);
+  } else if (!event.candidate && !useTrickle){
+    remotePeerConnection.setRemoteDescription(
+      localPeerConnection.localDescription,
+      createAnswer,
+      onSetSessionDescriptionError);
+  }
+}
+
+function iceCallback2(event) {
+  if (event.candidate && useTrickle) {
+    localPeerConnection.addIceCandidate(new RTCIceCandidate(event.candidate),
+      onAddIceCandidateSuccess, onAddIceCandidateError);
+    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
+  } else if (!event.candidate && !useTrickle) {
+    localPeerConnection.setRemoteDescription(
+      remotePeerConnection.localDescription,
+      onSetSessionDescriptionSuccess,
+      onSetSessionDescriptionError);
+  }
+}
+
+function onAddIceCandidateSuccess() {
+  trace('AddIceCandidate success.');
+}
+
+function onAddIceCandidateError(error) {
+  trace('Failed to add Ice Candidate: ' + error.toString());
+}


### PR DESCRIPTION
Since the original trickle demo is now more a demo of candidate gathering here is one that lets the user compare trickle ice and non-trickle. Mashed up from the trickle and munge demos.
Online version: http://fippo.github.io/webrtc/samples/web/content/peerconnection/trickle-effect/

It measures the time between createOffer and iceconnectionstatechange->connected. For the biggest effect I recommend disabling trickle, using a TURN/TCP or TLS server and having a virtualbox interface.

@samdutton: might be useful as part of the codelab since it demonstrates why trickle ice is such a great idea :-)