### PR TITLE
make gum demos use adapter.js and attachMediaStream

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
       <p>This is a repository for the WebRTC Javascript code samples. The source for these samples is available at <a href="//github.com/webrtc/samples" title="View GitHub repository for these files">github.com/webrtc/samples</a>.</p>
 
-      <p>Some of the samples use new browser features. They may only work in <a href="//www.google.com/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a> and/or <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a>, and may require flags to be set.</p>
+      <p>Some of the samples use new browser features. They may only work in <a href="//www.google.com/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a>, <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a> or Microsoft Edge (available with Windows 10), and may require flags to be set.</p>
 
       <p>Most of the samples use <a href="//github.com/webrtc/adapter">adapter.js</a>, a shim to insulate apps from spec changes and prefix differences. (In fact, the standards and protocols used for WebRTC implementations are highly stable, and there are only a few prefixed names. For full interop information, see <a href="//www.webrtc.org/web-apis/interop">webrtc.org/web-apis/interop</a>.)</p>
 

--- a/src/content/getusermedia/audio/index.html
+++ b/src/content/getusermedia/audio/index.html
@@ -34,7 +34,7 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>getUserMedia, audio only</span></h1>
 
-    <audio controls autoplay></audio>
+    <audio id="gum-local" controls autoplay></audio>
 
     <p>Render the audio stream from an audio-only <code>getUserMedia()</code> call with an audio element.</p>
 
@@ -44,6 +44,7 @@
 
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/audio/js/main.js
+++ b/src/content/getusermedia/audio/js/main.js
@@ -9,7 +9,7 @@
 'use strict';
 
 // Put variables in global scope to make them available to the browser console.
