### PR TITLE
Improve setup for new developers …

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Some of the samples use new browser features. They may only work in Chrome Canar
 All of the samples use [adapter.js](https://github.com/webrtc/adapter), a shim to insulate apps from spec changes and prefix differences. In fact, the standards and protocols used for WebRTC implementations are highly stable, and there are only a few prefixed names. For full interop information, see [webrtc.org/web-apis/interop](http://www.webrtc.org/web-apis/interop).
 
 In Chrome and Opera, all samples that use `getUserMedia()` must be run from a server. Calling `getUserMedia()` from a file:// URL will work in Firefox, but fail silently in Chrome and Opera.
+To start a simple server for development, run `npm install && node server.js` then navigate
+your browser to `https://localhost:8080`.
 
 [webrtc.org/testing](http://www.webrtc.org/testing) lists command line flags useful for development and testing with Chrome.
 
@@ -81,6 +83,3 @@ Patches and issues welcome! See [CONTRIBUTING](https://github.com/webrtc/samples
 [AppRTC video chat client](https://apprtc.appspot.com/) powered by Google App Engine
 
 [AppRTC URL parameters](https://apprtc.appspot.com/params.html)
-
-
-

--- a/index.html
+++ b/index.html
@@ -147,6 +147,12 @@
   </div>
 
   <script src="src/js/lib/ga.js"></script>
+  <script type="application/javascript">
+    // Redirect to HTTPS for Github Pages
+    if (window.location.protocol !== "https:"){
+      window.location.protocol = "https";
+    }
+  </script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -76,63 +76,63 @@
 
       <h3 id="getusermedia">getUserMedia</h3>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/gum/">Basic getUserMedia demo</a></p>
+      <p><a href="/src/content/getusermedia/gum/">Basic getUserMedia demo</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/canvas/">Use getUserMedia with canvas</a></p>
+      <p><a href="/src/content/getusermedia/canvas/">Use getUserMedia with canvas</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/filter/">Use getUserMedia with canvas and CSS filters</a></p>
+      <p><a href="/src/content/getusermedia/filter/">Use getUserMedia with canvas and CSS filters</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/resolution/">Choose camera resolution</a></p>
+      <p><a href="/src/content/getusermedia/resolution/">Choose camera resolution</a></p>
 
 
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/audio/">Audio-only getUserMedia() output to local audio element</a></p>
+      <p><a href="/src/content/getusermedia/audio/">Audio-only getUserMedia() output to local audio element</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/volume/">Audio-only getUserMedia() displaying volume</a></p>
+      <p><a href="/src/content/getusermedia/volume/">Audio-only getUserMedia() displaying volume</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/getusermedia/face/">Face tracking, using getUserMedia and canvas</a></p>
+      <p><a href="/src/content/getusermedia/face/">Face tracking, using getUserMedia and canvas</a></p>
 
 
       <h3 id="devices">Devices</h3>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/devices/input-output/">Choose camera, microphone and speaker</a></p>
+      <p><a href="/src/content/devices/input-output/">Choose camera, microphone and speaker</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/devices/multi/">Choose media source and audio output</a></p>
+      <p><a href="/src/content/devices/multi/">Choose media source and audio output</a></p>
 
 
       <h3 id="peerconnection">RTCPeerConnection</h3>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/pc1/">Basic peer connection demo</a></p>
+      <p><a href="/src/content/peerconnection/pc1/">Basic peer connection demo</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/audio/">Audio-only peer connection demo</a></p>
+      <p><a href="/src/content/peerconnection/audio/">Audio-only peer connection demo</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/multiple/">Multiple peer connections at once</a></p>
+      <p><a href="/src/content/peerconnection/multiple/">Multiple peer connections at once</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/multiple-relay/">Forward the output of one PC into another</a></p>
+      <p><a href="/src/content/peerconnection/multiple-relay/">Forward the output of one PC into another</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/munge-sdp/">Munge SDP parameters</a></p>
+      <p><a href="/src/content/peerconnection/munge-sdp/">Munge SDP parameters</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/pr-answer/">Use pranswer when setting up a peer connection</a></p>
+      <p><a href="/src/content/peerconnection/pr-answer/">Use pranswer when setting up a peer connection</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/constraints/">Constraints and stats</a></p>
+      <p><a href="/src/content/peerconnection/constraints/">Constraints and stats</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/create-offer/">Display createOffer output for various scenarios</a></p>
+      <p><a href="/src/content/peerconnection/create-offer/">Display createOffer output for various scenarios</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/dtmf/">Use RTCDTMFSender</a></p>
+      <p><a href="/src/content/peerconnection/dtmf/">Use RTCDTMFSender</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/states/">Display peer connection states</a></p>
+      <p><a href="/src/content/peerconnection/states/">Display peer connection states</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/">ICE candidate gathering from STUN/TURN servers</a></p>
+      <p><a href="/src/content/peerconnection/trickle-ice/">ICE candidate gathering from STUN/TURN servers</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/peerconnection/webaudio-input/">Web Audio output as input to peer connection</a></p>
+      <p><a href="/src/content/peerconnection/webaudio-input/">Web Audio output as input to peer connection</a></p>
 
       <h3 id="datachannel">RTCDataChannel</h3>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/datachannel/basic/">Transmit text</a></p>
+      <p><a href="/src/content/datachannel/basic/">Transmit text</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/datachannel/filetransfer/">Transfer a file</a></p>
+      <p><a href="/src/content/datachannel/filetransfer/">Transfer a file</a></p>
 
-      <p><a href="https://webrtc.github.io/samples/src/content/datachannel/datatransfer/">Transfer data</a></p>
+      <p><a href="/src/content/datachannel/datatransfer/">Transfer data</a></p>
 
       <h3 id="videoChat">Video chat</h3>
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "chromedriver": "^2.16.0",
+    "express": "^4.13.3",
     "grunt": "^0.4.5",
     "grunt-cli": ">=0.1.9",
     "grunt-contrib-compress": "^0.13.0",
@@ -33,6 +34,7 @@
     "grunt-githooks": "^0.3.1",
     "grunt-htmlhint": ">=0.4.1",
     "grunt-jscs": ">=0.8.1",
+    "pem": "^1.8.1",
     "selenium-webdriver": "^2.46.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^2.6.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,20 @@
+var express = require('express');
+var https = require('https');
+var http = require('http');
+var pem = require('pem');
+
+pem.createCertificate({ days:1, selfSigned:true }, function(err, keys) {
+  var options = {
+    key: keys.serviceKey,
+    cert: keys.certificate
+  };
+
+  var app = express();
+
+  app.use(express.static('.'));
+
+  // Create an HTTPS service
+  https.createServer(options, app).listen(8080);
+
+  console.log('serving on https://localhost:8080');
+});

--- a/server.js
+++ b/server.js
@@ -1,6 +1,13 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
 var express = require('express');
 var https = require('https');
-var http = require('http');
 var pem = require('pem');
 
 pem.createCertificate({ days:1, selfSigned:true }, function(err, keys) {


### PR DESCRIPTION
... by including a simple server script and using relative links. I noticed all branches of this (including localhost and @fippo's [branch](http://fippo.github.io/webrtc/) have links back to this repo, instead of relative. I used relative links to simplify. Also added a simple script to do the grunt work (excuse the pun) of setting up a simple static server for devs over https. This is especially useful with upcoming Chrome release which will stop gUM from working off of https.

Now, to be off and running, all that's needed is `npm install && node server.js`