### PR TITLE
package.json: Sorted objects and fixed license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,23 +2,27 @@
   "name": "webrtc-samples",
   "version": "1.0.0",
   "description": "Project checking for WebRTC GitHub samples repo",
-  "main": "Gruntfile.js",
-  "scripts": {
-    "test": "grunt --verbose"
+  "keywords": [
+    "webrtc",
+    "demos",
+    "samples",
+    "javascript"
+  ],
+  "homepage": "https://github.com/webrtc/samples",
+  "bugs": {
+    "url": "https://github.com/webrtc/samples/issues"
   },
+  "license": "BSD-3-Clause",
+  "author": "The WebRTC project authors",
+  "main": "Gruntfile.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/webrtc/samples.git"
   },
-  "keywords": [
-    "webrtc"
-  ],
-  "author": "The WebRTC project authors",
-  "license": "BSD",
-  "bugs": {
-    "url": "https://github.com/webrtc/samples/issues"
+   "scripts" : {
+    "postinstall": "cp node_modules/webrtc-adapter-test/adapter.js src/js",
+    "test": "grunt --verbose"
   },
-  "homepage": "https://github.com/webrtc/samples",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": ">=0.1.9",
@@ -28,9 +32,6 @@
     "grunt-githooks": "^0.3.1",
     "grunt-htmlhint": ">=0.4.1",
     "grunt-jscs": ">=0.8.1",
-    "webrtc-adapter-test": "^0.1.1"
-  },
-  "scripts" : {
-    "postinstall": "cp node_modules/webrtc-adapter-test/adapter.js src/js"
+    "webrtc-adapter-test": "^0.1.0"
   }
 }


### PR DESCRIPTION
Sorted the objects to follow https://docs.npmjs.com/files/package.json, fixed license (npm was complaining) and loosened up webrtc-adapter-test devDependency.