### PR TITLE
Fix for #457, rejoin is broken.

### DIFF
--- a/samples/web/content/apprtc/js/call.js
+++ b/samples/web/content/apprtc/js/call.js
@@ -40,12 +40,18 @@ var Call = function(params) {
   this.onsignalingstatechange = null;
   this.onstatusmessage = null;
 
-  this.getMediaPromise_ = this.maybeGetMedia_();
-  this.getTurnServersPromise_ = this.maybeGetTurnServers_();
+  this.getMediaPromise_ = null;
+  this.getTurnServersPromise_ = null;
+  this.initPromises_();
 };
 
 Call.prototype.isInitiator = function() {
   return this.params_.isInitiator;
+};
+
+Call.prototype.initPromises_ = function() {
+  this.getMediaPromise_ = this.maybeGetMedia_();
+  this.getTurnServersPromise_ = this.maybeGetTurnServers_();
 };
 
 Call.prototype.start = function(roomId) {
@@ -56,6 +62,9 @@ Call.prototype.start = function(roomId) {
 };
 
 Call.prototype.restart = function() {
+  // Reinitialize the promises so the media gets hooked up as a result
+  // of calling maybeGetMedia_.
+  this.initPromises_();
   this.start(this.params_.previousRoomId);
 };
 


### PR DESCRIPTION
Previously calling .start() triggered the media promise to be run, but it no longer does, so restart needs to do it. All of the media attach events happen as a result of that promise executing.

We probably could skip doing the turn servers promise, but I was just trying to restore the previous functionality and not optimizing it.
@jiayliu @juberti 