### PR TITLE
Enable FF beta and fix FF41 issue where it does not start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
-    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=unstable
 
 before_script:

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -26,6 +26,13 @@ function buildDriver() {
   profile.setPreference('media.navigator.streams.fake', true);
   // This enables device labels for enumerateDevices when using fake devices.
   profile.setPreference('media.navigator.permission.disabled', true);
+  // Currently the FF webdriver extension is not signed and FF 41 no longer
+  // allows unsigned extensions by default.
+  // TODO: Remove this once FF no longer allow turning this off and the
+  // selenium team starts making a signed FF webdriver extension.
+  // https://github.com/SeleniumHQ/selenium/issues/901.
+  profile.setPreference('xpinstall.signatures.required', false);
+
   var firefoxOptions = new firefox.Options()
       .setProfile(profile)
       .setBinary('node_modules/.bin/start-firefox');


### PR DESCRIPTION
Fixes #583 

Note that Firefox unstable (FF42) still fails due to it no longer allows turning off the check for unsigned extensions. See the issue for more details.