### PR TITLE
support for firefox getStats

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -254,9 +254,10 @@ window.setInterval(function() {
       var bytes;
       var packets;
       var now = report.timestamp;
-      if ((report.type === 'outboundrtp' || report.type === 'ssrc') && report['bytesSent']) {
-        bytes = report['bytesSent'];
-        packets = report['packetsSent'];
+      if ((report.type === 'outboundrtp') ||
+          (report.type === 'ssrc' && report.bytesSent)) {
+        bytes = report.bytesSent;
+        packets = report.packetsSent;
         if (lastTime) {
           // calculate bitrate
           var bitrate = 8 * (bytes - lastBytes) / (now - lastTime);
@@ -276,7 +277,7 @@ window.setInterval(function() {
         lastTime = now;
       }
     });
-  }, function (err) {
+  }, function(err) {
     console.log(err);
   });
 }, 1000);

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -278,6 +278,6 @@ window.setInterval(function() {
       }
     });
   }, function(err) {
-    console.log(err);
+    console.error(err);
   });
 }, 1000);


### PR DESCRIPTION
this makes the graph in the pc audio demo work in Firefox, too, thanks to the shim of getStats in adapter.js

note: it took me a bit to figure out that adapter doesn't shim the type=outboundrtp on the stats report. There are probably many pitfalls here...