### PR TITLE
Update samples to use spec-compliant constraints.

### DIFF
--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -85,6 +85,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/resolution" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -34,51 +34,20 @@ fullHdButton.onclick = function() {
 };
 
 var qvgaConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 320,
-      minHeight: 180,
-      maxWidth: 320,
-      maxHeight: 180
-    }
-  }
+  video: {width: {exact: 320}, height: {exact: 240}}
 };
 
 var vgaConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 640,
-      minHeight: 360,
-      maxWidth: 640,
-      maxHeight: 360
-    }
-  }
+  video: {width: {exact: 640}, height: {exact: 480}}
 };
 
 var hdConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 1280,
-      minHeight: 720,
-      maxWidth: 1280,
-      maxHeight: 720
-    }
-  }
+  video: {width: 1280, height: 720}
 };
 
 var fullHdConstraints = {
-  video: {
-    mandatory: {
-      minWidth: 1920,
-      minHeight: 1080,
-      maxWidth: 1920,
-      maxHeight: 1080
-    }
-  }
+  video: {width: {exact: 1920}, height: {exact: 1080}}
 };
-
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
 function successCallback(stream) {
   window.stream = stream; // stream available to console
@@ -90,20 +59,21 @@ function errorCallback(error) {
 }
 
 function displayVideoDimensions() {
+  if (!video.videoWidth) {
+    setTimeout(displayVideoDimensions, 500);
+  }
   dimensions.innerHTML = 'Actual video dimensions: ' + video.videoWidth +
     'x' + video.videoHeight + 'px.';
 }
 
-video.onplay = function() {
-  setTimeout(function() {
-    displayVideoDimensions();
-  }, 500);
-};
+video.onloadedmetadata = displayVideoDimensions;
 
 function getMedia(constraints) {
   if (stream) {
     video.src = null;
     stream.stop();
   }
-  navigator.getUserMedia(constraints, successCallback, errorCallback);
+  setTimeout(function() {
+    navigator.getUserMedia(constraints, successCallback, errorCallback);
+  }, (stream ? 200 : 0));
 }

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -51,7 +51,7 @@ var fullHdConstraints = {
 
 function successCallback(stream) {
   window.stream = stream; // stream available to console
-  video.src = window.URL.createObjectURL(stream);
+  attachMediaStream(video, stream);
 }
 
 function errorCallback(error) {

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -76,25 +76,26 @@ function gotStream(stream) {
 function getUserMediaConstraints() {
   var constraints = {};
   constraints.audio = true;
-  constraints.video = {
-    mandatory: {},
-    optional: []
-  };
-  var mandatory = constraints.video.mandatory;
+  constraints.video = {};
   if (minWidthInput.value !== '0') {
-    mandatory.minWidth = minWidthInput.value;
+    constraints.video.width = {};
+    constraints.video.width.min = minWidthInput.value;
   }
   if (maxWidthInput.value !== '0') {
-    mandatory.maxWidth = maxWidthInput.value;
+    constraints.video.width = constraints.video.width || {};
+    constraints.video.width.max = maxWidthInput.value;
   }
   if (minHeightInput.value !== '0') {
-    mandatory.minHeight = minHeightInput.value;
+    constraints.video.height = {};
+    constraints.video.height.min = minHeightInput.value;
   }
   if (maxHeightInput.value !== '0') {
-    mandatory.maxHeight = maxHeightInput.value;
+    constraints.video.height = constraints.video.height || {};
+    constraints.video.height.max = maxHeightInput.value;
   }
   if (framerateInput.value !== '0') {
-    mandatory.minFrameRate = framerateInput.value;
+    constraints.video.frameRate = {};
+    constraints.video.frameRate.min = framerateInput.value;
   }
   return constraints;
 }
@@ -253,7 +254,7 @@ setInterval(function() {
     console.log('Not connected yet');
   }
   // Collect some stats from the video tags.
-  if (localVideo.src) {
+  if (localVideo.videoWidth) {
     localVideoStatsDiv.innerHTML = '<strong>Video dimensions:</strong> ' +
       localVideo.videoWidth + 'x' + localVideo.videoHeight + 'px';
   }


### PR DESCRIPTION
A rebase of #493. @alvestrand do I need any automated tests here?

Note: I've also updated the /samples/js/adapter.js to the most recent one from /adapter (but I'm unsure if this is the correct procedure here).

To test manually, try [getusermedia/resolution/index.html](http://htmlpreview.github.io/?https://raw.githubusercontent.com/jan-ivar/samples/ecc0fcb98d24db1e393fbf5ad4acf94557794d3a/src/content/getusermedia/resolution/index.html) and [peerconnection/constraints.html](http://htmlpreview.github.io/?https://raw.githubusercontent.com/jan-ivar/samples/ecc0fcb98d24db1e393fbf5ad4acf94557794d3a/src/content/peerconnection/constraints/index.html).