### PR TITLE
use spec constraints in offers

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -30,10 +30,9 @@ var packetSeries;
 var lastResult;
 
 var sdpConstraints = {
-  'mandatory': {
-    'OfferToReceiveAudio': true,
-    'OfferToReceiveVideo': false
-  }
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 0,
+  voiceActivityDecection: false
 };
 
 function gotStream(stream) {
@@ -48,7 +47,7 @@ function gotStream(stream) {
   trace('Adding Local Stream to peer connection');
 
   pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
-    {voiceActivityDetection: false});
+      sdpConstraints);
 
   bitrateSeries = new TimelineDataSeries();
   bitrateGraph = new TimelineGraphView('bitrateGraph', 'bitrateCanvas');
@@ -98,8 +97,7 @@ function gotDescription1(desc) {
       // Since the 'remote' side has no media stream we need
       // to pass in the right constraints in order for it to
       // accept the incoming offer of audio.
-      pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError,
-          sdpConstraints);
+      pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError);
     }, onSetSessionDescriptionError);
   }, onSetSessionDescriptionError);
 }

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -32,7 +32,7 @@ var lastResult;
 var sdpConstraints = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 0,
-  voiceActivityDecection: false
+  voiceActivityDetection: false
 };
 
 function gotStream(stream) {

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -29,7 +29,7 @@ var packetSeries;
 
 var lastResult;
 
-var sdpConstraints = {
+var offerOptions = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 0,
   voiceActivityDetection: false
@@ -47,7 +47,7 @@ function gotStream(stream) {
   trace('Adding Local Stream to peer connection');
 
   pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
-      sdpConstraints);
+      offerOptions);
 
   bitrateSeries = new TimelineDataSeries();
   bitrateGraph = new TimelineGraphView('bitrateGraph', 'bitrateCanvas');

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -34,10 +34,8 @@ var localStream;
 var dtmfSender;
 
 var sdpConstraints = {
-  'mandatory': {
-    'OfferToReceiveAudio': true,
-    'OfferToReceiveVideo': false
-  }
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 0
 };
 
 main();
@@ -56,7 +54,8 @@ function gotStream(stream) {
   }
   pc1.addStream(localStream);
   trace('Adding Local Stream to peer connection');
-  pc1.createOffer(gotDescription1, onCreateSessionDescriptionError);
+  pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
+      sdpConstraints);
 }
 
 function onCreateSessionDescriptionError(error) {
@@ -99,8 +98,7 @@ function gotDescription1(desc) {
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio.
-  pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError,
-      sdpConstraints);
+  pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError);
 }
 
 function gotDescription2(desc) {

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -33,7 +33,7 @@ var pc2;
 var localStream;
 var dtmfSender;
 
-var sdpConstraints = {
+var offerOptions = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 0
 };
@@ -55,7 +55,7 @@ function gotStream(stream) {
   pc1.addStream(localStream);
   trace('Adding Local Stream to peer connection');
   pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
-      sdpConstraints);
+      offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -26,10 +26,8 @@ var pc1Remote;
 var pc2Local;
 var pc2Remote;
 var sdpConstraints = {
-  'mandatory': {
-    'OfferToReceiveAudio': true,
-    'OfferToReceiveVideo': true
-  }
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 1
 };
 
 function gotStream(stream) {
@@ -83,11 +81,13 @@ function call() {
 
   pc1Local.addStream(window.localstream);
   trace('Adding local stream to pc1Local');
-  pc1Local.createOffer(gotDescription1Local, onCreateSessionDescriptionError);
+  pc1Local.createOffer(gotDescription1Local, onCreateSessionDescriptionError,
+      sdpConstraints);
 
   pc2Local.addStream(window.localstream);
   trace('Adding local stream to pc2Local');
-  pc2Local.createOffer(gotDescription2Local, onCreateSessionDescriptionError);
+  pc2Local.createOffer(gotDescription2Local, onCreateSessionDescriptionError,
+      sdpConstraints);
 }
 
 function onCreateSessionDescriptionError(error) {
@@ -102,7 +102,7 @@ function gotDescription1Local(desc) {
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
   pc1Remote.createAnswer(gotDescription1Remote,
-      onCreateSessionDescriptionError, sdpConstraints);
+      onCreateSessionDescriptionError);
 }
 
 function gotDescription1Remote(desc) {
@@ -119,7 +119,7 @@ function gotDescription2Local(desc) {
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
   pc2Remote.createAnswer(gotDescription2Remote,
-      onCreateSessionDescriptionError, sdpConstraints);
+      onCreateSessionDescriptionError);
 }
 
 function gotDescription2Remote(desc) {

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -25,7 +25,7 @@ var pc1Local;
 var pc1Remote;
 var pc2Local;
 var pc2Remote;
-var sdpConstraints = {
+var offerOptions = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 1
 };
@@ -82,12 +82,12 @@ function call() {
   pc1Local.addStream(window.localstream);
   trace('Adding local stream to pc1Local');
   pc1Local.createOffer(gotDescription1Local, onCreateSessionDescriptionError,
-      sdpConstraints);
+      offerOptions);
 
   pc2Local.addStream(window.localstream);
   trace('Adding local stream to pc2Local');
   pc2Local.createOffer(gotDescription2Local, onCreateSessionDescriptionError,
-      sdpConstraints);
+      offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -44,10 +44,8 @@ var localPeerConnection;
 var remotePeerConnection;
 var localStream;
 var sdpConstraints = {
-  'mandatory': {
-    'OfferToReceiveAudio': true,
-    'OfferToReceiveVideo': true
-  }
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 1
 };
 
 getSources();
@@ -175,7 +173,7 @@ function maybeAddLineBreakToEnd(sdp) {
 
 function createOffer() {
   localPeerConnection.createOffer(gotDescription1,
-      onCreateSessionDescriptionError);
+      onCreateSessionDescriptionError, sdpConstraints);
 }
 
 function onCreateSessionDescriptionError(error) {
@@ -207,8 +205,7 @@ function createAnswer() {
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
   remotePeerConnection.createAnswer(gotDescription2,
-      onCreateSessionDescriptionError,
-      sdpConstraints);
+      onCreateSessionDescriptionError);
 }
 
 function setAnswer() {

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -43,7 +43,7 @@ var selectSourceDiv = document.querySelector('div#selectSource');
 var localPeerConnection;
 var remotePeerConnection;
 var localStream;
-var sdpConstraints = {
+var offerOptions = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 1
 };
@@ -173,7 +173,7 @@ function maybeAddLineBreakToEnd(sdp) {
 
 function createOffer() {
   localPeerConnection.createOffer(gotDescription1,
-      onCreateSessionDescriptionError, sdpConstraints);
+      onCreateSessionDescriptionError, offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -47,10 +47,8 @@ var localStream;
 var pc1;
 var pc2;
 var sdpConstraints = {
-  'mandatory': {
-    'OfferToReceiveAudio': true,
-    'OfferToReceiveVideo': true
-  }
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 1
 };
 
 function getName(pc) {
@@ -118,7 +116,8 @@ function call() {
   trace('Added local stream to pc1');
 
   trace('pc1 createOffer start');
-  pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError);
+  pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError,
+      sdpConstraints);
 }
 
 function onCreateSessionDescriptionError(error) {
@@ -139,8 +138,7 @@ function onCreateOfferSuccess(desc) {
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
-  pc2.createAnswer(onCreateAnswerSuccess, onCreateSessionDescriptionError,
-      sdpConstraints);
+  pc2.createAnswer(onCreateAnswerSuccess, onCreateSessionDescriptionError);
 }
 
 function onSetLocalSuccess(pc) {

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -46,7 +46,7 @@ remoteVideo.onresize = function() {
 var localStream;
 var pc1;
 var pc2;
-var sdpConstraints = {
+var offerOptions = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 1
 };
@@ -117,7 +117,7 @@ function call() {
 
   trace('pc1 createOffer start');
   pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError,
-      sdpConstraints);
+      offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {

--- a/src/content/peerconnection/states/js/main.js
+++ b/src/content/peerconnection/states/js/main.js
@@ -30,7 +30,7 @@ var localstream;
 var pc1;
 var pc2;
 
-var sdpConstraints = {
+var offerOptions = {
   offerToReceiveAudio: 1,
   offerToReceiveVideo: 1
 };
@@ -94,7 +94,7 @@ function call() {
   pc1.addStream(localstream);
   trace('Adding Local Stream to peer connection');
   pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
-      sdpConstraints);
+      offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {

--- a/src/content/peerconnection/states/js/main.js
+++ b/src/content/peerconnection/states/js/main.js
@@ -31,10 +31,8 @@ var pc1;
 var pc2;
 
 var sdpConstraints = {
-  mandatory: {
-    OfferToReceiveAudio: true,
-    OfferToReceiveVideo: true
-  }
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 1
 };
 
 function gotStream(stream) {
@@ -95,7 +93,8 @@ function call() {
   pc2.onaddstream = gotRemoteStream;
   pc1.addStream(localstream);
   trace('Adding Local Stream to peer connection');
-  pc1.createOffer(gotDescription1, onCreateSessionDescriptionError);
+  pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
+      sdpConstraints);
 }
 
 function onCreateSessionDescriptionError(error) {
@@ -106,8 +105,7 @@ function gotDescription1(description) {
   pc1.setLocalDescription(description);
   trace('Offer from pc1: \n' + description.sdp);
   pc2.setRemoteDescription(description);
-  pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError,
-      sdpConstraints);
+  pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError);
 }
 
 function gotDescription2(description) {

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -17,7 +17,7 @@ var servers = document.querySelector('select#servers');
 var urlInput = document.querySelector('input#url');
 var usernameInput = document.querySelector('input#username');
 var ipv6Check = document.querySelector('input#ipv6');
-var unbundleCheck = document.querySelector('input#unbundle');
+//var unbundleCheck = document.querySelector('input#unbundle');
 
 addButton.onclick = addServer;
 gatherButton.onclick = start;
@@ -94,11 +94,11 @@ function start() {
   // on whether the unbundle RTCP checkbox is checked.
   var config = {'iceServers': iceServers, iceTransportPolicy: iceTransports};
   var pcConstraints = {};
-  var offerConstraints = {'mandatory': {'OfferToReceiveAudio': true}};
+  var offerConstraints = {offerToReceiveAudio: 1};
   // Whether we gather IPv6 candidates.
   pcConstraints.optional = [{'googIPv6': ipv6Check.checked}];
   // Whether we only gather a single set of candidates for RTP and RTCP.
-  offerConstraints.optional = [{'googUseRtpMUX': !unbundleCheck.checked}];
+  //offerConstraints.optional = [{'googUseRtpMUX': !unbundleCheck.checked}];
 
   trace('Creating new PeerConnection with config=' + JSON.stringify(config) +
         ', constraints=' + JSON.stringify(pcConstraints));

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -94,17 +94,17 @@ function start() {
   // on whether the unbundle RTCP checkbox is checked.
   var config = {'iceServers': iceServers, iceTransportPolicy: iceTransports};
   var pcConstraints = {};
-  var offerConstraints = {offerToReceiveAudio: 1};
+  var offerOptions = {offerToReceiveAudio: 1};
   // Whether we gather IPv6 candidates.
   pcConstraints.optional = [{'googIPv6': ipv6Check.checked}];
   // Whether we only gather a single set of candidates for RTP and RTCP.
-  //offerConstraints.optional = [{'googUseRtpMUX': !unbundleCheck.checked}];
+  //offerOptions.optional = [{'googUseRtpMUX': !unbundleCheck.checked}];
 
   trace('Creating new PeerConnection with config=' + JSON.stringify(config) +
         ', constraints=' + JSON.stringify(pcConstraints));
   pc = new RTCPeerConnection(config, pcConstraints);
   pc.onicecandidate = iceCallback;
-  pc.createOffer(gotDescription, noDescription, offerConstraints);
+  pc.createOffer(gotDescription, noDescription, offerOptions);
 }
 
 function gotDescription(desc) {


### PR DESCRIPTION
this removes most of the answer options (which are currrently only supported in Chrome and use the legacy format) and uses offer options instead. Not sure why answer options were used even, looks like copy-paste without thinking :-)

One thing that broke is the googUseRtpMux on the candidate gathering page but I suppose that should be updated to use the bundle/rtcp-mux constraints anyway @juberti @pthatcherg?