### PR TITLE
add basic selenium test

### DIFF
--- a/src/content/getusermedia/gum/js/test.js
+++ b/src/content/getusermedia/gum/js/test.js
@@ -63,5 +63,10 @@ test('video width and video height are set on GUM sample', function(t) {
     t.pass('got video dimensions ' + dimensions.join('x'));
     driver.quit();
     t.end();
+  })
+  .then(null, function (err) {
+    t.fail(err);
+    driver.quit();
+    t.end();
   });
 });

--- a/src/content/getusermedia/gum/js/test.js
+++ b/src/content/getusermedia/gum/js/test.js
@@ -1,0 +1,66 @@
+'use strict';
+// This is a basic test file for use with testling.
+// The test script language comes from tape.
+/* jshint node: true */
+/* global Promise */
+var test = require('tape');
+
+// https://code.google.com/p/selenium/wiki/WebDriverJs
+var webdriver = require('selenium-webdriver');
+var chrome = require('selenium-webdriver/chrome');
+var firefox = require('selenium-webdriver/firefox');
+
+var profile;
+var ffoptions;
+var croptions;
+
+// firefox options
+var profile = new firefox.Profile();
+// from http://selenium.googlecode.com/git/docs/api/javascript/module_selenium-webdriver_firefox.html
+profile.setPreference('media.navigator.streams.fake', true);
+var ffoptions = new firefox.Options()
+    .setProfile(profile);
+// assume it's running chrome
+// http://selenium.googlecode.com/git/docs/api/javascript/module_selenium-webdriver_chrome_class_Options.html#addArguments
+var croptions = new chrome.Options()
+    .addArguments('use-fake-device-for-media-stream')
+    .addArguments('use-fake-ui-for-media-stream');
+
+
+test('video width and video height are set on GUM sample', function (t) {
+    // FIXME: use env[SELENIUM_BROWSER] instead?
+    var driver = new webdriver.Builder()
+        .forBrowser(process.env['BROWSER'])
+        .setFirefoxOptions(ffoptions)
+        .setChromeOptions(croptions)
+        .build();
+
+    driver.get('https://webrtc.github.io/samples/src/content/getusermedia/gum/')
+    .then(function () {
+        t.pass('page loaded');
+        return driver.findElement(webdriver.By.id('gum-local'));
+    })
+    .then(function (videoElement) {
+        t.pass('found video element');
+        var width = 0;
+        var height = 0;
+        return new webdriver.promise.Promise(function (resolve) {
+            videoElement.getAttribute('videoWidth').then(function (w) {
+                width = w;
+                t.pass('got videoWidth ' + w);
+                if (width && height) resolve([width, height]);
+            });
+            videoElement.getAttribute('videoHeight').then(function (h) {
+                height = h;
+                t.pass('got videoHeight' + h);
+                if (width && height) resolve([width, height]);
+            });
+        });
+
+    })
+    .then(function (dimensions) {
+        t.pass('got video dimensions ' + dimensions.join('x'));
+        driver.quit();
+        t.end();
+    });
+});

--- a/src/content/getusermedia/gum/js/test.js
+++ b/src/content/getusermedia/gum/js/test.js
@@ -22,6 +22,7 @@ var ffoptions = new firefox.Options()
 // assume it's running chrome
 // http://selenium.googlecode.com/git/docs/api/javascript/module_selenium-webdriver_chrome_class_Options.html#addArguments
 var croptions = new chrome.Options()
+    .addArguments('allow-file-access-from-files')
     .addArguments('use-fake-device-for-media-stream')
     .addArguments('use-fake-ui-for-media-stream');
 
