### PR TITLE
Add polyfill for getStats in adapter.js.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,17 +61,27 @@ module.exports = function(grunt) {
       // can choose more than one name + array of paths
       // usage with this name: grunt jshint:files
       files: ['src/content/**/*.js']
-    }
+    },
+
+    jstdPhantom: {
+      options: {
+        useLatest : true,
+        port: 9876,
+      },
+      files: [
+        'src/js/test_driver_chrome.conf',
+      ]},
   });
 
   // enable plugins
   grunt.loadNpmTasks('grunt-contrib-csslint');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-htmlhint');
   grunt.loadNpmTasks('grunt-jscs');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-jstestdriver-phantomjs');
 
   // set default tasks to run when grunt is called without parameters
-  grunt.registerTask('default', ['csslint', 'htmlhint', 'jscs', 'jshint']);
+  grunt.registerTask('default', ['csslint', 'htmlhint', 'jscs', 'jshint', 'jstdPhantom']);
   // also possible to call JavaScript directly in registerTask()
   // or to call external tasks with grunt.loadTasks()
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-contrib-csslint": ">=0.3.1",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-htmlhint": ">=0.4.1",
-    "grunt-jscs": ">=0.8.1"
+    "grunt-jscs": ">=0.8.1",
+    "grunt-jstestdriver-phantomjs": ">=0.0.7"
   }
 }

--- a/src/js/adapter_test.js
+++ b/src/js/adapter_test.js
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+// Enable async testing since getStats uses a callback.
+var AdapterTest = new AsyncTestCase('AdapterTest');
+
+// Test getStats using the original Chrome ordering: successCallback,
+// selector. This case does _not_ polyfill the results. It returns an
+// object with a `results` getter. The getter returns an array of
+// specialized maps.
+AdapterTest.prototype.testOldGetStats = function(queue) {
+  var pc = new RTCPeerConnection();
+
+  var chromeReport0 =
+      new FakeStatsReportStruct('chromeReport0', '1234', 'audio', {
+	'field1': 'value1',
+	'field2': 'value2',
+      });
+  var chromeReport1 =
+      new FakeStatsReportStruct('chromeReport1', '1234', 'video', {
+	'field1': 'value1',
+	'field3': 'value3',
+      });
+  var chromeReport2 =
+      new FakeStatsReportStruct('chromeReport2', '1234', 'data', {
+	'field1': 'value1',
+	'field2': 'value2',
+	'field3': 'value3',
+      });
+
+  var report = {}
+  report.result = function() {
+    return [chromeReport0, chromeReport1, chromeReport2];
+  }
+
+  pc.fakeGetStatsData = report;
+
+  var task = function(callbacks) {
+    // Using the old argument style return whatever getStats returns to us.
+    var success = callbacks.add(function (actualReport) {
+      assertEquals(report.result(), actualReport.result());
+    });
+    pc.getStats(success);
+  };
+
+  // Call getStats using the old non-W3C argument spec.
+  queue.call('getStats(successCallback)', task);
+};
+
+// Test getStats using W3C argument ordering: selector,
+// successCallback, errorCallback. This triggers the polyfill to
+// convert the Chrome style stats objects into the W3C standard
+// format.
+AdapterTest.prototype.testNewGetStats = function(queue) {
+  var pc = new RTCPeerConnection();
+
+  var chromeReport0 =
+      new FakeStatsReportStruct('chromeReport0', '1234', 'audio', {
+	'field1': 'value1',
+	'field2': 'value2',
+      });
+  var chromeReport1 =
+      new FakeStatsReportStruct('chromeReport1', '1234', 'video', {
+	'field1': 'value1',
+	'field3': 'value3',
+      });
+  var chromeReport2 =
+      new FakeStatsReportStruct('chromeReport2', '1234', 'data', {
+	'field1': 'value1',
+	'field2': 'value2',
+	'field3': 'value3',
+  });
+
+  var report = {}
+  report.result = function() {
+    return [chromeReport0, chromeReport1, chromeReport2];
+  }
+
+  pc.fakeGetStatsData = report;
+
+  expectedStats = {
+    'chromeReport0': {
+      'id': 'chromeReport0',
+      'timestamp': '1234',
+      'type': 'audio',
+      'field1': 'value1',
+      'field2': 'value2',
+    },
+    'chromeReport1': {
+      'id': 'chromeReport1',
+      'timestamp': '1234',
+      'type': 'video',
+      'field1': 'value1',
+      'field3': 'value3',
+    },
+    'chromeReport2': {
+      'id': 'chromeReport2',
+      'timestamp': '1234',
+      'type': 'data',
+      'field1': 'value1',
+      'field2': 'value2',
+      'field3': 'value3',
+    }
+  }
+
+  var task = function(callbacks) {
+    // Using the old argument style return whatever getStats returns to us.
+    var success = callbacks.add(function (actualStats) {
+      assertEquals(expectedStats, actualStats);
+    });
+    pc.getStats(undefined, success);
+  };
+
+  // Call getStats using the W3C argument spec.
+  queue.call('getStats(undefined, successCallback)', task);
+};

--- a/src/js/test_driver_chrome.conf
+++ b/src/js/test_driver_chrome.conf
@@ -1,0 +1,10 @@
+# Javascript test driver for Chrome in jstd.
+server: http://localhost:9876
+
+load:
+  - test_preload.js
+  - test_preload_chrome.js
+  - adapter.js
+
+test:
+  - adapter_test.js

--- a/src/js/test_preload.js
+++ b/src/js/test_preload.js
@@ -1,0 +1,10 @@
+/* Functionality shared by all tests. */
+
+// PhantomJS doesn't support bind yet.
+// Taken from: https://github.com/ariya/phantomjs/issues/10522
+Function.prototype.bind = Function.prototype.bind || function (thisp) {
+    var fn = this;
+    return function () {
+        return fn.apply(thisp, arguments);
+    };
+};

--- a/src/js/test_preload_chrome.js
+++ b/src/js/test_preload_chrome.js
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/*
+ * Provides fakes for Chrome Javascript API.
+ *
+ * JS Test Driver (JSTD) implements a subset of Javascript
+ * functionality. This simulates the Chrome JS behavior for testing.
+ */
+
+navigator.webkitGetUserMedia = function() {};
+
+// Fake for webkitRTCPeerConnection.
+webkitRTCPeerConnection = function(config, constraints) {
+  // Provides access to test data for getStats.
+  this.fakeGetStatsData = [];
+};
+
+webkitRTCPeerConnection.prototype.getStats =
+    function(successCallback, selector) {
+      var stats = this.fakeGetStatsData;
+      // Simulate a callback on the stats object.
+      window.setTimeout(function() {
+	successCallback(stats);
+      }, 0);
+    };
+
+
+// Mimcs Chrome's specialized stats datastructure.
+var FakeStatsReportStruct = function(id, timestamp, type, obj) {
+  this.id = id;
+  this.timestamp = timestamp;
+  this.type = type;
+  this.obj = obj;
+}
+
+FakeStatsReportStruct.prototype.names = function() {
+  return Object.keys(this.obj);
+};
+
+FakeStatsReportStruct.prototype.stat = function(key) {
+  return this.obj[key];
+};


### PR DESCRIPTION
The Chrome version of getStats produces a cryptic data structure. This
wraps the getStats call so that it comes out in the W3C standard
structure.