### PR TITLE
Allow firefox to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
+    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
 
 before_install:


### PR DESCRIPTION
**Description**
FF beta + webdriver fails on travis but not locally, disabling until we know why.

cc @fippo @samdutton @jan-ivar 

**Purpose**
