### PR TITLE
add getStats helper

### DIFF
--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -54,7 +54,7 @@ function getStats(driver, peerConnection) {
   // Execute getStats on peerconnection named `peerConnection`
   driver.executeScript(
       'window.' + tmp + ' = null;' +
-      peerConnection + '.getStats(null, function(report) {' +
+      peerConnection + '.getStats(null).then(function(report) {' +
       '  window.' + tmp + ' = report;' +
       '});');
   // Wait for result.

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -49,7 +49,6 @@ function buildDriver() {
 // A helper function to query stats from a PeerConnection.
 function getStats(driver, peerConnection) {
   // Execute getStats on peerconnection named `peerConnection`.
-  console.log(driver.manage().timeouts());
   driver.manage().timeouts().setScriptTimeout(1000);
   return driver.executeAsyncScript(
       'var callback = arguments[arguments.length - 1];' +

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -46,27 +46,16 @@ function buildDriver() {
   return sharedDriver;
 }
 
-// getStats is async so we need to call it,
-// assign the result to a temporary variable
-// and wait for it to return.
+// A helper function to query stats from a PeerConnection.
 function getStats(driver, peerConnection) {
-  var tmp = '_getStats_' + Math.floor(Math.random() * 65536);
-  // Execute getStats on peerconnection named `peerConnection`
-  driver.executeScript(
-      'window.' + tmp + ' = null;' +
+  // Execute getStats on peerconnection named `peerConnection`.
+  console.log(driver.manage().timeouts());
+  driver.manage().timeouts().setScriptTimeout(1000);
+  return driver.executeAsyncScript(
+      'var callback = arguments[arguments.length - 1];' +
       peerConnection + '.getStats(null).then(function(report) {' +
-      '  window.' + tmp + ' = report;' +
+      '  callback(report);' +
       '});');
-  // Wait for result.
-  return driver.wait(function() {
-    return driver.executeScript(
-        'return window.' + tmp + ' !== null && ' +
-        '(function() {' +
-        '  var val = window.' + tmp + ';' +
-        '  delete window.' + tmp + ';' +
-        '  return val;' +
-        '})()');
-  }, 30 * 1000);
 }
 
 module.exports = {

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -46,6 +46,30 @@ function buildDriver() {
   return sharedDriver;
 }
 
+// getStats is async so we need to call it,
+// assign the result to a temporary variable
+// and wait for it to return.
+function getStats(driver, peerConnection) {
+  var tmp = '_getStats_' + Math.floor(Math.random() * 65536);
+  // Execute getStats on peerconnection named `peerConnection`
+  driver.executeScript(
+      'window.' + tmp + ' = null;' +
+      peerConnection + '.getStats(null, function(report) {' +
+      '  window.' + tmp + ' = report;' +
+      '});');
+  // Wait for result.
+  return driver.wait(function() {
+    return driver.executeScript(
+        'return window.' + tmp + ' !== null && ' +
+        '(function() {' +
+        '  var val = window.' + tmp + ';' +
+        '  delete window.' + tmp + ';' +
+        '  return val;' +
+        '})()');
+  }, 30 * 1000);
+}
+
 module.exports = {
-  buildDriver: buildDriver
+  buildDriver: buildDriver,
+  getStats: getStats
 };


### PR DESCRIPTION
Things like https://github.com/webrtc/samples/pull/504 are tricky to test since getStats (to allow querying the codec name used) is async and we can only execute sync calls.

This adds a helper function which allows doing the following:
```
.then(function() {
  return seleniumHelpers.getStats(driver, 'name of peerconnection variable to inspect');
})
.then(function(stats) {
  console.log(stats);
})
```