### PR TITLE
Add a variant of the file transfer demo that generates data instead.

### DIFF
--- a/src/content/datachannel/datatransfer/css/main.css
+++ b/src/content/datachannel/datatransfer/css/main.css
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+div.progress, div#bitrate {
+  margin: 0 0 1em 0;
+}
+
+div.progress div.label {
+  display: inline-block;
+  font-weight: 400;
+  width: 8.2em;
+}
+
+form {
+  margin: 0 0 1em 0;
+  white-space: nowrap;
+}
+
+progress {
+  width: calc(100% - 8.5em);
+}

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="description" content="WebRTC code samples">
+  <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1">
+  <meta itemprop="description" content="Client-side WebRTC code samples">
+  <meta itemprop="image" content="../../../images/webrtc-icon-192x192.png">
+  <meta itemprop="name" content="WebRTC code samples">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta id="theme-color" name="theme-color" content="#ffffff">
+
+  <base target="_blank">
+
+  <title>Generate and transfer data</title>
+
+  <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
+  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="../../../css/main.css">
+  <link rel="stylesheet" href="css/main.css" />
+
+</head>
+
+<body>
+
+  <div id="container">
+
+    <h1><a href="https://webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Generate and transfer data</span></h1>
+    <section>
+
+      <p>This page generates and sends the specified amount of data via WebRTC datachannels.</p>
+
+      <p>To accomplish this in an interoperable way, the data is split into chunks which are then transferred via the datachannel. The datachannel is reliable and ordered by default which is well-suited to filetransfers.</p>
+
+      <p>Send and receive progress is monitored using HTML5 <i>progress</i> elements.</p>
+
+    </section>
+
+    <section>
+      <div>
+        <input type="number" id="megsToSend" min="1" name="megs" value="1048"/>
+        <button id="sendTheData" type="button">Generate and send data</button>
+      </div>
+      <div class="progress">
+        <div class="label">Send progress: </div>
+        <progress id="sendProgress" max="0" value="0"></progress>
+      </div>
+
+      <div class="progress">
+        <div class="label">Receive progress: </div>
+        <progress id="receiveProgress" max="0" value="0"></progress>
+      </div>
+
+      <div id="bitrate"></div>
+
+      <a id="received"></a>
+    </section>
+
+    <section>
+      <p>View the console to see logging.</p>
+
+      <p>The <code>RTCPeerConnection</code> objects <code>localConnection</code> and <code>remoteConnection</code> are in global scope, so you can inspect them in the console as well.</p>
+
+      <p>For more information about RTCDataChannel, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/#toc-rtcdatachannel" title="RTCDataChannel section of HTML5 Rocks article about WebRTC">Getting Started With WebRTC</a>.</p>
+    </section>
+
+    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/filetransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+  </div>
+
+  <script src="../../../js/adapter.js"></script>
+  <script src="js/main.js"></script>
+
+  <script src="../../../js/lib/ga.js"></script>
+
+</body>
+</html>

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -58,10 +58,6 @@
         <div class="label">Receive progress: </div>
         <progress id="receiveProgress" max="0" value="0"></progress>
       </div>
-
-      <div id="bitrate"></div>
-
-      <a id="received"></a>
     </section>
 
     <section>
@@ -72,7 +68,7 @@
       <p>For more information about RTCDataChannel, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/#toc-rtcdatachannel" title="RTCDataChannel section of HTML5 Rocks article about WebRTC">Getting Started With WebRTC</a>.</p>
     </section>
 
-    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/filetransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/datatransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
   <script src="../../../js/adapter.js"></script>

--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -21,7 +21,6 @@ var receiveProgress = document.querySelector('progress#receiveProgress');
 var receivedSize = 0;
 var bytesToSend = 0;
 
-var bytesPrev = 0;
 var statsInterval = null;
 var bitrateMax = 0;
 

