### PR TITLE
Audio feedback warning re #798

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
 
       <p>Patches and issues welcome! See <a href="https://github.com/webrtc/samples/blob/gh-pages/CONTRIBUTING.md">CONTRIBUTING.md</a> for instructions. The <a href="https://bit.ly/webrtcdevguide">Developer's Guide</a> for this repo has more information about code style, structure and validation. Head over to <a href="test/README.md">test/README.md</a> and get started developing.</p>
 
+      <p class="warning"><strong>Warning:</strong> some of these demos will result in loud feedback if used without headphones.</p>
+
     </section>
 
     <section>

--- a/src/content/capture/canvas-record/js/main.js
+++ b/src/content/capture/canvas-record/js/main.js
@@ -45,7 +45,7 @@ if (!isSecureOrigin) {
   location.protocol = 'HTTPS';
 }
 
-var stream = canvas.captureStream();
+var stream = canvas.captureStream(); // frames per second
 console.log('Started stream capture from canvas element: ', stream);
 
 function handleSourceOpen(event) {
@@ -105,7 +105,7 @@ function startRecording() {
   downloadButton.disabled = true;
   mediaRecorder.onstop = handleStop;
   mediaRecorder.ondataavailable = handleDataAvailable;
-  mediaRecorder.start(10); // collect 10ms of data
+  mediaRecorder.start(100); // collect 100ms of data
   console.log('MediaRecorder started', mediaRecorder);
 }
 

--- a/src/content/getusermedia/audio/index.html
+++ b/src/content/getusermedia/audio/index.html
@@ -36,6 +36,8 @@
 
     <audio id="gum-local" controls autoplay></audio>
 
+    <p class="warning">Warning: if you're not using headphones, pressing play will cause feedback.</p>
+
     <p>Render the audio stream from an audio-only <code>getUserMedia()</code> call with an audio element.</p>
 
     <p>The <code>MediaStream</code> object <code><em>stream</em></code> passed to the <code>getUserMedia()</code> callback is in global scope, so you can inspect it from the console.</p>

--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -38,6 +38,8 @@
 
     <div id="errorMsg"></div>
 
+    <p class="warning"><strong>Warning:</strong> if you're not using headphones, pressing play will cause feedback.</p>
+
     <p>Display the video stream from <code>getUserMedia()</code> in a video element.</p>
 
     <p>The <code>MediaStream</code> object <code>stream</code> passed to the <code>getUserMedia()</code> callback is in global scope, so you can inspect it from the console.</p>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -9,6 +9,11 @@
   display: none;
 }
 
+.warning {
+  color: red;
+  font-weight: 400;
+}
+
 div#errorMsg p {
   color: #F00;
 }


### PR DESCRIPTION
**Description**
In response to #798.

**Purpose**
Add audio feedback warning.

Added to index.html and also to gUM audio example (but could be added to several other demos as well, I guess).

(Also includes minor tweak to canvas-record demo.)
