### PR TITLE
Update create offer constraints and bump travis-multirunner to 3.0 and enable FF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
-    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
 
 before_script:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pem": "^1.8.1",
     "selenium-webdriver": "^2.48.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^2.7.2",
+    "travis-multirunner": "^3.0.0",
     "webrtc-adapter-test": "^0.2.1"
   }
 }

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source

--- a/src/content/peerconnection/create-offer/index.html
+++ b/src/content/peerconnection/create-offer/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source

--- a/src/content/peerconnection/pr-answer/js/main.js
+++ b/src/content/peerconnection/pr-answer/js/main.js
@@ -25,9 +25,9 @@ btn3.disabled = true;
 var pc1 = null;
 var pc2 = null;
 var localstream;
-var sdpConstraints = {'mandatory': {
-  'OfferToReceiveAudio': true,
-  'OfferToReceiveVideo': true}
+var offerOptions = {
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 1
 };
 
 function gotStream(stream) {
@@ -43,7 +43,7 @@ navigator.mediaDevices.getUserMedia({
 })
 .then(gotStream)
 .catch(function(e) {
-  alert('getUserMedia() error: ' + e.name);
+  alert('getUserMedia() error: ' + e);
 });
 
 function start() {
@@ -72,7 +72,8 @@ function start() {
   pc1.addStream(localstream);
   trace('Adding Local Stream to peer connection');
 
-  pc1.createOffer(gotDescription1, onCreateSessionDescriptionError);
+  pc1.createOffer(gotDescription1, onCreateSessionDescriptionError,
+      offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {
@@ -102,8 +103,7 @@ function gotDescription1(desc) {
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
-  pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError,
-                   sdpConstraints);
+  pc2.createAnswer(gotDescription2, onCreateSessionDescriptionError);
 }
 
 function gotDescription2(desc) {
@@ -127,7 +127,7 @@ function gotDescription3(desc) {
 }
 
 function accept() {
-  pc2.createAnswer(gotDescription3, onCreateAnswerError, sdpConstraints);
+  pc2.createAnswer(gotDescription3, onCreateAnswerError);
   btn2.disabled = true;
   btn1.disabled = false;
 }


### PR DESCRIPTION
Not sure if the pranswer test page actually works due to a webrtc bug in Chrome and FF has not implmeneted pranswer yet.

However I think it makes sense to setup the expectations in the offer due offerToReceiveVideo/Audio are not valid createAnswer constraints (only voiceActivityDetection is a valid answer and offer constraint according to http://w3c.github.io/webrtc-pc/#idl-def-RTCAnswerOptions)