@@ -33,9 +34,20 @@ test('video width and video height are set on GUM sample', function(t) {
       .setChromeOptions(croptions)
       .build();
 
-  driver.get('https://webrtc.github.io/samples/src/content/getusermedia/gum/')
+  driver.get('file://' + process.cwd() +
+      '/src/content/getusermedia/gum/index.html')
   .then(function() {
     t.pass('page loaded');
+  })
+  // Check that there is a stream with a video track.
+  .then(function() {
+    return driver.executeScript('return stream && stream.getTracks().length');
+  })
+  .then(function(numberOfStreams) {
+    t.ok(numberOfStreams === 1, 'stream exists and has one track');
+  })
+  // Check that there is a video element and it is displaying something.
+  .then(function() {
     return driver.findElement(webdriver.By.id('gum-local'));
   })
   .then(function(videoElement) {

--- a/src/content/getusermedia/gum/js/test.js
+++ b/src/content/getusermedia/gum/js/test.js
@@ -64,7 +64,7 @@ test('video width and video height are set on GUM sample', function(t) {
     driver.quit();
     t.end();
   })
-  .then(null, function (err) {
+  .then(null, function(err) {
     t.fail(err);
     driver.quit();
     t.end();

--- a/src/content/getusermedia/gum/js/test.js
+++ b/src/content/getusermedia/gum/js/test.js
@@ -2,7 +2,6 @@
 // This is a basic test file for use with testling.
 // The test script language comes from tape.
 /* jshint node: true */
-/* global Promise */
 var test = require('tape');
 
 // https://code.google.com/p/selenium/wiki/WebDriverJs
@@ -26,41 +25,43 @@ var croptions = new chrome.Options()
     .addArguments('use-fake-device-for-media-stream')
     .addArguments('use-fake-ui-for-media-stream');
 
+test('video width and video height are set on GUM sample', function(t) {
+  // FIXME: use env[SELENIUM_BROWSER] instead?
+  var driver = new webdriver.Builder()
+      .forBrowser(process.env.BROWSER)
+      .setFirefoxOptions(ffoptions)
+      .setChromeOptions(croptions)
+      .build();
 
-test('video width and video height are set on GUM sample', function (t) {
-    // FIXME: use env[SELENIUM_BROWSER] instead?
-    var driver = new webdriver.Builder()
-        .forBrowser(process.env['BROWSER'])
-        .setFirefoxOptions(ffoptions)
-        .setChromeOptions(croptions)
-        .build();
-
-    driver.get('https://webrtc.github.io/samples/src/content/getusermedia/gum/')
-    .then(function () {
-        t.pass('page loaded');
-        return driver.findElement(webdriver.By.id('gum-local'));
-    })
-    .then(function (videoElement) {
-        t.pass('found video element');
-        var width = 0;
-        var height = 0;
-        return new webdriver.promise.Promise(function (resolve) {
-            videoElement.getAttribute('videoWidth').then(function (w) {
-                width = w;
-                t.pass('got videoWidth ' + w);
-                if (width && height) resolve([width, height]);
-            });
-            videoElement.getAttribute('videoHeight').then(function (h) {
-                height = h;
-                t.pass('got videoHeight' + h);
-                if (width && height) resolve([width, height]);
-            });
-        });
-
-    })
-    .then(function (dimensions) {
-        t.pass('got video dimensions ' + dimensions.join('x'));
-        driver.quit();
-        t.end();
+  driver.get('https://webrtc.github.io/samples/src/content/getusermedia/gum/')
+  .then(function() {
+    t.pass('page loaded');
+    return driver.findElement(webdriver.By.id('gum-local'));
+  })
+  .then(function(videoElement) {
+    t.pass('found video element');
+    var width = 0;
+    var height = 0;
+    return new webdriver.promise.Promise(function(resolve) {
+      videoElement.getAttribute('videoWidth').then(function(w) {
+        width = w;
+        t.pass('got videoWidth ' + w);
+        if (width && height) {
+          resolve([width, height]);
+        }
+      });
+      videoElement.getAttribute('videoHeight').then(function(h) {
+        height = h;
+        t.pass('got videoHeight ' + h);
+        if (width && height) {
+          resolve([width, height]);
+        }
+      });
     });
+  })
+  .then(function(dimensions) {
+    t.pass('got video dimensions ' + dimensions.join('x'));
+    driver.quit();
+    t.end();
+  });
 });


### PR DESCRIPTION
this adds a basic selenium test to the gum sample. What the test does is that the video has a videoWidth and videoHeight set which imo is the right high-level assertion that things work.

Ideally, we can get this thing to run on travis for every PR as well as nightly on every new canary build so you notice things like #564 without someone reporting it, but there is some work left. 
Currently requires manual installation of [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) from npm, also $BROWSER must be set (and requires chromedriver for running in chrome)