### PR TITLE
Update samples to use spec-compliant mediaDevices.enumerateDevices().

### DIFF
--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -58,6 +58,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/source" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -12,19 +12,16 @@ var videoElement = document.querySelector('video');
 var audioSelect = document.querySelector('select#audioSource');
 var videoSelect = document.querySelector('select#videoSource');
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 function gotSources(sourceInfos) {
   for (var i = 0; i !== sourceInfos.length; ++i) {
     var sourceInfo = sourceInfos[i];
     var option = document.createElement('option');
-    option.value = sourceInfo.id;
-    if (sourceInfo.kind === 'audio') {
+    option.value = sourceInfo.deviceId;
+    if (sourceInfo.kind === 'audioinput') {
       option.text = sourceInfo.label ||
         'microphone ' + (audioSelect.length + 1);
       audioSelect.appendChild(option);
-    } else if (sourceInfo.kind === 'video') {
+    } else if (sourceInfo.kind === 'videoinput') {
       option.text = sourceInfo.label || 'camera ' + (videoSelect.length + 1);
       videoSelect.appendChild(option);
     } else {
@@ -33,10 +30,12 @@ function gotSources(sourceInfos) {
   }
 }
 
-if (typeof MediaStreamTrack === 'undefined') {
-  alert('This browser does not support MediaStreamTrack.\n\nTry Chrome.');
+if (!navigator.mediaDevices) {
+  alert('This browser does not support navigator.mediaDevices.');
 } else {
-  MediaStreamTrack.getSources(gotSources);
+  navigator.mediaDevices.enumerateDevices()
+  .then(gotSources)
+  .catch(errorCallback);
 }
 
 function successCallback(stream) {

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -40,7 +40,7 @@ if (!navigator.mediaDevices) {
 
 function successCallback(stream) {
   window.stream = stream; // make stream available to console
-  videoElement.src = window.URL.createObjectURL(stream);
+  attachMediaStream(videoElement, stream);
 }
 
 function errorCallback(error) {


### PR DESCRIPTION
A rebase of #499.  @alvestrand any automated tests needed here?

To test manually, try [/getusermedia/source/index.html](http://htmlpreview.github.io/?https://raw.githubusercontent.com/jan-ivar/samples/polyenumerate2preview/src/content/getusermedia/source/index.html) (note: from separate polyenumerate2preview branch that includes a fresh adapter.js as of this writing).