### PR TITLE
use the root folder instead of the test one

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -21,7 +21,7 @@ pem.createCertificate({days: 1, selfSigned: true}, function(err, keys) {
 
   var app = express();
 
-  app.use(express.static('.'));
+  app.use(express.static('../'));
 
   // Create an HTTPS service.
   https.createServer(options, app).listen(8080);


### PR DESCRIPTION
This commit https://github.com/webrtc/samples/commit/139da5b0c819b7149eef596e30af5722014ea1dc moved the `server.js` file to the `test` folder. We need to _mount_ the `..` folder to be served via express.