-var audio = document.getElementById('gum-local');
+var audio = document.querySelector('audio');
 var constraints = window.constraints = {
   audio: true,
   video: false

--- a/src/content/getusermedia/audio/js/main.js
+++ b/src/content/getusermedia/audio/js/main.js
@@ -9,13 +9,11 @@
 'use strict';
 
 // Put variables in global scope to make them available to the browser console.
-var audio = window.audio = document.querySelector('audio');
+var audio = document.getElementById('gum-local');
 var constraints = window.constraints = {
   audio: true,
   video: false
 };
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
 function successCallback(stream) {
   var videoTracks = stream.getVideoTracks();
@@ -28,11 +26,7 @@ function successCallback(stream) {
     };
   }
   window.stream = stream; // make variable available to browser console
-  if (window.URL) {
-    audio.src = window.URL.createObjectURL(stream);
-  } else {
-    audio.src = stream;
-  }
+  attachMediaStream(audio, stream);
 }
 
 function errorCallback(error) {

--- a/src/content/getusermedia/audio/js/main.js
+++ b/src/content/getusermedia/audio/js/main.js
@@ -16,15 +16,12 @@ var constraints = window.constraints = {
 };
 
 function successCallback(stream) {
-  var videoTracks = stream.getVideoTracks();
   var audioTracks = stream.getAudioTracks();
-  if (audioTracks.length === 1 && videoTracks.length === 0) {
-    console.log('Got stream with constraints:', constraints);
-    console.log('Using audio device: ' + audioTracks[0].label);
-    stream.onended = function() {
-      console.log('Stream ended');
-    };
-  }
+  console.log('Got stream with constraints:', constraints);
+  console.log('Using audio device: ' + audioTracks[0].label);
+  stream.onended = function() {
+    console.log('Stream ended');
+  };
   window.stream = stream; // make variable available to browser console
   attachMediaStream(audio, stream);
 }

--- a/src/content/getusermedia/canvas/index.html
+++ b/src/content/getusermedia/canvas/index.html
@@ -46,6 +46,7 @@
 
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/canvas/js/main.js
+++ b/src/content/getusermedia/canvas/js/main.js
@@ -21,9 +21,6 @@ button.onclick = function() {
 
 var video = document.querySelector('video');
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 var constraints = {
   audio: false,
   video: true
@@ -31,11 +28,7 @@ var constraints = {
 
 function successCallback(stream) {
   window.stream = stream; // make stream available to browser console
-  if (window.URL) {
-    video.src = window.URL.createObjectURL(stream);
-  } else {
-    video.src = stream;
-  }
+  attachMediaStream(video, stream);
 }
 
 function errorCallback(error) {

--- a/src/content/getusermedia/filter/index.html
+++ b/src/content/getusermedia/filter/index.html
@@ -66,6 +66,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/filter" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/filter/js/main.js
+++ b/src/content/getusermedia/filter/js/main.js
@@ -30,9 +30,6 @@ filterButton.onclick = function() {
   canvas.className = filters[newIndex];
 };
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 var constraints = {
   audio: false,
   video: true
@@ -40,11 +37,7 @@ var constraints = {
 
 function successCallback(stream) {
   window.stream = stream; // make stream available to browser console
-  if (window.URL) {
-    video.src = window.URL.createObjectURL(stream);
-  } else {
-    video.src = stream;
-  }
+  attachMediaStream(video, stream);
 }
 
 function errorCallback(error) {

--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -43,6 +43,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/gum" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -11,8 +11,8 @@
 // Put variables in global scope to make them available to the browser console.
 var video = document.getElementById('gum-local');
 var constraints = window.constraints = {
-  audio: true,
-  video: false
+  audio: false,
+  video: true
 };
 
 function successCallback(stream) {

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -20,7 +20,7 @@ function successCallback(stream) {
   var audioTracks = stream.getAudioTracks();
   if (videoTracks.length === 1 && audioTracks.length === 0) {
     console.log('Got stream with constraints:', constraints);
-    console.log('Using video device: ' + videotracks[0].label);
+    console.log('Using video device: ' + videoTracks[0].label);
     stream.onended = function() {
       console.log('Stream ended');
     };

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -8,23 +8,25 @@
 
 'use strict';
 
-// variables in global scope so available to console
-var video = document.querySelector('video');
-var constraints = {
-  audio: false,
-  video: true
+// Put variables in global scope to make them available to the browser console.
+var video = document.getElementById('gum-local');
+var constraints = window.constraints = {
+  audio: true,
+  video: false
 };
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 function successCallback(stream) {
-  window.stream = stream; // stream available to console
-  if (window.URL) {
-    video.src = window.URL.createObjectURL(stream);
-  } else {
-    video.src = stream;
+  var videoTracks = stream.getVideoTracks();
+  var audioTracks = stream.getAudioTracks();
+  if (videoTracks.length === 1 && audioTracks.length === 0) {
+    console.log('Got stream with constraints:', constraints);
+    console.log('Using video device: ' + videotracks[0].label);
+    stream.onended = function() {
+      console.log('Stream ended');
+    };
   }
+  window.stream = stream; // make variable available to browser console
+  attachMediaStream(video, stream);
 }
 
 function errorCallback(error) {

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -17,14 +17,11 @@ var constraints = window.constraints = {
 
 function successCallback(stream) {
   var videoTracks = stream.getVideoTracks();
-  var audioTracks = stream.getAudioTracks();
-  if (videoTracks.length === 1 && audioTracks.length === 0) {
-    console.log('Got stream with constraints:', constraints);
-    console.log('Using video device: ' + videoTracks[0].label);
-    stream.onended = function() {
-      console.log('Stream ended');
-    };
-  }
+  console.log('Got stream with constraints:', constraints);
+  console.log('Using video device: ' + videoTracks[0].label);
+  stream.onended = function() {
+    console.log('Stream ended');
+  };
   window.stream = stream; // make variable available to browser console
   attachMediaStream(video, stream);
 }

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -9,7 +9,7 @@
 'use strict';
 
 // Put variables in global scope to make them available to the browser console.
-var video = document.getElementById('gum-local');
+var video = document.querySelector('video');
 var constraints = window.constraints = {
   audio: false,
   video: true

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -77,9 +77,6 @@ var fullHdConstraints = {
   }
 };
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 function successCallback(stream) {
   window.stream = stream; // stream available to console
   video.src = window.URL.createObjectURL(stream);

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -103,7 +103,8 @@ video.onplay = function() {
 function getMedia(constraints) {
   if (stream) {
     video.src = null;
-    stream.stop();
+    stream.getAudioTracks().forEach(function (track) { track.stop(); });
+    stream.getVideoTracks().forEach(function (track) { track.stop(); });
   }
   navigator.getUserMedia(constraints, successCallback, errorCallback);
 }

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -103,8 +103,8 @@ video.onplay = function() {
 function getMedia(constraints) {
   if (stream) {
     video.src = null;
-    stream.getAudioTracks().forEach(function (track) { track.stop(); });
-    stream.getVideoTracks().forEach(function (track) { track.stop(); });
+    stream.getAudioTracks().forEach(function(track) { track.stop(); });
+    stream.getVideoTracks().forEach(function(track) { track.stop(); });
   }
   navigator.getUserMedia(constraints, successCallback, errorCallback);
 }

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -58,6 +58,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/source" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -12,9 +12,6 @@ var videoElement = document.querySelector('video');
 var audioSelect = document.querySelector('select#audioSource');
 var videoSelect = document.querySelector('select#videoSource');
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 function gotSources(sourceInfos) {
   for (var i = 0; i !== sourceInfos.length; ++i) {
     var sourceInfo = sourceInfos[i];
@@ -41,7 +38,7 @@ if (typeof MediaStreamTrack === 'undefined') {
 
 function successCallback(stream) {
   window.stream = stream; // make stream available to console
-  videoElement.src = window.URL.createObjectURL(stream);
+  attachMediaStream(videoElement, stream);
 }
 
 function errorCallback(error) {

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -48,8 +48,8 @@ function errorCallback(error) {
 function start() {
   if (window.stream) {
     videoElement.src = null;
-    stream.getAudioTracks().forEach(function (track) { track.stop(); });
-    stream.getVideoTracks().forEach(function (track) { track.stop(); });
+    window.stream.getAudioTracks().forEach(function(track) { track.stop(); });
+    window.stream.getVideoTracks().forEach(function(track) { track.stop(); });
   }
   var audioSource = audioSelect.value;
   var videoSource = videoSelect.value;

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -48,7 +48,8 @@ function errorCallback(error) {
 function start() {
   if (window.stream) {
     videoElement.src = null;
-    window.stream.stop();
+    stream.getAudioTracks().forEach(function (track) { track.stop(); });
+    stream.getVideoTracks().forEach(function (track) { track.stop(); });
   }
   var audioSource = audioSelect.value;
   var videoSource = videoSelect.value;

--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -64,6 +64,7 @@
   </div>
 
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/soundmeter.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/getusermedia/volume/js/main.js
+++ b/src/content/getusermedia/volume/js/main.js
@@ -31,9 +31,6 @@ var constraints = window.constraints = {
   video: false
 };
 
-navigator.getUserMedia = navigator.getUserMedia ||
-    navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 function successCallback(stream) {
   // Put variables in global scope to make them available to the browser console.
   window.stream = stream;


### PR DESCRIPTION
this makes http://webrtc.github.io/samples/src/content/getusermedia/gum/ http://webrtc.github.io/samples/src/content/getusermedia/audio/ use adapter.js and attachMediaStream instead of reinventing that functionality.