### PR TITLE
candidate gathering demo: try to detect authentication failures and unreachable servers

### DIFF
--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -36,6 +36,8 @@
 
       <p>Individual STUN and TURN servers can be added using the Add server / Remove server controls below; in addition, the type of candidates released to the application can be controlled via the IceTransports constraint.</p>
 
+      <p>If you test just a single TURN/UDP server, this page even allows you to detect when you are using the wrong credential to authenticated.</p>
+
     </section>
 
     <section id="iceServers">

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -25,6 +25,7 @@ removeButton.onclick = removeServer;
 
 var begin;
 var pc;
+var candidates;
 
 function selectServer(event) {
   var option = event.target;
@@ -105,6 +106,7 @@ function start() {
 
 function gotDescription(desc) {
   begin = window.performance.now();
+  candidates = [];
   pc.setLocalDescription(desc);
 }
 
@@ -150,6 +152,46 @@ function appendCell(row, val, span) {
   row.appendChild(cell);
 }
 
+// Try to determine authentication failures and unreachable TURN
+// servers by using heuristics on the candidate types gathered.
+function getFinalResult() {
+  var result = 'Done';
+
+  // if more than one server is used, it can not be determined
+  // which server failed.
+  if (servers.length === 1) {
+    var server = JSON.parse(servers[0].value);
+
+    // get the candidates types (host, srflx, relay)
+    var types = candidates.map(function(cand) {
+      return cand.type;
+    });
+
+    // If the server is a TURN server we should have a relay candidate.
+    // If we did not get a relay candidate but a srflx candidate
+    // authentication might have failed.
+    // If we did not get  a relay candidate or a srflx candidate
+    // we could not reach the TURN server. Either it is not running at
+    // the target address or the clients access to the port is blocked.
+    //
+    // This only works for TURN/UDP since we do not get
+    // srflx candidates from TURN/TCP.
+    if (server.url.indexOf('turn:') === 0 &&
+        server.url.indexOf('?transport=tcp') === -1) {
+      if (types.indexOf('relay') === -1) {
+        if (types.indexOf('srflx') > -1) {
+          // a binding response but no relay candidate suggests auth failure.
+          result = 'Authentication failed?';
+        } else {
+          // either the TURN server is down or the clients access is blocked.
+          result = 'Not reachable?';
+        }
+      }
+    }
+  }
+  return result;
+}
+
 function iceCallback(event) {
   var elapsed = ((window.performance.now() - begin) / 1000).toFixed(3);
   var row = document.createElement('tr');
@@ -163,34 +205,9 @@ function iceCallback(event) {
     appendCell(row, c.address);
     appendCell(row, c.port);
     appendCell(row, formatPriority(c.priority));
+    candidates.push(c);
   } else {
-    var result = 'Done';
-    if (servers.length === 1) {
-      var server = JSON.parse(servers[0].value);
-
-      // figure out the types of candidates (host, srflx, relay)
-      var types = pc.localDescription.sdp.split('\r\n').filter(
-        function(line) {
-          return line.indexOf('a=candidate:') === 0;
-        }
-      ).map(function(cand) {
-        return parseCandidate(cand).type;
-      });
-
-      // this trick only works for TURN/UDP
-      if (server.url.indexOf('turn:') === 0 &&
-          server.url.indexOf('?transport=tcp') === -1) {
-        if (types.indexOf('relay') === -1) {
-          if (types.indexOf('srflx') > -1) {
-            // binding response but no relay candidate suggests auth failure
-            result = 'Authentication failed?';
-          } else {
-            result = 'Not reachable?';
-          }
-        }
-      }
-    }
-    appendCell(row, result, 7);
+    appendCell(row, getFinalResult(), 7);
     pc.close();
     pc = null;
   }


### PR DESCRIPTION
that demo is actually pretty useful when helping people to debug their TURN servers. This makes it slightly more useful by doing a little bit of cause analysis. Or at least easier to explain.

@juberti does it make your eyes hurt enough that I get the turn server event listener faster? Oh wait, this actually solves ~50% of the issue at least so no hurry.