### PR TITLE
MediaRecorder demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,13 +84,13 @@
 
       <p><a href="src/content/getusermedia/resolution/">Choose camera resolution</a></p>
 
-
-
       <p><a href="src/content/getusermedia/audio/">Audio-only getUserMedia() output to local audio element</a></p>
 
       <p><a href="src/content/getusermedia/volume/">Audio-only getUserMedia() displaying volume</a></p>
 
       <p><a href="src/content/getusermedia/face/">Face tracking, using getUserMedia and canvas</a></p>
+
+      <p><a href="src/content/getusermedia/record/">Record stream</a></p>
 
 
       <h3 id="devices">Devices</h3>

--- a/src/content/getusermedia/record/css/main.css
+++ b/src/content/getusermedia/record/css/main.css
@@ -1,0 +1,51 @@
+ button {
+  margin: 0 3px 10px 0;
+  width: 99px;
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+button:last-of-type {
+  margin: 0;
+}
+
+p.borderBelow {
+  margin: 0 0 20px 0;
+  padding: 0 0 20px 0;
+}
+
+video {
+  height: 232px;
+  margin: 0 12px 20px 0;
+  vertical-align: top;
+  width: calc(20em - 10px);
+}
+
+
+video:last-of-type {
+  margin: 0 0 20px 0;
+}
+
+video#gumVideo {
+  margin: 0 20px 20px 0;
+}
+
+@media screen and (max-width: 500px) {
+  button {
+    font-size: 0.7em;
+    margin: 0 3px 10px 0;
+    width: 88px;
+  }
+}
+
+@media screen and (max-width: 720px) {
+  video {
+    height: calc((50vw - 48px) * 3 / 4);
+    margin: 0 10px 10px 0;
+    width: calc(50vw - 48px);
+  }
+
+  video#gumVideo {
+    margin: 0 10px 10px 0;
+  }
+}

