### PR TITLE
allow FF beta to fail temporarely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
+    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
 
 before_script:


### PR DESCRIPTION
The URL that travis-multirunner fetches FF beta and nightly is responding with 404 at the moment. Disabling until fixed.
