### PR TITLE
Modern constraints samples using polyfill in adapter.js

### DIFF
--- a/src/content/getusermedia/desktopcapture/extension/content-script.js
+++ b/src/content/getusermedia/desktopcapture/extension/content-script.js
@@ -17,7 +17,7 @@ port.onMessage.addListener(function(msg) {
 });
 
 window.addEventListener('message', function(event) {
-	// We only accept messages from ourselves
+  // We only accept messages from ourselves
   if (event.source !== window) {
     return;
   }

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -80,6 +80,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/resolution" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -34,19 +34,19 @@ fullHdButton.onclick = function() {
 };
 
 var qvgaConstraints = {
-  video: { width: { exact: 320 }, height: { exact: 240 } }
+  video: {width: {exact: 320}, height: {exact: 240}}
 };
 
 var vgaConstraints = {
-  video: { width: { exact: 640 }, height: { exact: 480 } }
+  video: {width: {exact: 640}, height: {exact: 480}}
 };
 
 var hdConstraints = {
-  video: { width: 1280, height: 720 }
+  video: {width: 1280, height: 720}
 };
 
 var fullHdConstraints = {
-  video: { width: { exact: 1920 }, height: { exact: 1080 } }
+  video: {width: {exact: 1920}, height: {exact: 1080}}
 };
 
 function successCallback(stream) {
@@ -75,5 +75,5 @@ function getMedia(constraints) {
   }
   setTimeout(function() {
     navigator.getUserMedia(constraints, successCallback, errorCallback);
-  }, (stream? 200 : 0));
+  }, (stream ? 200 : 0));
 }

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -34,51 +34,20 @@ fullHdButton.onclick = function() {
 };
 
 var qvgaConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 320,
-      minHeight: 180,
-      maxWidth: 320,
-      maxHeight: 180
-    }
-  }
+  video: { width: { exact: 320 }, height: { exact: 240 } }
 };
 
 var vgaConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 640,
-      minHeight: 360,
-      maxWidth: 640,
-      maxHeight: 360
-    }
-  }
+  video: { width: { exact: 640 }, height: { exact: 480 } }
 };
 
 var hdConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 1280,
-      minHeight: 720,
-      maxWidth: 1280,
-      maxHeight: 720
-    }
-  }
+  video: { width: 1280, height: 720 }
 };
 
 var fullHdConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 1920,
-      minHeight: 1080,
-      maxWidth: 1920,
-      maxHeight: 1080
-    }
-  }
+  video: { width: { exact: 1920 }, height: { exact: 1080 } }
 };
