### PR TITLE
Change link URLs to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,17 +53,17 @@
 
     <section>
 
-      <p>This is a repository for the WebRTC Javascript code samples. The source for these samples is available at <a href="//github.com/webrtc/samples" title="View GitHub repository for these files">github.com/webrtc/samples</a>.</p>
+      <p>This is a repository for the WebRTC Javascript code samples. The source for these samples is available at <a href="https://github.com/webrtc/samples" title="View GitHub repository for these files">github.com/webrtc/samples</a>.</p>
 
-      <p>Some of the samples use new browser features. They may only work in <a href="//www.google.com/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a>, <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a> or Microsoft Edge (available with Windows 10), and may require flags to be set.</p>
+      <p>Some of the samples use new browser features. They may only work in <a href="https://www.google.com/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a>, <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a> or Microsoft Edge (available with Windows 10), and may require flags to be set.</p>
 
-      <p>Most of the samples use <a href="//github.com/webrtc/adapter">adapter.js</a>, a shim to insulate apps from spec changes and prefix differences. (In fact, the standards and protocols used for WebRTC implementations are highly stable, and there are only a few prefixed names. For full interop information, see <a href="//www.webrtc.org/web-apis/interop">webrtc.org/web-apis/interop</a>.)</p>
+      <p>Most of the samples use <a href="https://github.com/webrtc/adapter">adapter.js</a>, a shim to insulate apps from spec changes and prefix differences. (In fact, the standards and protocols used for WebRTC implementations are highly stable, and there are only a few prefixed names. For full interop information, see <a href="http://www.webrtc.org/web-apis/interop">webrtc.org/web-apis/interop</a>.)</p>
 
       <p>In Chrome and Opera, all samples that use <code>getUserMedia()</code> must be run from a server. Calling <code>getUserMedia()</code> from a file:// URL will work in Firefox, but fail silently in Chrome and Opera.</p>
 
       <p><a href="http://www.webrtc.org/testing" title="Command-line flags for WebRTC testing">webrtc.org/testing</a> lists command line flags useful for development and testing with Chrome.</p>
 
-      <p>For more information about WebRTC, we maintain a list of <a href="//docs.google.com/document/d/1idl_NYQhllFEFqkGQOLv8KBK8M3EVzyvxnKkHl4SuM8/edit">WebRTC Resources</a>. If you've never worked with WebRTC, we recommend you start with the 2013 Google I/O <a href="//www.youtube.com/watch?v=p2HzZkd2A40">WebRTC presentation</a>.</p>
+      <p>For more information about WebRTC, we maintain a list of resources at <a href="https://g.co/webrtc">g.co/webrtc</a>. If you've never worked with WebRTC, we recommend you start with the 2013 Google I/O <a href="https://www.youtube.com/watch?v=p2HzZkd2A40">WebRTC presentation</a>.</p>
 
       <p>Patches and issues welcome! See <a href="https://github.com/webrtc/samples/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a> for instructions. The <a href="https://bit.ly/webrtcdevguide">Developer's Guide</a> for this repo has more information about code style, structure and validation.</p>
 
@@ -75,73 +75,73 @@
 
       <h3 id="getusermedia">getUserMedia</h3>
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/gum/">Basic getUserMedia demo</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/gum/">Basic getUserMedia demo</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/canvas/">Use getUserMedia with canvas</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/canvas/">Use getUserMedia with canvas</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/filter/">Use getUserMedia with canvas and CSS filters</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/filter/">Use getUserMedia with canvas and CSS filters</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/resolution/">Choose camera resolution</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/resolution/">Choose camera resolution</a></p>
 
 
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/audio/">Audio-only getUserMedia() output to local audio element</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/audio/">Audio-only getUserMedia() output to local audio element</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/volume/">Audio-only getUserMedia() displaying volume</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/volume/">Audio-only getUserMedia() displaying volume</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/getusermedia/face/">Face tracking, using getUserMedia and canvas</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/face/">Face tracking, using getUserMedia and canvas</a></p>
 
 
       <h3 id="devices">Devices</h3>
 
-      <p><a href="//webrtc.github.io/samples/src/content/devices/input-output/">Choose camera, microphone and speaker</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/devices/input-output/">Choose camera, microphone and speaker</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/devices/multi/">Choose media source and audio output</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/devices/multi/">Choose media source and audio output</a></p>
 
 
       <h3 id="peerconnection">RTCPeerConnection</h3>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/pc1/">Basic peer connection demo</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/pc1/">Basic peer connection demo</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/audio/">Audio-only peer connection demo</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/audio/">Audio-only peer connection demo</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/multiple/">Multiple peer connections at once</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/multiple/">Multiple peer connections at once</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/multiple-relay/">Forward the output of one PC into another</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/multiple-relay/">Forward the output of one PC into another</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/munge-sdp/">Munge SDP parameters</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/munge-sdp/">Munge SDP parameters</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/pr-answer/">Use pranswer when setting up a peer connection</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/pr-answer/">Use pranswer when setting up a peer connection</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/constraints/">Constraints and stats</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/constraints/">Constraints and stats</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/create-offer/">Display createOffer output for various scenarios</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/create-offer/">Display createOffer output for various scenarios</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/dtmf/">Use RTCDTMFSender</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/dtmf/">Use RTCDTMFSender</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/states/">Display peer connection states</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/states/">Display peer connection states</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/trickle-ice/">ICE candidate gathering from STUN/TURN servers</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/">ICE candidate gathering from STUN/TURN servers</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/peerconnection/webaudio-input/">Web Audio output as input to peer connection</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/webaudio-input/">Web Audio output as input to peer connection</a></p>
 
       <h3 id="datachannel">RTCDataChannel</h3>
 
-      <p><a href="//webrtc.github.io/samples/src/content/datachannel/basic/">Transmit text</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/datachannel/basic/">Transmit text</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/datachannel/filetransfer/">Transfer a file</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/datachannel/filetransfer/">Transfer a file</a></p>
 
-      <p><a href="//webrtc.github.io/samples/src/content/datachannel/datatransfer/">Transfer data</a></p>
+      <p><a href="https://webrtc.github.io/samples/src/content/datachannel/datatransfer/">Transfer data</a></p>
 
       <h3 id="videoChat">Video chat</h3>
 
-      <p><a href="//apprtc.appspot.com/">AppRTC video chat client</a> powered by Google App Engine</p>
+      <p><a href="https://apprtc.appspot.com/">AppRTC video chat client</a> powered by Google App Engine</p>
 
-      <p><a href="//apprtc.appspot.com/params.html">AppRTC URL parameters</a></p>
+      <p><a href="https://apprtc.appspot.com/params.html">AppRTC URL parameters</a></p>
 
     </section>
 
-    <a href="//github.com/webrtc/samples" title="View the repository" id="viewSource">github.com/webrtc/samples</a>
+    <a href="https://github.com/webrtc/samples" title="View the repository" id="viewSource">github.com/webrtc/samples</a>
 
   </div>
 


### PR DESCRIPTION
As per #639, to cope with secure origin enforcement.

(Also updated links to docs, etc.)