### PR TITLE
Fix "AppRTC URL parameters" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Patches and issues welcome! See [CONTRIBUTING](https://github.com/webrtc/samples
 
 [AppRTC video chat client](https://apprtc.appspot.com) powered by Google App Engine
 
-[AppRTC URL parameters](https://apprtc.appspot.com/html/params.html)
+[AppRTC URL parameters](https://apprtc.appspot.com/params.html)
 
 
 


### PR DESCRIPTION
The URL proposed in this PR triggers a mixed content warning, but I'm addressing that in https://github.com/webrtc/apprtc/pull/145.