### PR TITLE
Tweaks to MediaRecorder example: redundant asserts, etc.

### DIFF
--- a/src/content/extensions/multipleroutes/src/utils.js
+++ b/src/content/extensions/multipleroutes/src/utils.js
@@ -6,8 +6,7 @@
  *  tree.
  */
 
-/* exported browserSupportsIPHandlingPolicy browserSupportsNonProxiedUdpBoolean
-   getPolicyFromBooleans */
+/* exported getPolicyFromBooleans */
 
 'use strict';
 

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -19,9 +19,6 @@ var mediaRecorder;
 var recordedBlobs;
 var sourceBuffer;
 
-navigator.getUserMedia = navigator.getUserMedia ||
-navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-
 var constraints = {
   audio: true,
   video: true

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -62,11 +62,6 @@ function handleSourceOpen(event) {
 function handleDataAvailable(event) {
   if (event.data && event.data.size > 0) {
     recordedBlobs.push(event.data);
-    console.assert(mediaRecorder.state === 'recording',
-      'State should be "recording"');
-  } else {
-    console.assert(mediaRecorder.state === 'inactive',
-      'State should be "inactive"');
   }
 }
 
@@ -86,24 +81,29 @@ function toggleRecording() {
 }
 
 function startRecording() {
+  var options = {mimeType: 'video/vp9'};
   try {
     recordedBlobs = [];
-    mediaRecorder = new MediaRecorder(window.stream /* , 'video/vp8' */);
-  } catch (event) {
-    alert('MediaRecorder is not supported by this browser.\n\n' +
-      'Try Firefox 29 or later, or Chrome 47 or later, with Enable experimental Web Platform features enabled from chrome://flags.');
-    console.error('Exception while creating MediaRecorder:', event);
-    return;
+    mediaRecorder = new MediaRecorder(window.stream, options);
+  } catch (e) {
+    try {
+      options = 'video/vp8'; // Chrome 47
+      mediaRecorder = new MediaRecorder(window.stream, options);
+    } catch (event) {
+      alert('MediaRecorder is not supported by this browser.\n\n' +
+        'Try Firefox 29 or later, or Chrome 47 or later, with Enable experimental Web Platform features enabled from chrome://flags.');
+      console.error('Exception while creating MediaRecorder:', event);
+      return;
+    }
   }
-  console.assert(mediaRecorder.state === 'inactive');
+  console.log('Created MediaRecorder', mediaRecorder, 'with options', options);
   recordButton.textContent = 'Stop Recording';
   playButton.disabled = true;
   downloadButton.disabled = true;
   mediaRecorder.onstop = handleStop;
   mediaRecorder.ondataavailable = handleDataAvailable;
-  mediaRecorder.start();
+  mediaRecorder.start(10); // collect 10ms of data
   console.log('MediaRecorder started', mediaRecorder);
-  console.assert(mediaRecorder.state === 'recording');
 }
 
 function stopRecording() {


### PR DESCRIPTION
Various updates to cope with different codecs, etc. Also removed `console.assert()` statements, which are now redundant (@miguelao says).

Live [here](https://samdutton.github.io/webrtc/src/content/getusermedia/record/).

PR includes minor tweak to utils.js to remove redundant linting declarations.
