### PR TITLE
record demo: use adapter + srcObject

### DIFF
--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -52,6 +52,7 @@
 
   </div>
 
+  <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -52,6 +52,7 @@
 
   </div>
 
+  <!-- include adapter for srcObject shim -->
   <script src="../../../js/adapter.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -51,7 +51,7 @@ navigator.mediaDevices.getUserMedia(constraints)
 .then(function(stream) {
   console.log('getUserMedia() got stream: ', stream);
   window.stream = stream; // make available to browser console
-  gumVideo.srcObject = stream;
+  gumVideo.srcObject = stream; // srcObject is shimmed in adapter.js
 }).catch(function(error) {
   console.log('navigator.getUserMedia error: ', error);
 });
@@ -117,7 +117,7 @@ function stopRecording() {
 
 function play() {
   var superBuffer = new Blob(recordedBlobs);
-  recordedVideo.src = window.URL.createObjectURL(superBuffer);
+  recordedVideo.srcObject = superBuffer;
 }
 
 function download() {

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -51,11 +51,7 @@ navigator.mediaDevices.getUserMedia(constraints)
 .then(function(stream) {
   console.log('getUserMedia() got stream: ', stream);
   window.stream = stream; // make available to browser console
-  if (window.URL) {
-    gumVideo.src = window.URL.createObjectURL(stream);
-  } else {
-    gumVideo.src = stream;
-  }
+  gumVideo.srcObject = stream;
 }).catch(function(error) {
   console.log('navigator.getUserMedia error: ', error);
 });


### PR DESCRIPTION
just because...

Oddly, in play() one can't use srcObject so createObjectUrl still has to be used. The spec looks like doing that for blobs should be possible but that does not seem to be implemented yet -- https://crbug.com/506273)
