### PR TITLE
Fixing typo that breaks setOffer in the sdp munging sample.

### DIFF
--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -201,7 +201,7 @@ function setOffer() {
   var sdp = offerSdpTextarea.value;
   sdp = maybeAddLineBreakToEnd(sdp);
   sdp = sdp.replace(/\n/g, '\r\n');
-  offer.ѕdp = sdp;
+  offer.sdp = sdp;
   localPeerConnection.setLocalDescription(offer,
       onSetSessionDescriptionSuccess,
       onSetSessionDescriptionError);


### PR DESCRIPTION
The 'cyrillic small letter dze' (http://www.fileformat.info/info/unicode/char/0455/index.htm) was somehow used instead of an 's'. So "offer.sdp = sdp" wasn't actually changing the sdp of the offer as intended.