### PR TITLE
Removing the need to install webtest-master.

### DIFF
--- a/run_python_tests.py
+++ b/run_python_tests.py
@@ -13,7 +13,17 @@ TEST_PATH    Path to package containing test modules.
 WEBTEST_PATH Path to the webtest library."""
 
 
+def _CheckDependencyInPlace(path):
+  if not os.path.exists(path):
+    raise Exception('Missing %s; please run run_python_tests.sh '
+                    'instead to have the dependencies downloaded.' % path)
+
+
 def main(sdk_path, test_path, webtest_path):
+    _CheckDependencyInPlace(sdk_path)
+    _CheckDependencyInPlace(test_path)
+    _CheckDependencyInPlace(webtest_path)
+
     sys.path.insert(0, sdk_path)
     import dev_appserver
     dev_appserver.fix_sys_path()

--- a/run_python_tests.sh
+++ b/run_python_tests.sh
@@ -32,13 +32,6 @@ if [ ! -d 'webtest-master' ]; then
   echo "Downloading webtest-master..."
   download $WEBTEST_FILE $WEBTEST_URL
   tar xvf $WEBTEST_FILE
-
-  # At least on my box, we must have root to modify your system python.
-  # This package only needs to be installed once.
-  echo "Missing webtest; must run sudo to install."
-  cd webtest-master
-  sudo python setup.py install
-  cd ..
 fi
 
 python run_python_tests.py google_appengine/ samples/web/content/apprtc/ webtest-master/


### PR DESCRIPTION
I tried uninstalling webtest, and it actually seems it may not need installing since we add it to sys.path in run_python_tests.sh. I also made it clearer if one runs the .py instead of .sh the first time, when we need to download stuff.

The problem is that installing webtest needs easy_install, whose installation process is stupid and clunky. Let's hope we can avoid it. I'm also reluctant to require devs to run stuff like

wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python

which is recommended by the easy_install webpage.