### PR TITLE
Fix grunt-jscs 2.0 errors

### DIFF
--- a/src/content/peerconnection/create-offer/js/main.js
+++ b/src/content/peerconnection/create-offer/js/main.js
@@ -27,7 +27,7 @@ numAudioTracksInput.onchange = function() {
 
 var pc = new RTCPeerConnection(null);
 /* global webkitAudioContext */
-var wacx = new webkitAudioContext();
+var wacx = new webkitAudioContext(); // jscs:ignore requireCapitalizedConstructors
 
 function createOffer() {
   var numRequestedAudioTracks = numAudioTracksInput.value;

--- a/src/content/peerconnection/pr-answer/js/main.js
+++ b/src/content/peerconnection/pr-answer/js/main.js
@@ -25,9 +25,9 @@ btn3.disabled = true;
 var pc1 = null;
 var pc2 = null;
 var localstream;
-var sdpConstraints = {'mandatory':{
-  'OfferToReceiveAudio':true,
-  'OfferToReceiveVideo':true}
+var sdpConstraints = {'mandatory': {
+  'OfferToReceiveAudio': true,
+  'OfferToReceiveVideo': true}
 };
 
 function gotStream(stream) {
@@ -39,8 +39,8 @@ function gotStream(stream) {
 }
 
 navigator.mediaDevices.getUserMedia({
-  audio:true,
-  video:true
+  audio: true,
+  video: true
 })
 .then(gotStream)
 .catch(function(e) {

--- a/src/content/peerconnection/webaudio-input/js/main.js
+++ b/src/content/peerconnection/webaudio-input/js/main.js
@@ -69,10 +69,10 @@ function gotStream(stream) {
 
     var servers = null;
 
-    pc1 = new webkitRTCPeerConnection(servers);
+    pc1 = new webkitRTCPeerConnection(servers); // jscs:ignore requireCapitalizedConstructors
     console.log('Created local peer connection object pc1');
     pc1.onicecandidate = iceCallback1;
-    pc2 = new webkitRTCPeerConnection(servers);
+    pc2 = new webkitRTCPeerConnection(servers); // jscs:ignore requireCapitalizedConstructors
     console.log('Created remote peer connection object pc2');
     pc2.onicecandidate = iceCallback2;
     pc2.onaddstream = gotRemoteStream;


### PR DESCRIPTION
Same story as in https://github.com/webrtc/adapter/pull/101.

I do not like adding inliners like that on each one but we do not have have choice for our prefixed constructors, it's better than turning off the requireCapitalizedConstructors check globally.