### PR TITLE
Add polyfill for getStats to spec.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,6 +124,7 @@ module.exports = function(grunt) {
       },
       files: [
         'samples/web/content/apprtc/js_test_driver.conf',
+        'samples/web/js/js_test_driver.conf',
       ]},
 
     closurecompiler: {

--- a/samples/web/js/adapter.js
+++ b/samples/web/js/adapter.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2014-2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -181,7 +181,33 @@ if (navigator.mozGetUserMedia) {
 
   // The RTCPeerConnection object.
   RTCPeerConnection = function(pcConfig, pcConstraints) {
-    return new webkitRTCPeerConnection(pcConfig, pcConstraints);
+    var pc = new webkitRTCPeerConnection(pcConfig, pcConstraints);
+    var origGetStats = pc.getStats.bind(pc);
+    pc.getStats = function(selector, successCallback) {
+      var successCallbackWrapper = function(response) {
+	successCallback(RTCPeerConnection.fixChromeStats(response));
+      };
+      return origGetStats(successCallbackWrapper, selector);
+    };
+    return pc;
+  };
+
+  RTCPeerConnection.fixChromeStats = function(response) {
+    var standardReport = {};
+    var reports = response.result();
+    reports.forEach(function(report) {
+      var standardStats = {
+	id: report.id,
+	timestamp: report.timestamp,
+	type: report.type
+      };
+      report.names().forEach(function(name) {
+	standardStats[name] = report.stat(name);
+      });
+      standardReport[standardStats.id] = standardStats;
+    });
+
+    return standardReport;
   };
 
   // Get UserMedia (only difference is the prefix).

--- a/samples/web/js/adapter_test.js
+++ b/samples/web/js/adapter_test.js
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+var AdapterTest = new TestCase('AdapterTest');
+
+AdapterTest.prototype.setUp = function() {
+  window.console.log("Setting stuff up!");
+};
+
+AdapterTest.prototype.tearDown = function() {
+  window.console.log("Tearing stuff down!");
+};
+
+// FakeReportStruct is basically a dictionary but with accessor
+// functions. This is the way that Chrome returns stats to us.
+var FakeReportStruct = function(id, timestamp, type, obj) {
+  this.id = id;
+  this.timestamp = timestamp;
+  this.type = type;
+  this.obj = obj;
+};
+
+FakeReportStruct.prototype.names = function() {
+  return Object.keys(this.obj);
+};
+
+FakeReportStruct.prototype.stat = function(key) {
+  return this.obj[key];
+};
+
+AdapterTest.prototype.testWhich = function() {
+  var chromeReport0 = new FakeReportStruct('chromeReport0', '1234', 'audio', {
+    'field1': 'value1',
+    'field2': 'value2',
+  });
+  var chromeReport1 = new FakeReportStruct('chromeReport1', '1234', 'video', {
+    'field1': 'value1',
+    'field3': 'value3',
+  });
+  var chromeReport2 = new FakeReportStruct('chromeReport2', '1234', 'data', {
+    'field1': 'value1',
+    'field2': 'value2',
+    'field3': 'value3',
+  });
+
+  var report = {}
+  report.result = function() {
+    return [chromeReport0, chromeReport1, chromeReport2];
+  }
+
+  fixedStats = RTCPeerConnection.fixChromeStats(report);
+  assertEquals(fixedStats, {
+    'chromeReport0': {
+      'id': 'chromeReport0',
+      'timestamp': '1234',
+      'type': 'audio',
+      'field1': 'value1',
+      'field2': 'value2',
+    },
+    'chromeReport1': {
+      'id': 'chromeReport1',
+      'timestamp': '1234',
+      'type': 'video',
+      'field1': 'value1',
+      'field3': 'value3',
+    },
+    'chromeReport2': {
+      'id': 'chromeReport2',
+      'timestamp': '1234',
+      'type': 'data',
+      'field1': 'value1',
+      'field2': 'value2',
+      'field3': 'value3',
+    }
+  });
+
+};

--- a/samples/web/js/js_test_driver.conf
+++ b/samples/web/js/js_test_driver.conf
@@ -1,0 +1,8 @@
+server: http://localhost:9876
+
+load:
+  - test_preload.js
+  - adapter.js
+
+test:
+  - adapter_test.js

--- a/samples/web/js/test_preload.js
+++ b/samples/web/js/test_preload.js
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* This file is used to simply extract the Chrome bits somewhere we can test. */
+
+// Fake for Chrome to take over getUserMedia.
+var webkitGetUserMediaFake = function() {
+};
+
+webkitGetUserMediaFake.prototype.bind = function() {
+};
+navigator.webkitGetUserMedia = new webkitGetUserMediaFake();
+
+// Fake for webkitRTCPeerConnection
+webkitRTCPeerConnection = function(config, constraints) {
+};


### PR DESCRIPTION
This replaces the getStats function on RTCPeerConnection to match the
format in the spec: http://w3c.github.io/webrtc-pc/#statistics-model.