--- a/src/content/getusermedia/record/css/main.css
+++ b/src/content/getusermedia/record/css/main.css
@@ -1,3 +1,10 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
  button {
   margin: 0 3px 10px 0;
   width: 99px;

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -39,7 +39,7 @@
 
     <p>For more information see the MediaStream Recording API <a href="http://w3c.github.io/mediacapture-record/MediaRecorder.html" title="W3C MediaStream Recording API Editor's Draft">Editor's&nbsp;Draft</a>.</p>
 
-    <video id="gum" autoplay></video>
+    <video id="gum" autoplay muted></video>
     <video id="recorded" autoplay loop></video>
 
     <div>

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="description" content="WebRTC code samples">
+  <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1">
+  <meta itemprop="description" content="Client-side WebRTC code samples">
+  <meta itemprop="image" content="../../../images/webrtc-icon-192x192.png">
+  <meta itemprop="name" content="WebRTC code samples">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta id="theme-color" name="theme-color" content="#ffffff">
+
+  <base target="_blank">
+
+  <title>MediaStream Recording</title>
+
+  <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
+  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="../../../css/main.css">
+  <link rel="stylesheet" href="css/main.css">
+
+</head>
+
+<body>
+
+  <div id="container">
+
+    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>MediaRecorder</span></h1>
+
+    <p>This demo requires Firefox 29 or later, or Chrome 47 or later with <strong>Enable experimental Web Platform features</strong> enabled from chrome://flags.</p>
+
+    <p>For more information see the MediaStream Recording API <a href="http://w3c.github.io/mediacapture-record/MediaRecorder.html" title="W3C MediaStream Recording API Editor's Draft">Editor's&nbsp;Draft</a>.</p>
+
+    <video id="gum" autoplay></video>
+    <video id="recorded" autoplay loop></video>
+
+    <div>
+      <button id="record">Start Recording</button>
+      <button id="play" disabled>Play</button>
+      <button id="download" disabled>Download</button>
+    </div>
+
+    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/record" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+
+  </div>
+
+  <script src="js/main.js"></script>
+  <script src="../../../js/lib/ga.js"></script>
+
+</body>
+</html>

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -23,7 +23,7 @@ navigator.getUserMedia = navigator.getUserMedia ||
 navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
 var constraints = {
-  audio: false,
+  audio: true,
   video: true
 };
 
@@ -97,8 +97,7 @@ function toggleRecording() {
 function startRecording() {
   try {
     recordedBlobs = [];
-    mediaRecorder = new MediaRecorder(window.stream);
-    // mediaRecorder = new MediaRecorder(window.stream, 'video/vp8');
+    mediaRecorder = new MediaRecorder(window.stream /* , 'video/vp8' */);
   } catch (event) {
     alert('MediaRecorder is not supported by this browser.\n\n' +
       'Try Chrome 47 or later, with Enable experimental Web Platform features enabled from chrome://flags.');
@@ -131,12 +130,15 @@ function play() {
 
 function download() {
   var blob = new Blob(recordedBlobs, {type: 'video/webm'});
-  var url = URL.createObjectURL(blob);
+  var url = window.URL.createObjectURL(blob);
   var a = document.createElement('a');
-  document.body.appendChild(a);
   a.style = 'display: none';
   a.href = url;
   a.download = 'test.webm';
+  document.body.appendChild(a);
   a.click();
-  window.URL.revokeObjectURL(url);
+  setTimeout(function() {
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  }, 100);
 }

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+'use strict';
+
+/* globals MediaRecorder */
+
+// This code is adapted from
+// https://rawgit.com/Miguelao/demos/master/mediarecorder.html
+
+var mediaSource = new MediaSource();
+mediaSource.addEventListener('sourceopen', handleSourceOpen, false);
+var mediaRecorder;
+var recordedBlobs;
+var sourceBuffer;
+
+navigator.getUserMedia = navigator.getUserMedia ||
+navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+
+var constraints = {
+  audio: false,
+  video: true
+};
+
+var gumVideo = document.querySelector('video#gum');
+var recordedVideo = document.querySelector('video#recorded');
+// recordedVideo.src = URL.createObjectURL(mediaSource);
+
+var recordButton = document.querySelector('button#record');
+var playButton = document.querySelector('button#play');
+var downloadButton = document.querySelector('button#download');
+recordButton.onclick = toggleRecording;
+playButton.onclick = play;
+downloadButton.onclick = download;
+
+// window.isSecureContext could be used for Chrome
+var isSecureOrigin = location.protocol === 'https:' ||
+location.host === 'localhost';
+if (!isSecureOrigin) {
+  alert('getUserMedia() must be run from a secure origin: HTTPS or localhost.' +
+    '\n\nChanging protocol to HTTPS');
+  location.protocol = 'HTTPS';
+}
+navigator.getUserMedia(constraints, handleGumSuccess, handleGumError);
+
+function handleSourceOpen(event) {
+  console.log('MediaSource opened');
+  sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp8"');
+  console.log('Source buffer: ', sourceBuffer);
+}
+
+function handleGumSuccess(stream) {
+  console.log('getUserMedia() got stream: ', stream);
+  window.stream = stream; // make available to browser console
+  if (window.URL) {
+    gumVideo.src = window.URL.createObjectURL(stream);
+  } else {
+    gumVideo.src = stream;
+  }
+}
+
+function handleGumError(error) {
+  console.log('navigator.getUserMedia error: ', error);
+}
+
+function handleDataAvailable(event) {
+  if (event.data.size > 0) {
+    recordedBlobs.push(event.data);
+    console.assert(mediaRecorder.state === 'recording',
+      'State should be "recording"');
+  } else {
+    console.assert(mediaRecorder.state === 'inactive',
+      'State should be "inactive"');
+  }
+}
+
+function handleStop(event) {
+  console.log('Recorder stopped: ', event);
+}
+
+function toggleRecording() {
+  if (recordButton.textContent === 'Start Recording') {
+    startRecording();
+  } else {
+    stopRecording();
+    recordButton.textContent = 'Start Recording';
+    playButton.disabled = false;
+    downloadButton.disabled = false;
+  }
+}
+
+function startRecording() {
+  try {
+    recordedBlobs = [];
+    mediaRecorder = new MediaRecorder(window.stream);
+    // mediaRecorder = new MediaRecorder(window.stream, 'video/vp8');
+  } catch (event) {
+    alert('MediaRecorder is not supported by this browser.\n\n' +
+      'Try Chrome 47 or later, with Enable experimental Web Platform features enabled from chrome://flags.');
+    console.error('Exception while creating MediaRecorder:', event);
+    return;
+  }
+  console.assert(mediaRecorder.state === 'inactive');
+  recordButton.textContent = 'Stop Recording';
+  playButton.disabled = true;
+  downloadButton.disabled = true;
+  mediaRecorder.onstop = handleStop;
+  mediaRecorder.ondataavailable = handleDataAvailable;
+  mediaRecorder.start();
+  console.log('MediaRecorder started', mediaRecorder);
+  console.assert(mediaRecorder.state === 'recording');
+}
+
+function stopRecording() {
+  mediaRecorder.stop();
+  console.log('Recorded Blobs: ', recordedBlobs);
+  // window.stream.getVideoTracks()[0].stop();
+}
+
+function play() {
+  // sourceBuffer.appendBuffer(recordedBlobs); // or...
+  var superBuffer = new Blob(recordedBlobs);
+  recordedVideo.src = window.URL.createObjectURL(superBuffer);
+  recordedVideo.controls = true;
+}
+
+function download() {
+  var blob = new Blob(recordedBlobs, {type: 'video/webm'});
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  document.body.appendChild(a);
+  a.style = 'display: none';
+  a.href = url;
+  a.download = 'test.webm';
+  a.click();
+  window.URL.revokeObjectURL(url);
+}

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -1,10 +1,10 @@
 /*
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
- *
- *  Use of this source code is governed by a BSD-style license
- *  that can be found in the LICENSE file in the root of the source
- *  tree.
- */
+*  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+*
+*  Use of this source code is governed by a BSD-style license
+*  that can be found in the LICENSE file in the root of the source
+*  tree.
+*/
 
 'use strict';
 
@@ -43,18 +43,12 @@ var isSecureOrigin = location.protocol === 'https:' ||
 location.host === 'localhost';
 if (!isSecureOrigin) {
   alert('getUserMedia() must be run from a secure origin: HTTPS or localhost.' +
-    '\n\nChanging protocol to HTTPS');
+      '\n\nChanging protocol to HTTPS');
   location.protocol = 'HTTPS';
 }
-navigator.getUserMedia(constraints, handleGumSuccess, handleGumError);
 
-function handleSourceOpen(event) {
-  console.log('MediaSource opened');
-  sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp8"');
-  console.log('Source buffer: ', sourceBuffer);
-}
-
-function handleGumSuccess(stream) {
+navigator.mediaDevices.getUserMedia(constraints)
+.then(function(stream) {
   console.log('getUserMedia() got stream: ', stream);
   window.stream = stream; // make available to browser console
   if (window.URL) {
@@ -62,10 +56,14 @@ function handleGumSuccess(stream) {
   } else {
     gumVideo.src = stream;
   }
-}
-
-function handleGumError(error) {
+}).catch(function(error) {
   console.log('navigator.getUserMedia error: ', error);
+});
+
+function handleSourceOpen(event) {
+  console.log('MediaSource opened');
+  sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp8"');
+  console.log('Source buffer: ', sourceBuffer);
 }
 
 function handleDataAvailable(event) {
@@ -100,7 +98,7 @@ function startRecording() {
     mediaRecorder = new MediaRecorder(window.stream /* , 'video/vp8' */);
   } catch (event) {
     alert('MediaRecorder is not supported by this browser.\n\n' +
-      'Try Chrome 47 or later, with Enable experimental Web Platform features enabled from chrome://flags.');
+      'Try Firefox 29 or later, or Chrome 47 or later, with Enable experimental Web Platform features enabled from chrome://flags.');
     console.error('Exception while creating MediaRecorder:', event);
     return;
   }
@@ -118,14 +116,12 @@ function startRecording() {
 function stopRecording() {
   mediaRecorder.stop();
   console.log('Recorded Blobs: ', recordedBlobs);
-  // window.stream.getVideoTracks()[0].stop();
+  recordedVideo.controls = true;
 }
 
 function play() {
-  // sourceBuffer.appendBuffer(recordedBlobs); // or...
   var superBuffer = new Blob(recordedBlobs);
   recordedVideo.src = window.URL.createObjectURL(superBuffer);
-  recordedVideo.controls = true;
 }
 
 function download() {


### PR DESCRIPTION
This is based on Miguel's demo at https://rawgit.com/Miguelao/demos/master/mediarecorder.html.

I've added it to the getUserMedia items on index.html, but we might eventually want to create a section for recording demos.

Works in Firefox, including audio, though for some reason the audio doesn't save properly when you download.

You can try it live at [samdutton.github.io/webrtc/src/content/getusermedia/record](https://samdutton.github.io/webrtc/src/content/getusermedia/record/).

PTAL @miguelao @juberti @KaptenJansson 
