### PR TITLE
add ice restart example

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,8 @@
 
       <p><a href="src/content/peerconnection/trickle-ice/">ICE candidate gathering from STUN/TURN servers</a></p>
 
+      <p><a href="src/content/peerconnection/restart-ice/">Do an ICE restart</a></p>
+
       <p><a href="src/content/peerconnection/webaudio-input/">Web Audio output as input to peer connection</a></p>
 
       <h3 id="datachannel">RTCDataChannel</h3>

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -225,7 +225,7 @@ setInterval(function() {
       var activeCandidatePair = null;
       var remoteCandidate = null;
 
-      // search for the candidate pa
+      // search for the candidate pair
       Object.keys(results).forEach(function(result) {
         var report = results[result];
         if (report.type === 'candidatepair' && report.selected ||

--- a/src/content/peerconnection/restart-ice/css/main.css
+++ b/src/content/peerconnection/restart-ice/css/main.css
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+button {
+  margin: 0 20px 0 0;
+  width: 83px;
+}
+
+button#hangupButton {
+    margin: 0;
+}
+
+video {
+  height: 225px;
+  margin: 0 0 20px 0;
+  vertical-align: top;
+  width: calc(50% - 12px);
+}
+
+video#localVideo {
+  margin: 0 20px 20px 0;
+}
+
+@media screen and (max-width: 400px) {
+  button {
+    width: 83px;
+  }
+
+  button {
+    margin: 0 11px 10px 0;
+  }
+
+
+  video {
+    height: 90px;
+    margin: 0 0 10px 0;
+    width: calc(50% - 7px);
+  }
+  video#localVideo {
+    margin: 0 10px 20px 0;
+  }
+
+}

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="description" content="WebRTC code samples">
+  <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1">
+  <meta itemprop="description" content="Client-side WebRTC code samples">
+  <meta itemprop="image" content="../../../images/webrtc-icon-192x192.png">
+  <meta itemprop="name" content="WebRTC code samples">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta id="theme-color" name="theme-color" content="#ffffff">
+
+  <base target="_blank">
+
+  <title>ICE Restart</title>
+
+  <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
+  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="../../../css/main.css" />
+  <link rel="stylesheet" href="css/main.css" />
+
+</head>
+
+<body>
+
+  <div id="container">
+
+    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Peer connection</span></h1>
+
+    <video id="localVideo" autoplay muted></video>
+    <video id="remoteVideo" autoplay></video>
+
+    <div>
+      <button id="startButton">Start</button>
+      <button id="callButton">Call</button>
+      <button id="restartButton">Restart ICE</button>
+      <button id="hangupButton">Hang Up</button>
+    </div>
+
+    <p>View the console to see logging. The <code>MediaStream</code> object <code>localStream</code>, and the <code>RTCPeerConnection</code> objects <code>localPeerConnection</code> and <code>remotePeerConnection</code> are in global scope, so you can inspect them in the console as well.</p>
+
+    <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/" title="HTML5 Rocks article about WebRTC by Sam Dutton">Getting Started With WebRTC</a>.</p>
+
+
+    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/peerconnection/pc1" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+
+  </div>
+
+  <script src="../../../js/adapter.js"></script>
+  <script src="../../../js/common.js"></script>
+  <script src="js/main.js"></script>
+
+  <script src="../../../js/lib/ga.js"></script>
+</body>
+</html>

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -1,0 +1,259 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+'use strict';
+
+var startButton = document.getElementById('startButton');
+var callButton = document.getElementById('callButton');
+var restartButton = document.getElementById('restartButton');
+var hangupButton = document.getElementById('hangupButton');
+callButton.disabled = true;
+hangupButton.disabled = true;
+restartButton.disabled = true;
+startButton.onclick = start;
+callButton.onclick = call;
+hangupButton.onclick = hangup;
+restartButton.onclick = restart;
+
+var startTime;
+var localVideo = document.getElementById('localVideo');
+var remoteVideo = document.getElementById('remoteVideo');
+
+localVideo.addEventListener('loadedmetadata', function() {
+  trace('Local video videoWidth: ' + this.videoWidth +
+    'px,  videoHeight: ' + this.videoHeight + 'px');
+});
+
+remoteVideo.addEventListener('loadedmetadata', function() {
+  trace('Remote video videoWidth: ' + this.videoWidth +
+    'px,  videoHeight: ' + this.videoHeight + 'px');
+});
+
+remoteVideo.onresize = function() {
+  trace('Remote video size changed to ' +
+    remoteVideo.videoWidth + 'x' + remoteVideo.videoHeight);
+  // We'll use the first onsize callback as an indication that video has started
+  // playing out.
+  if (startTime) {
+    var elapsedTime = window.performance.now() - startTime;
+    trace('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
+    startTime = null;
+  }
+};
+
+var localStream;
+var pc1;
+var pc2;
+var offerOptions = {
+  offerToReceiveAudio: 1,
+  offerToReceiveVideo: 1
+};
+
+function getName(pc) {
+  return (pc === pc1) ? 'pc1' : 'pc2';
+}
+
+function getOtherPc(pc) {
+  return (pc === pc1) ? pc2 : pc1;
+}
+
+function gotStream(stream) {
+  trace('Received local stream');
+  localVideo.srcObject = stream;
+  localStream = stream;
+  callButton.disabled = false;
+}
+
+function start() {
+  trace('Requesting local stream');
+  startButton.disabled = true;
+  navigator.mediaDevices.getUserMedia({
+    audio: true,
+    video: true
+  })
+  .then(gotStream)
+  .catch(function(e) {
+    alert('getUserMedia() error: ' + e.name);
+  });
+}
+
+// Simulate an ice restart.
+function restart() {
+  restartButton.disabled = true;
+  offerOptions.iceRestart = true;
+  trace('pc1 createOffer restart');
+  pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError,
+      offerOptions);
+}
+
+function call() {
+  callButton.disabled = true;
+  hangupButton.disabled = false;
+  trace('Starting call');
+  startTime = window.performance.now();
+  var videoTracks = localStream.getVideoTracks();
+  var audioTracks = localStream.getAudioTracks();
+  if (videoTracks.length > 0) {
+    trace('Using video device: ' + videoTracks[0].label);
+  }
+  if (audioTracks.length > 0) {
+    trace('Using audio device: ' + audioTracks[0].label);
+  }
+  var servers = null;
+  pc1 = new RTCPeerConnection(servers);
+  trace('Created local peer connection object pc1');
+  pc1.onicecandidate = function(e) {
+    onIceCandidate(pc1, e);
+  };
+  pc2 = new RTCPeerConnection(servers);
+  trace('Created remote peer connection object pc2');
+  pc2.onicecandidate = function(e) {
+    onIceCandidate(pc2, e);
+  };
+  pc1.oniceconnectionstatechange = function(e) {
+    onIceStateChange(pc1, e);
+    if (pc1 && (pc1.iceConnectionState === 'connected' ||
+        pc1.iceConnectionState === 'completed')) {
+      restartButton.disabled = false;
+    }
+  };
+  pc2.oniceconnectionstatechange = function(e) {
+    onIceStateChange(pc2, e);
+  };
+  pc2.onaddstream = gotRemoteStream;
+
+  pc1.addStream(localStream);
+  trace('Added local stream to pc1');
+
+  trace('pc1 createOffer start');
+  pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError,
+      offerOptions);
+}
+
+function onCreateSessionDescriptionError(error) {
+  trace('Failed to create session description: ' + error.toString());
+}
+
+function onCreateOfferSuccess(desc) {
+  trace('Offer from pc1\n' + desc.sdp);
+  trace('pc1 setLocalDescription start');
+  pc1.setLocalDescription(desc, function() {
+    onSetLocalSuccess(pc1);
+  }, onSetSessionDescriptionError);
+  trace('pc2 setRemoteDescription start');
+  pc2.setRemoteDescription(desc, function() {
+    onSetRemoteSuccess(pc2);
+  }, onSetSessionDescriptionError);
+  trace('pc2 createAnswer start');
+  // Since the 'remote' side has no media stream we need
+  // to pass in the right constraints in order for it to
+  // accept the incoming offer of audio and video.
+  pc2.createAnswer(onCreateAnswerSuccess, onCreateSessionDescriptionError);
+}
+
+function onSetLocalSuccess(pc) {
+  trace(getName(pc) + ' setLocalDescription complete');
+}
+
+function onSetRemoteSuccess(pc) {
+  trace(getName(pc) + ' setRemoteDescription complete');
+}
+
+function onSetSessionDescriptionError(error) {
+  trace('Failed to set session description: ' + error.toString());
+}
+
+function gotRemoteStream(e) {
+  remoteVideo.srcObject = e.stream;
+  trace('pc2 received remote stream');
+}
+
+function onCreateAnswerSuccess(desc) {
+  trace('Answer from pc2:\n' + desc.sdp);
+  trace('pc2 setLocalDescription start');
+  pc2.setLocalDescription(desc, function() {
+    onSetLocalSuccess(pc2);
+  }, onSetSessionDescriptionError);
+  trace('pc1 setRemoteDescription start');
+  pc1.setRemoteDescription(desc, function() {
+    onSetRemoteSuccess(pc1);
+  }, onSetSessionDescriptionError);
+}
+
+function onIceCandidate(pc, event) {
+  if (event.candidate) {
+    getOtherPc(pc).addIceCandidate(new RTCIceCandidate(event.candidate),
+        function() {
+          onAddIceCandidateSuccess(pc);
+        },
+        function(err) {
+          onAddIceCandidateError(pc, err);
+        }
+    );
+    trace(getName(pc) + ' ICE candidate: \n' + event.candidate.candidate);
+  }
+}
+
+function onAddIceCandidateSuccess(pc) {
+  trace(getName(pc) + ' addIceCandidate success');
+}
+
+function onAddIceCandidateError(pc, error) {
+  trace(getName(pc) + ' failed to add ICE Candidate: ' + error.toString());
+}
+
+function onIceStateChange(pc, event) {
+  if (pc) {
+    trace(getName(pc) + ' ICE state: ' + pc.iceConnectionState);
+    console.log('ICE state change event: ', event);
+    // TODO: get rid of this in favor of http://w3c.github.io/webrtc-pc/#widl-RTCIceTransport-onselectedcandidatepairchange
+    if (pc.iceConnectionState === 'connected' ||
+        pc.iceConnectionState === 'completed') {
+      pc.getStats(null).then(function(results) {
+        // figure out the peer's ip
+        var activeCandidatePair = null;
+        var remoteCandidate = null;
+
+        // search for the candidate pair
+        Object.keys(results).forEach(function(result) {
+          var report = results[result];
+          if (report.type === 'candidatepair' && report.selected ||
+              report.type === 'googCandidatePair' &&
+              report.googActiveConnection === 'true') {
+            activeCandidatePair = report;
+          }
+        });
+        if (activeCandidatePair && activeCandidatePair.remoteCandidateId) {
+          Object.keys(results).forEach(function(result) {
+            var report = results[result];
+            if (report.type === 'remotecandidate' &&
+                report.id === activeCandidatePair.remoteCandidateId) {
+              remoteCandidate = report;
+            }
+          });
+        }
+        if (remoteCandidate && remoteCandidate.ipAddress &&
+            remoteCandidate.portNumber) {
+          console.log(pc === pc1 ? 'PC1' : 'PC2', 'remote address changed',
+              remoteCandidate.ipAddress, remoteCandidate.portNumber);
+          // TODO: update a div showing the remote ip/port?
+        }
+      });
+    }
+  }
+}
+
+function hangup() {
+  trace('Ending call');
+  pc1.close();
+  pc2.close();
+  pc1 = null;
+  pc2 = null;
+  hangupButton.disabled = true;
+  callButton.disabled = false;
+}

--- a/src/content/peerconnection/restart-ice/js/test.js
+++ b/src/content/peerconnection/restart-ice/js/test.js
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+
+'use strict';
+// This is a basic test file for use with testling.
+// The test script language comes from tape.
+var test = require('tape');
+
+var webdriver = require('selenium-webdriver');
+var seleniumHelpers = require('../../../../../test/selenium-lib');
+
+test('PeerConnection pc1 sample', function(t) {
+  var driver = seleniumHelpers.buildDriver();
+
+  driver.get('file://' + process.cwd() +
+      '/src/content/peerconnection/pc1/index.html')
+  .then(function() {
+    t.pass('page loaded');
+    return driver.findElement(webdriver.By.id('startButton')).click();
+  })
+  .then(function() {
+    t.pass('got media');
+    return driver.findElement(webdriver.By.id('callButton')).click();
+  })
+  .then(function() {
+    return driver.wait(function() {
+      return driver.executeScript(
+          'return pc2 && pc2.iceConnectionState === \'connected\';');
+    }, 30 * 1000);
+  })
+  .then(function() {
+    t.pass('pc2 ICE connected');
+    return driver.findElement(webdriver.By.id('hangupButton')).click();
+  })
+  .then(function() {
+    return driver.wait(function() {
+      return driver.executeScript('return pc1 === null');
+    }, 30 * 1000);
+  })
+  .then(function() {
+    t.pass('hangup');
+    t.end();
+  })
+  .then(null, function(err) {
+    t.fail(err);
+    t.end();
+  });
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -30,6 +30,9 @@ require('../src/content/peerconnection/munge-sdp/js/test');
 // Tests basic functionality of the trickle-ice demo.
 require('../src/content/peerconnection/trickle-ice/js/test');
 
+// Tests basic functionality of the ice restart demo.
+require('../src/content/peerconnection/restart-ice/js/test.js');
+
 // Tests basic functionality of the datachannel textchat demo.
 require('../src/content/datachannel/basic/js/test');
 


### PR DESCRIPTION
@pthatcherg -- let's document this :-)

I am not really happy that it is quite hard to detect the ice restart at pc2.
pc1 triggers an iceconnectionstatechange to connected (or completed), but pc2 does not which, without onselectedcandidatepairchange, makes it very hard to determine a restart happened. Polling getStats is not an option. Shall I file an issue?
