### PR TITLE
filetransfer: use mostly-spec getStats and fix test

### DIFF
--- a/src/content/datachannel/filetransfer/js/main.js
+++ b/src/content/datachannel/filetransfer/js/main.js
@@ -231,15 +231,16 @@ function displayStats() {
     if (webrtcDetectedBrowser === 'chrome') {
       // TODO: once https://code.google.com/p/webrtc/issues/detail?id=4321
       // lands those stats should be preferrred over the connection stats.
-      remoteConnection.getStats(function(stats) {
-        stats.result().forEach(function(res) {
+      remoteConnection.getStats(null, function(stats) {
+        for (var key in stats) {
+          var res = stats[key];
           if (timestampPrev === res.timestamp) {
             return;
           }
           if (res.type === 'googCandidatePair' &&
-              res.stat('googActiveConnection') === 'true') {
+              res.googActiveConnection === 'true') {
             // calculate current bitrate
-            var bytesNow = res.stat('bytesReceived');
+            var bytesNow = res.bytesReceived;
             var bitrate = Math.round((bytesNow - bytesPrev) * 8 /
                 (res.timestamp - timestampPrev));
             display(bitrate);
@@ -249,7 +250,7 @@ function displayStats() {
               bitrateMax = bitrate;
             }
           }
-        });
+        }
       });
     } else {
       // Firefox currently does not have data channel stats. See

--- a/src/content/datachannel/filetransfer/js/test.js
+++ b/src/content/datachannel/filetransfer/js/test.js
@@ -20,8 +20,8 @@ function sendFile(t, path) {
   })
   .then(function() {
     // Wait for the received element to be displayed.
-    return driver.wait(webdriver.until.elementLocated(
-        webdriver.By.id('received')));
+    return driver.wait(webdriver.until.elementIsVisible(
+        driver.findElement(webdriver.By.id('received'))));
   })
   .then(function() {
     t.end();


### PR DESCRIPTION
@KaptenJansson also shows how to use elementIsVisible. I had assumed one could call it directly from By.id() but you need to wrap it apparently.

Some of the field names used in getStats are not spec but removing the .stat calls is a step in the right direction.