### PR TITLE
audio demo: also support outbound-rtp in addition to outboundrtp

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -254,6 +254,7 @@ window.setInterval(function() {
       var packets;
       var now = report.timestamp;
       if ((report.type === 'outboundrtp') ||
+          (report.type === 'outbound-rtp') ||
           (report.type === 'ssrc' && report.bytesSent)) {
         bytes = report.bytesSent;
         packets = report.packetsSent;


### PR DESCRIPTION
I am not sure what the plan is WRT to outbound-rtp vs outboundrtp. The former is used by webrtc-pc and ortc, the latter by webrtc-stats. Either way, this should make things work, we can remove the wrong types at some point in the future :-)