### PR TITLE
Check for error message in status element for empty file test

### DIFF
--- a/src/content/datachannel/filetransfer/js/test.js
+++ b/src/content/datachannel/filetransfer/js/test.js
@@ -33,14 +33,13 @@ function sendFile(t, path) {
       return driver.wait(function() {
         return driver.findElement(webdriver.By.id('status'))
         .getText().then(function(text) {
-          return (text === 'File is empty, please select a non-empty file')
-        })
-      }, 2000)
-    } else {
-      // Wait for the download element to be displayed.
-      return driver.wait(webdriver.until.elementIsVisible(
-          driver.findElement(webdriver.By.id('download'))), 90 * 1000);
+          return (text === 'File is empty, please select a non-empty file');
+        });
+      }, 2000);
     }
+    // Wait for the download element to be displayed.
+    return driver.wait(webdriver.until.elementIsVisible(
+        driver.findElement(webdriver.By.id('download'))), 90 * 1000);
   })
   .then(function() {
     if (path === emptyFilePath) {

--- a/src/content/datachannel/filetransfer/js/test.js
+++ b/src/content/datachannel/filetransfer/js/test.js
@@ -15,7 +15,7 @@ var test = require('tape');
 var webdriver = require('selenium-webdriver');
 var seleniumHelpers = require('../../../../../test/selenium-lib');
 var emptyFilePath =
-process.cwd() + '/src/content/datachannel/filetransfer/emptyFile';
+  process.cwd() + '/src/content/datachannel/filetransfer/emptyFile';
 
 function sendFile(t, path) {
   var driver = seleniumHelpers.buildDriver();
@@ -29,20 +29,29 @@ function sendFile(t, path) {
     .sendKeys(path);
   })
   .then(function() {
-    // Wait for the download element to be displayed.
-    return driver.wait(webdriver.until.elementIsVisible(
-      driver.findElement(webdriver.By.id('download'))), 90 * 1000);
+    if (path === emptyFilePath) {
+      return driver.wait(function() {
+        return driver.findElement(webdriver.By.id('status'))
+        .getText().then(function(text) {
+          return (text === 'File is empty, please select a non-empty file')
+        })
+      }, 2000)
+    } else {
+      // Wait for the download element to be displayed.
+      return driver.wait(webdriver.until.elementIsVisible(
+          driver.findElement(webdriver.By.id('download'))), 90 * 1000);
+    }
   })
   .then(function() {
-    t.pass('download element found');
+    if (path === emptyFilePath) {
+      t.pass('Empty file error displayed');
+    } else {
+      t.pass('download element found');
+    }
     t.end();
   })
   .then(null, function(err) {
-    if (path === emptyFilePath) { // if empty file, download element is empty
-      t.pass('Empty file, no download link displayed');
-    } else {
-      t.fail(err);
-    }
+    t.fail(err);
     t.end();
   });
 }


### PR DESCRIPTION
Currently the test waits for the Download element to appear for 90 seconds before continuing, it never appears for the empty file test thus causing the empty file test taking way too long.
