### PR TITLE
remove rtp data channels from samples

### DIFF
--- a/src/content/datachannel/basic/index.html
+++ b/src/content/datachannel/basic/index.html
@@ -36,14 +36,6 @@
       <button id="closeButton" disabled>Stop</button>
     </div>
 
-    <form>
-      <span>Choose protocol for transmitting data:</span>
-      <input type="radio" id="useSctp" name="transportbtn" checked />
-      <label for="useSctp">SCTP</label>
-      <input type="radio" id="useRtp" name="transportbtn" />
-      <label for="useRtp">RTP</label>
-    </form>
-
     <div id="sendReceive">
       <div id="send">
         <h2>Send</h2>


### PR DESCRIPTION
I think the samples should not show rtp based data channels anymore. There is also a lack of Firefox detection in the sample so removing this is the easiest fix.

also removes code for chrome < 31 since adapter.js doesnt care about versions that old either