-
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
 function successCallback(stream) {
   window.stream = stream; // stream available to console
@@ -90,20 +59,21 @@ function errorCallback(error) {
 }
 
 function displayVideoDimensions() {
+  if (!video.videoWidth) {
+    setTimeout(displayVideoDimensions, 500);
+  }
   dimensions.innerHTML = 'Actual video dimensions: ' + video.videoWidth +
     'x' + video.videoHeight + 'px.';
 }
 
-video.onplay = function() {
-  setTimeout(function() {
-    displayVideoDimensions();
-  }, 500);
-};
+video.onloadedmetadata = displayVideoDimensions;
 
 function getMedia(constraints) {
   if (stream) {
     video.src = null;
     stream.stop();
   }
-  navigator.getUserMedia(constraints, successCallback, errorCallback);
+  setTimeout(function() {
+    navigator.getUserMedia(constraints, successCallback, errorCallback);
+  }, (stream? 200 : 0));
 }

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -76,25 +76,26 @@ function gotStream(stream) {
 function getUserMediaConstraints() {
   var constraints = {};
   constraints.audio = true;
-  constraints.video = {
-    mandatory: {},
-    optional: []
-  };
-  var mandatory = constraints.video.mandatory;
+  constraints.video = {};
   if (minWidthInput.value !== '0') {
-    mandatory.minWidth = minWidthInput.value;
+    constraints.video.width = {};
+    constraints.video.width.min = minWidthInput.value;
   }
   if (maxWidthInput.value !== '0') {
-    mandatory.maxWidth = maxWidthInput.value;
+    constraints.video.width = constraints.video.width || {};
+    constraints.video.width.max = maxWidthInput.value;
   }
   if (minHeightInput.value !== '0') {
-    mandatory.minHeight = minHeightInput.value;
+    constraints.video.height = {};
+    constraints.video.height.min = minHeightInput.value;
   }
   if (maxHeightInput.value !== '0') {
-    mandatory.maxHeight = maxHeightInput.value;
+    constraints.video.height = constraints.video.height || {};
+    constraints.video.height.max = maxHeightInput.value;
   }
   if (framerateInput.value !== '0') {
-    mandatory.minFrameRate = framerateInput.value;
+    constraints.video.frameRate = {};
+    constraints.video.frameRate.min = framerateInput.value;
   }
   return constraints;
 }
@@ -253,7 +254,7 @@ setInterval(function() {
     console.log('Not connected yet');
   }
   // Collect some stats from the video tags.
-  if (localVideo.src) {
+  if (localVideo.videoWidth) {
     localVideoStatsDiv.innerHTML = '<strong>Video dimensions:</strong> ' +
       localVideo.videoWidth + 'x' + localVideo.videoHeight + 'px';
   }

--- a/src/js/adapter.js
+++ b/src/js/adapter.js
@@ -232,27 +232,41 @@ if (navigator.mozGetUserMedia) {
           return;
         }
         var r = (typeof c[key] == "object")? c[key] : { ideal: c[key] };
-        if (r.exact !== undefined) {
+        if (r.exact !== undefined && typeof r.exact == "number") {
           r.min = r.max = r.exact;
         }
         var oldname = function(prefix, name) {
-          return prefix + name.charAt(0).toUpperCase() + name.slice(1);
+          if (prefix) {
+            return prefix + name.charAt(0).toUpperCase() + name.slice(1);
+          }
+          return (name == "deviceId")? "sourceId" : name;
         }
         if (r.ideal !== undefined) {
           cc.optional = cc.optional || [];
-          var oc = {};
-          oc[oldname("min", key)] = r.ideal;
-          cc.optional.push(oc);
-          oc = {};
-          oc[oldname("max", key)] = r.ideal;
-          cc.optional.push(oc);
-        }
-        ["min", "max"].forEach(function(mix) {
-          if (r[mix] !== undefined) {
-            cc.mandatory = cc.mandatory || {};
-            cc.mandatory[oldname(mix, key)] = r[mix];
+          if (typeof r.ideal == "number") {
+            var oc = {};
+            oc[oldname("min", key)] = r.ideal;
+            cc.optional.push(oc);
+            oc = {};
+            oc[oldname("max", key)] = r.ideal;
+            cc.optional.push(oc);
+          } else {
+            var oc = {};
+            oc[oldname("", key)] = r.ideal;
+            cc.optional.push(oc);
           }
-        });
+        }
+        if (r.exact !== undefined && typeof r.exact != "number") {
+          cc.mandatory = cc.mandatory || {};
+          cc.mandatory[oldname("", key)] = r.exact;
+        } else {
+          ["min", "max"].forEach(function(mix) {
+            if (r[mix] !== undefined) {
+              cc.mandatory = cc.mandatory || {};
+              cc.mandatory[oldname(mix, key)] = r[mix];
+            }
+          });
+        }
       });
       if (c.advanced) {
         cc.optional = (cc.optional || []).concat(c.advanced);


### PR DESCRIPTION
I noticed the samples were promoting old constraint-syntax, so I updated the shim and two of the samples. Translation is logged to web console. Tested in Chrome 41 & 43 and Firefox 36-39. No-op on Firefox 38+.
