### PR TITLE
Temporarily allow FF beta to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
+    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=unstable
 
 before_script:


### PR DESCRIPTION
For quite some time FF unstable + webdriver have timed out. Specifically it was FF 41, it has now moved to the beta track hence the failure tagged along.

You can see this [here](https://travis-ci.org/webrtc/samples/jobs/75139235#L304) where yesterday's last commit used FF 40 for beta and today's commitis [used](https://travis-ci.org/webrtc/samples/jobs/75409702#L285) FF 41 for the beta track.

We need to figure out why FF 41 and webdriver stops working at the first test (presumably the first gum request), I can see the firefox window open but then nothing else happens.

I will try to look into it today or tomorrow, @fippo @jan-ivar please let me know if you have any info to what it might be.