### PR TITLE
Use { exact: } on deviceId constraints (suppress FF doorhanger choices)

### DIFF
--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -94,8 +94,8 @@ function start() {
   var audioSource = audioInputSelect.value;
   var videoSource = videoSelect.value;
   var constraints = {
-    audio: {deviceId: audioSource? { exact: audioSource } : undefined },
-    video: {deviceId: videoSource? { exact: videoSource } : undefined }
+    audio: {deviceId: audioSource ? {exact: audioSource} : undefined},
+    video: {deviceId: videoSource ? {exact: videoSource} : undefined}
   };
   navigator.mediaDevices.getUserMedia(constraints)
   .then(function(stream) {

--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -94,8 +94,8 @@ function start() {
   var audioSource = audioInputSelect.value;
   var videoSource = videoSelect.value;
   var constraints = {
-    audio: {deviceId: audioSource},
-    video: {deviceId: videoSource}
+    audio: {deviceId: audioSource? { exact: audioSource } : undefined },
+    video: {deviceId: videoSource? { exact: videoSource } : undefined }
   };
   navigator.mediaDevices.getUserMedia(constraints)
   .then(function(stream) {


### PR DESCRIPTION
In-content selectors should use the { [`exact`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Parameters): } keyword in constraints, to make the request mandatory.

Several people got confused by http://webrtc.github.io/samples/src/content/devices/input-output/ because the Firefox doorhanger gives them choices, letting them override the in-content choice (optional constraints only affect the default choice in Firefox). This fixes that.