### PR TITLE
some ice restart tuning

### DIFF
--- a/src/content/peerconnection/restart-ice/css/main.css
+++ b/src/content/peerconnection/restart-ice/css/main.css
@@ -16,13 +16,14 @@ button#hangupButton {
 
 video {
   height: 225px;
-  margin: 0 0 20px 0;
-  vertical-align: top;
-  width: calc(50% - 12px);
+  margin: 0;
 }
 
-video#localVideo {
-  margin: 0 20px 20px 0;
+div#video > div {
+  display: inline-block;
+  margin: 0 5px 0 0;
+  vertical-align: top;
+  width: calc(50% - 22px);
 }
 
 @media screen and (max-width: 400px) {
@@ -34,14 +35,7 @@ video#localVideo {
     margin: 0 11px 10px 0;
   }
 
-
   video {
-    height: 90px;
-    margin: 0 0 10px 0;
-    width: calc(50% - 7px);
+    height: 96px;
   }
-  video#localVideo {
-    margin: 0 10px 20px 0;
-  }
-
 }

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -35,8 +35,16 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Peer connection</span></h1>
 
-    <video id="localVideo" autoplay muted></video>
-    <video id="remoteVideo" autoplay></video>
+    <div id="video">
+      <div>
+        <video id="localVideo" autoplay muted></video>
+        <p id="localAddress">Not connected.</p>
+      </div>
+      <div>
+        <video id="remoteVideo" autoplay muted></video>
+        <p id="remoteAddress">Not connected.</p>
+      </div>
+    </div>
 
     <div>
       <button id="startButton">Start</button>

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -117,8 +117,7 @@ function call() {
   };
   pc1.oniceconnectionstatechange = function(e) {
     onIceStateChange(pc1, e);
-    if (pc1 && (pc1.iceConnectionState === 'connected' ||
-        pc1.iceConnectionState === 'completed')) {
+    if (pc1 && pc1.iceConnectionState === 'completed') {
       restartButton.disabled = false;
     }
   };
@@ -242,6 +241,10 @@ function onIceStateChange(pc, event) {
           console.log(pc === pc1 ? 'PC1' : 'PC2', 'remote address changed',
               remoteCandidate.ipAddress, remoteCandidate.portNumber);
           // TODO: update a div showing the remote ip/port?
+          document.getElementById(pc === pc1 ? 'localAddress' :
+              'remoteAddress')
+              .textContent = remoteCandidate.ipAddress + ':' +
+                  remoteCandidate.portNumber;
         }
       });
     }
@@ -255,5 +258,6 @@ function hangup() {
   pc1 = null;
   pc2 = null;
   hangupButton.disabled = true;
+  restartButton.disabled = true;
   callButton.disabled = false;
 }

--- a/src/content/peerconnection/restart-ice/js/test.js
+++ b/src/content/peerconnection/restart-ice/js/test.js
@@ -61,7 +61,7 @@ test('PeerConnection restart ICE sample', function(t) {
   .then(function() {
     return driver.wait(function() {
       return driver.executeScript(
-          'return pc2 && pc2.iceConnectionState === \'connected\';');
+          'return pc1 && pc1.iceConnectionState === \'completed\';');
     }, 30 * 1000);
   })
   .then(function() {
@@ -76,13 +76,11 @@ test('PeerConnection restart ICE sample', function(t) {
   })
   .then(function() {
     t.pass('ICE restart triggered');
-    // TODO: add event listener to pc1 and wait for connected / completed(?)
     driver.manage().timeouts().setScriptTimeout(10000);
     return driver.executeAsyncScript(
         'var callback = arguments[arguments.length - 1];' +
         'pc1.addEventListener(\'iceconnectionstatechange\', function() {' +
-        '  if (pc1.iceConnectionState === \'connected\' || ' +
-        '      pc1.iceConnectionState === \'completed\') {' +
+        '  if (pc1.iceConnectionState === \'completed\') {' +
         '    callback();' +
         '  }' +
         '});');


### PR DESCRIPTION
The html/css was mostly copied from the constraints page. @samdutton one day we will sit down and clean up everything, ok? ;-)

Biggest technical change is that the restart button is only re-enabled when pc1s iceconnectionstate changes to connected. This is mostly because ice restarts (sometimes?) cause the connectionstate to go from completed to connected immediately. I expected 'checking' here and want to avoid users clicking "ice restart" while one is in progress.

Biggest visual change is that the remote addresses are shown. I'm updating both now on pc1s iceconnectionstatechange to completed which should be ok.
