### PR TITLE
Resolving |Failed to load resource: net::ERR_FILE_NOT_FOUND" error on Chrome

### DIFF
--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -23,7 +23,7 @@
   <title>Select audio and video sources</title>
 
   <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
-  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="../../../css/main.css">
 
   <style>

--- a/src/js/lib/ga.js
+++ b/src/js/lib/ga.js
@@ -1,7 +1,7 @@
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+})(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
 
 ga('create', 'UA-48530561-1', 'auto');
 ga('send', 'pageview');


### PR DESCRIPTION
**Description**
 Added http for testing on local file system. 
chrome adds file:// if no protocol is specified.

**Purpose**
Doubt non-developers will be able to figure where the error is by checking their console.log(), if they are testing on their local system.