--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -1,0 +1,239 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+'use strict';
+
+var localConnection;
+var remoteConnection;
+var sendChannel;
+var receiveChannel;
+var pcConstraint;
+var megsToSend = document.querySelector('input#megsToSend');
+var sendButton = document.querySelector('button#sendTheData');
+var bitrateDiv = document.querySelector('div#bitrate');
+var sendProgress = document.querySelector('progress#sendProgress');
+var receiveProgress = document.querySelector('progress#receiveProgress');
+
+var receivedSize = 0;
+var bytesToSend = 0;
+
+var bytesPrev = 0;
+var timestampPrev = 0;
+var timestampStart;
+var statsInterval = null;
+var bitrateMax = 0;
+
+sendButton.onclick = createConnection;
+
+function createConnection() {
+  var servers = null;
+  pcConstraint = null;
+
+  bytesToSend = megsToSend.value * 1024 * 1024;
+
+  // Add localConnection to global scope to make it visible from the browser console.
+  window.localConnection = localConnection = new RTCPeerConnection(servers,
+      pcConstraint);
+  trace('Created local peer connection object localConnection');
+
+  sendChannel = localConnection.createDataChannel('sendDataChannel');
+  sendChannel.binaryType = 'arraybuffer';
+  trace('Created send data channel');
+
+  sendChannel.onopen = onSendChannelStateChange;
+  sendChannel.onclose = onSendChannelStateChange;
+  localConnection.onicecandidate = iceCallback1;
+
+  localConnection.createOffer(gotDescription1, onCreateSessionDescriptionError);
+
+  // Add remoteConnection to global scope to make it visible from the browser console.
+  window.remoteConnection = remoteConnection = new RTCPeerConnection(servers,
+      pcConstraint);
+  trace('Created remote peer connection object remoteConnection');
+
+  remoteConnection.onicecandidate = iceCallback2;
+  remoteConnection.ondatachannel = receiveChannelCallback;
+}
+
+function onCreateSessionDescriptionError(error) {
+  trace('Failed to create session description: ' + error.toString());
+}
+
+function randomAsciiString(length) {
+  var result = '';
+  for (var i = 0; i < length; i++) {
+    // Visible ASCII chars are between 33 and 126.
+    result += String.fromCharCode(33 + Math.random() * 93);
+  }
+  return result;
+}
+
+function sendGeneratedData() {
+  sendProgress.max = bytesToSend;
+  receiveProgress.max = sendProgress.max;
+  var chunkSize = 16384;
+  var stringToSendRepeatedly = randomAsciiString(chunkSize);
+  var generateData = function(offset) {
+    sendChannel.send(stringToSendRepeatedly);
+    if (offset < sendProgress.max) {
+      window.setTimeout(generateData, 0, offset + chunkSize);
+    }
+    sendProgress.value = offset + chunkSize;
+  };
+  generateData(0);
+}
+
+function closeDataChannels() {
+  trace('Closing data channels');
+  sendChannel.close();
+  trace('Closed data channel with label: ' + sendChannel.label);
+  receiveChannel.close();
+  trace('Closed data channel with label: ' + receiveChannel.label);
+  localConnection.close();
+  remoteConnection.close();
+  localConnection = null;
+  remoteConnection = null;
+  trace('Closed peer connections');
+}
+
+function gotDescription1(desc) {
+  localConnection.setLocalDescription(desc);
+  trace('Offer from localConnection \n' + desc.sdp);
+  remoteConnection.setRemoteDescription(desc);
+  remoteConnection.createAnswer(gotDescription2,
+      onCreateSessionDescriptionError);
+}
+
+function gotDescription2(desc) {
+  remoteConnection.setLocalDescription(desc);
+  trace('Answer from remoteConnection \n' + desc.sdp);
+  localConnection.setRemoteDescription(desc);
+}
+
+function iceCallback1(event) {
+  trace('local ice callback');
+  if (event.candidate) {
+    remoteConnection.addIceCandidate(event.candidate,
+        onAddIceCandidateSuccess, onAddIceCandidateError);
+    trace('Local ICE candidate: \n' + event.candidate.candidate);
+  }
+}
+
+function iceCallback2(event) {
+  trace('remote ice callback');
+  if (event.candidate) {
+    localConnection.addIceCandidate(event.candidate,
+        onAddIceCandidateSuccess, onAddIceCandidateError);
+    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
+  }
+}
+
+function onAddIceCandidateSuccess() {
+  trace('AddIceCandidate success.');
+}
+
+function onAddIceCandidateError(error) {
+  trace('Failed to add Ice Candidate: ' + error.toString());
+}
+
+function receiveChannelCallback(event) {
+  trace('Receive Channel Callback');
+  receiveChannel = event.channel;
+  receiveChannel.binaryType = 'arraybuffer';
+  receiveChannel.onmessage = onReceiveMessageCallback;
+  receiveChannel.onopen = onReceiveChannelStateChange;
+  receiveChannel.onclose = onReceiveChannelStateChange;
+
+  receivedSize = 0;
+  bitrateMax = 0;
+}
+
+function onReceiveMessageCallback(event) {
+  receivedSize += event.data.length;
+  receiveProgress.value = receivedSize;
+
+  if (receivedSize >= bytesToSend) {
+    if (statsInterval) {
+      window.clearInterval(statsInterval);
+      statsInterval = null;
+    }
+
+    closeDataChannels();
+  }
+}
+
+function onSendChannelStateChange() {
+  var readyState = sendChannel.readyState;
+  trace('Send channel state is: ' + readyState);
+  if (readyState === 'open') {
+    sendGeneratedData();
+  }
+}
+
+function onReceiveChannelStateChange() {
+  var readyState = receiveChannel.readyState;
+  trace('Receive channel state is: ' + readyState);
+  if (readyState === 'open') {
+    timestampStart = (new Date()).getTime();
+    timestampPrev = timestampStart;
+    statsInterval = window.setInterval(displayStats, 500);
+    window.setTimeout(displayStats, 100);
+    window.setTimeout(displayStats, 300);
+  }
+}
+
+// display bitrate statistics.
+function displayStats() {
+  var display = function(bitrate) {
+    bitrateDiv.innerHTML = '<strong>Current Bitrate:</strong> ' +
+        bitrate + ' kbits/sec';
+  };
+
+  if (remoteConnection &&
+      remoteConnection.iceConnectionState === 'connected') {
+    if (webrtcDetectedBrowser === 'chrome') {
+      // TODO: once https://code.google.com/p/webrtc/issues/detail?id=4321
+      // lands those stats should be preferrred over the connection stats.
+      remoteConnection.getStats(function(stats) {
+        stats.result().forEach(function(res) {
+          if (timestampPrev === res.timestamp) {
+            return;
+          }
+          if (res.type === 'googCandidatePair' &&
+              res.stat('googActiveConnection') === 'true') {
+            // calculate current bitrate
+            var bytesNow = res.stat('bytesReceived');
+            var bitrate = Math.round((bytesNow - bytesPrev) * 8 /
+                (res.timestamp - timestampPrev));
+            display(bitrate);
+            timestampPrev = res.timestamp;
+            bytesPrev = bytesNow;
+            if (bitrate > bitrateMax) {
+              bitrateMax = bitrate;
+            }
+          }
+        });
+      });
+    } else {
+      // Firefox currently does not have data channel stats. See
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1136832
+      // Instead, the bitrate is calculated based on the number of
+      // bytes received.
+      var bytesNow = receivedSize;
+      var now = (new Date()).getTime();
+      var bitrate = Math.round((bytesNow - bytesPrev) * 8 /
+          (now - timestampPrev));
+      display(bitrate);
+      timestampPrev = now;
+      bytesPrev = bytesNow;
+      if (bitrate > bitrateMax) {
+        bitrateMax = bitrate;
+      }
+    }
+  }
+}

--- a/src/content/getusermedia/desktopcapture/extension/content-script.js
+++ b/src/content/getusermedia/desktopcapture/extension/content-script.js
@@ -17,7 +17,7 @@ port.onMessage.addListener(function(msg) {
 });
 
 window.addEventListener('message', function(event) {
-	// We only accept messages from ourselves
+  // We only accept messages from ourselves
   if (event.source !== window) {
     return;
   }


### PR DESCRIPTION
The main purpose is to be able to pull the demo into a telemetry page and measure CPU and memory usage while transferring a large amount of data. I initially planned to just give the original filetransfer demo a generated file, but that turned out to be difficult on CrOS and Android. This variant just generates a random 16k string it sends over and over.

The demo is a reworked and somewhat stripped down variant of Philip Hancke's file transfer demo.