### PR TITLE
Add output device selection to source demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Patches and issues welcome! See [CONTRIBUTING](https://github.com/webrtc/samples
 
 [getUserMedia with resolution constraints](https://webrtc.github.io/samples/src/content/getusermedia/resolution)
 
-[getUserMedia with camera/mic selection](https://webrtc.github.io/samples/src/content/getusermedia/source)
+[getUserMedia with camera, mic and speaker selection](https://webrtc.github.io/samples/src/content/getusermedia/source)
 
 [Audio-only getUserMedia output to local audio element](https://webrtc.github.io/samples/src/content/getusermedia/audio)
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -83,7 +83,7 @@
 
       <p><a href="src/content/getusermedia/resolution">Choose camera resolution</a></p>
 
-      <p><a href="src/content/getusermedia/source">Choose camera and microphone</a></p>
+      <p><a href="src/content/getusermedia/source">Choose camera, microphone and speaker</a></p>
 
       <p><a href="src/content/getusermedia/audio">Audio-only getUserMedia() output to local audio element</a></p>
 

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -16,8 +16,6 @@
     "arrayMax": true,
     "arrayMin": true,
     "attachMediaStream": true,
-    "attachMediaStream": true,
-    "attachSinkId": true,
     "audioContext": true,
     "AudioContext": true,
     "Call": true,

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -17,6 +17,7 @@
     "arrayMin": true,
     "attachMediaStream": true,
     "attachMediaStream": true,
+    "attachSinkId": true,
     "audioContext": true,
     "AudioContext": true,
     "Call": true,

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -43,10 +43,10 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Select audio &amp; video sources</span></h1>
 
-    <p>Get available audio, video sources and audio output devices* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.
+    <p>Get available audio, video sources and audio output devices* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.</p>
 
-    *Experimental support in Chrome 45.0.2441.x or later using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (sourceId for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.
-    </p>
+    <p>*Experimental support in Chrome 45.0.2441.x or later using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (sourceId for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.</p>
+
 
 
     <div class="select">

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -41,11 +41,11 @@
 <body>
   <div id="container">
 
-    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Select audio &amp; video sources</span></h1>
+    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a><span>Select sources &amp; outputs</span></h1>
 
-    <p>Get available audio, video sources and audio output devices* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.</p>
+    <p>Get available audio, video sources and audio output devices* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>deviceId</code> constraint.</p>
 
-    <p>*Experimental support in Chrome 45.0.2441.x or later using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (sourceId for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.</p>
+    <p>*'Enable experimental support in Chrome 45.0.2441.x or later by selecting Enable experimental Web Platform features or by using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (<code>deviceId</code> for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.</p>
 
 
 

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -34,6 +34,9 @@
     select {
       width: 110px;
     }
+    p.small {
+      font-size: 0.7em;
+    }
   </style>
 
 </head>
@@ -43,11 +46,9 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a><span>Select sources &amp; outputs</span></h1>
 
-    <p>Get available audio, video sources and audio output devices* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>deviceId</code> constraint.</p>
+    <p>Get available audio, video sources and audio output devices<b>*</b> from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>deviceId</code> constraint.</p>
 
-    <p>*'Enable experimental support in Chrome 45.0.2441.x or later by selecting Enable experimental Web Platform features or by using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (<code>deviceId</code> for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.</p>
-
-
+    <p class="small"><b>*</b>Enable experimental support in <b>Chrome 45.0.2441.x</b> or later by selecting <b>Enable experimental Web Platform features</b> in <b>chrome://flags</b> or by using command line flag "<b>--enable-blink-features=EnumerateDevices,AudioOutputDevices</b>". Use the <code>setSinkID()</code> method on the video element and provide a audio or video element and a sinkId (<code>deviceId</code> for where <code>deviceInfo.kind === 'audiooutput'</code>) as arguments. Also the web page must be served over HTTPS</p>
 
     <div class="select">
       <label for="audioSource">Audio input source: </label><select id="audioSource"></select>
@@ -61,7 +62,9 @@
       <label for="videoSource">Video source: </label><select id="videoSource"></select>
     </div>
 
-    <video muted autoplay></video>
+    <video autoplay></video>
+
+    <p class="small"><b>Note:</b> If you hear a reverb sound your microphone is picking up the output of your speakers/headset, lower the volume and/or move the microphone further away from your speakers/headset.</p>
 
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/source" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -37,6 +37,10 @@
     p.small {
       font-size: 0.7em;
     }
+    label {
+      width: 12em;
+      display: inline-block;
+    }
   </style>
 
 </head>
@@ -48,7 +52,7 @@
 
     <p>Get available audio, video sources and audio output devices<b>*</b> from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>deviceId</code> constraint.</p>
 
-    <p class="small"><b>*</b>Enable experimental support in <b>Chrome 45.0.2441.x</b> or later by selecting <b>Enable experimental Web Platform features</b> in <b>chrome://flags</b> or by using command line flag "<b>--enable-blink-features=EnumerateDevices,AudioOutputDevices</b>". Use the <code>setSinkID()</code> method on the video element and provide a audio or video element and a sinkId (<code>deviceId</code> for where <code>deviceInfo.kind === 'audiooutput'</code>) as arguments. Also the web page must be served over HTTPS</p>
+    <p class="small"><b>*</b>Enable experimental support in <b>Chrome 45.0.2441.x</b> or later by selecting <b>Enable experimental Web Platform features</b> in <b>chrome://flags</b> or by using command line flag "<b>--enable-blink-features=EnumerateDevices,AudioOutputDevices</b>". Use the <code>setSinkID()</code> method on the video element and provide a audio or video element and a sinkId (<code>deviceId</code> for where <code>deviceInfo.kind === 'audiooutput'</code>) as arguments. Also the web page must be served over HTTPS.</p>
 
     <div class="select">
       <label for="audioSource">Audio input source: </label><select id="audioSource"></select>

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -43,10 +43,18 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Select audio &amp; video sources</span></h1>
 
-    <p>Get available audio and video sources from <code>MediaStream.getSources()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.</p>
+    <p>Get available audio, video sources and audio output* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.
+
+    *Experimental support in Chrome 45.0.2441.x or later using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (sourceId for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.
+    </p>
+
 
     <div class="select">
-      <label for="audioSource">Audio source: </label><select id="audioSource"></select>
+      <label for="audioSource">Audio input source: </label><select id="audioSource"></select>
+    </div>
+
+    <div class="select">
+      <label for="audioOutput">Audio output destination: </label><select id="audioOutput"></select>
     </div>
 
     <div class="select">

--- a/src/content/getusermedia/source/index.html
+++ b/src/content/getusermedia/source/index.html
@@ -43,7 +43,7 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Select audio &amp; video sources</span></h1>
 
-    <p>Get available audio, video sources and audio output* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.
+    <p>Get available audio, video sources and audio output devices* from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>sourceId</code> constraint.
 
     *Experimental support in Chrome 45.0.2441.x or later using command line flag "--enable-blink-features=EnumerateDevices,AudioOutputDevices". Use the <code>setSinkID()</code> method on the video element and provide a MediaStream and a sinkId (sourceId for where <code>sourceInfos.kind === 'audiooutput'</code>) as arguments.
     </p>

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -9,7 +9,8 @@
 'use strict';
 
 var videoElement = document.querySelector('video');
-var audioSelect = document.querySelector('select#audioSource');
+var audioInputSelect = document.querySelector('select#audioSource');
+var audioOutputSelect = document.querySelector('select#audioOutput');
 var videoSelect = document.querySelector('select#videoSource');
 
 function gotSources(sourceInfos) {
@@ -19,24 +20,24 @@ function gotSources(sourceInfos) {
     option.value = sourceInfo.deviceId;
     if (sourceInfo.kind === 'audioinput') {
       option.text = sourceInfo.label ||
-        'microphone ' + (audioSelect.length + 1);
-      audioSelect.appendChild(option);
+        'microphone ' + (audioInputSelect.length + 1);
+      audioInputSelect.appendChild(option);
+    } else if (sourceInfo.kind === 'audiooutput') {
+      option.text = sourceInfo.label || 'speaker ' +
+          (audioOutputSelect.length + 1);
+      audioOutputSelect.appendChild(option);
     } else if (sourceInfo.kind === 'videoinput') {
       option.text = sourceInfo.label || 'camera ' + (videoSelect.length + 1);
       videoSelect.appendChild(option);
     } else {
-      console.log('Some other kind of source: ', sourceInfo);
+      console.log('Some other kind of source/device: ', sourceInfo);
     }
   }
 }
 
-if (!navigator.mediaDevices) {
-  alert('This browser does not support navigator.mediaDevices.');
-} else {
-  navigator.mediaDevices.enumerateDevices()
-  .then(gotSources)
-  .catch(errorCallback);
-}
+navigator.mediaDevices.enumerateDevices()
+.then(gotSources)
+.catch(errorCallback);
 
 function successCallback(stream) {
   window.stream = stream; // make stream available to console
@@ -47,12 +48,16 @@ function errorCallback(error) {
   console.log('navigator.getUserMedia error: ', error);
 }
 
+function changeAudioDestination() {
+  var audioDestination = audioOutputSelect.value;
+  attachSinkId(videoElement, audioDestination);
+}
+
 function start() {
   if (window.stream) {
-    attachMediaStream(videoElement, null);
     window.stream.getTracks().forEach(function(track) { track.stop(); });
   }
-  var audioSource = audioSelect.value;
+  var audioSource = audioInputSelect.value;
   var videoSource = videoSelect.value;
   var constraints = {
     audio: {
@@ -69,7 +74,8 @@ function start() {
   navigator.getUserMedia(constraints, successCallback, errorCallback);
 }
 
-audioSelect.onchange = start;
+audioInputSelect.onchange = start;
+audioOutputSelect.onchange = changeAudioDestination;
 videoSelect.onchange = start;
 
 start();

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source

--- a/src/content/getusermedia/source/js/main.js
+++ b/src/content/getusermedia/source/js/main.js
@@ -13,30 +13,30 @@ var audioInputSelect = document.querySelector('select#audioSource');
 var audioOutputSelect = document.querySelector('select#audioOutput');
 var videoSelect = document.querySelector('select#videoSource');
 
-function gotSources(sourceInfos) {
-  for (var i = 0; i !== sourceInfos.length; ++i) {
-    var sourceInfo = sourceInfos[i];
+function gotDevices(deviceInfos) {
+  for (var i = 0; i !== deviceInfos.length; ++i) {
+    var deviceInfo = deviceInfos[i];
     var option = document.createElement('option');
-    option.value = sourceInfo.deviceId;
-    if (sourceInfo.kind === 'audioinput') {
-      option.text = sourceInfo.label ||
+    option.value = deviceInfo.deviceId;
+    if (deviceInfo.kind === 'audioinput') {
+      option.text = deviceInfo.label ||
         'microphone ' + (audioInputSelect.length + 1);
       audioInputSelect.appendChild(option);
-    } else if (sourceInfo.kind === 'audiooutput') {
-      option.text = sourceInfo.label || 'speaker ' +
+    } else if (deviceInfo.kind === 'audiooutput') {
+      option.text = deviceInfo.label || 'speaker ' +
           (audioOutputSelect.length + 1);
       audioOutputSelect.appendChild(option);
-    } else if (sourceInfo.kind === 'videoinput') {
-      option.text = sourceInfo.label || 'camera ' + (videoSelect.length + 1);
+    } else if (deviceInfo.kind === 'videoinput') {
+      option.text = deviceInfo.label || 'camera ' + (videoSelect.length + 1);
       videoSelect.appendChild(option);
     } else {
-      console.log('Some other kind of source/device: ', sourceInfo);
+      console.log('Some other kind of source/device: ', deviceInfo);
     }
   }
 }
 
 navigator.mediaDevices.enumerateDevices()
-.then(gotSources)
+.then(gotDevices)
 .catch(errorCallback);
 
 function successCallback(stream) {
@@ -46,6 +46,28 @@ function successCallback(stream) {
 
 function errorCallback(error) {
   console.log('navigator.getUserMedia error: ', error);
+}
+
+// Attach audio output device to video element using device/sink ID.
+function attachSinkId(element, sinkId) {
+  if (typeof element.sinkId !== 'undefined') {
+    element.setSinkId(sinkId)
+    .then(function() {
+      console.log('Success, audio output device attached: ' + sinkId);
+    })
+    .catch(function(error) {
+      var errorMessage = error;
+      if (error.name === 'SecurityError') {
+        errorMessage = 'You need to use HTTPS for selecting audio output ' +
+            'device: ' + error;
+      }
+      console.error(errorMessage);
+      // Jump back to first output device in the list as it's the default.
+      audioOutputSelect.selectedIndex = 0;
+    });
+  } else {
+    console.warn('Browser does not support output device selection.');
+  }
 }
 
 function changeAudioDestination() {

--- a/src/js/adapter.js
+++ b/src/js/adapter.js
@@ -354,6 +354,27 @@ if (navigator.mozGetUserMedia) {
     navigator.mediaDevices.addEventListener = function() { };
     navigator.mediaDevices.removeEventListener = function() { };
   }
+
+  // Attach audio output device to video element using source/sink ID.
+  var attachSinkId = function(element, sinkId) {
+    if (typeof element.sinkId !== 'undefined') {
+      element.setSinkId(sinkId)
+      .then(function(event) {
+        return console.log('Success, audio output device attached: ' + sinkId);
+      })
+      .catch(function(error) {
+        var errorMessage = error;
+        if (error.name === 'SecurityError') {
+          errorMessage = 'You need to use HTTPS for selecting audio output ' +
+              'device: ' + error;
+        }
+        return console.error(errorMessage);
+      })
+    } else {
+      console.warn('Browser does not support output device selection.')
+    }
+  }
+
 } else if (navigator.mediaDevices && navigator.userAgent.match(
     /Edge\/(\d+).(\d+)$/)) {
   console.log('This appears to be Edge');

--- a/src/js/adapter.js
+++ b/src/js/adapter.js
@@ -354,27 +354,6 @@ if (navigator.mozGetUserMedia) {
     navigator.mediaDevices.addEventListener = function() { };
     navigator.mediaDevices.removeEventListener = function() { };
   }
-
-  // Attach audio output device to video element using source/sink ID.
-  var attachSinkId = function(element, sinkId) {
-    if (typeof element.sinkId !== 'undefined') {
-      element.setSinkId(sinkId)
-      .then(function(event) {
-        return console.log('Success, audio output device attached: ' + sinkId);
-      })
-      .catch(function(error) {
-        var errorMessage = error;
-        if (error.name === 'SecurityError') {
-          errorMessage = 'You need to use HTTPS for selecting audio output ' +
-              'device: ' + error;
-        }
-        return console.error(errorMessage);
-      })
-    } else {
-      console.warn('Browser does not support output device selection.')
-    }
-  }
-
 } else if (navigator.mediaDevices && navigator.userAgent.match(
     /Edge\/(\d+).(\d+)$/)) {
   console.log('This appears to be Edge');


### PR DESCRIPTION
* Add output device selection
* Add "attachSinkId" to the local copy of adapter.js in the Samples repo, I do intend of landing the change in the adapter.js repo but for the sake of having a working pull request it's currently only here, will create a pull request in the adapter.js repo if this approach is approved.

To test this properly you need to host this page over HTTPS, this can be accomplished using Stunnel configured to point to python -m SimpleHTTPServer.

Use latest M45 Chrome and start it with the following command line flags:
--enable-blink-features=EnumerateDevices,AudioOutputDevices

Note: I've on purpose not changed the HTML layout, I would get some input on that if it should be changed or if it's acceptable just leaving it as is with 3 drop downs.