### PR TITLE
use video.srcObject

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/webrtc/samples.git"
   },
   "scripts": {
-    "postinstall": "grunt githooks && cp node_modules/webrtc-adapter-test/adapter.js src/js",
+    "postinstall": "cp node_modules/webrtc-adapter-test/adapter.js src/js",
     "test": "grunt && test/run-tests"
   },
   "devDependencies": {
@@ -36,6 +36,6 @@
     "selenium-webdriver": "^2.46.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^2.6.0",
-    "webrtc-adapter-test": "^0.1.0"
+    "webrtc-adapter-test": "^0.2.1"
   }
 }

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -15,7 +15,8 @@ var constraints = window.constraints = {
   video: true
 };
 
-function successCallback(stream) {
+navigator.mediaDevices.getUserMedia(constraints)
+.then(function(stream) {
   var videoTracks = stream.getVideoTracks();
   console.log('Got stream with constraints:', constraints);
   console.log('Using video device: ' + videoTracks[0].label);
@@ -23,11 +24,8 @@ function successCallback(stream) {
     console.log('Stream ended');
   };
   window.stream = stream; // make variable available to browser console
-  attachMediaStream(video, stream);
-}
-
-function errorCallback(error) {
+  video.srcObject = stream;
+})
+.catch(function(error) {
   console.log('navigator.getUserMedia error: ', error);
-}
-
-navigator.getUserMedia(constraints, successCallback, errorCallback);
+});


### PR DESCRIPTION
probably breaks for chrome < 43 but... @samdutton

also bumps adapter to 0.2.1 and removes the grunt githooks call because of https://github.com/webrtc/adapter/pull/113 (even though samples are not a npm package)