### PR TITLE
Refresh device labels after gUM grant (makes them show in HTTP in Firefox)

### DIFF
--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -44,7 +44,7 @@ function gotDevices(deviceInfos) {
   }
   selectors.forEach(function(select, i) {
     if (Array.prototype.slice.call(select.childNodes).some(function(n) {
-      return n.value == values[i];
+      return n.value === values[i];
     })) {
       select.value = values[i];
     }

--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -16,7 +16,9 @@ var selectors = [audioInputSelect, audioOutputSelect, videoSelect];
 
 function gotDevices(deviceInfos) {
   // Handles being called several times to update labels. Preserve values.
-  var values = selectors.map(function(select) { return select.value; });
+  var values = selectors.map(function(select) {
+    return select.value;
+  });
   console.log(values);
   selectors.forEach(function(select) {
     while (select.firstChild) {

--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -19,7 +19,6 @@ function gotDevices(deviceInfos) {
   var values = selectors.map(function(select) {
     return select.value;
   });
-  console.log(values);
   selectors.forEach(function(select) {
     while (select.firstChild) {
       select.removeChild(select.firstChild);


### PR DESCRIPTION
Makes camera and mic labels appear
* instantly on first use without requiring user to refresh the page in Chrome and Firefox.
* in Firefox in normal flow (wo/requiring user to be on HTTPS *and* explicitly choosing "Always Allow").
