### PR TITLE
Modified link to constraints definition

### DIFF
--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -65,7 +65,7 @@
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>getUserMedia: select resolution</span></h1>
     <p></p>
 
-    <p>This example uses <a href="http://tools.ietf.org/html/draft-alvestrand-constraints-resolution-00#page-4" title="IETF constraints draft proposal">constraints</a>.</p>
+    <p>This example uses <a href="https://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints" title="W3C getusermedia specification - constraints section">constraints</a>.</p>
 
     <p>Click a button to call <code>getUserMedia()</code> with appropriate resolution.</p>
 


### PR DESCRIPTION
The old link points to a dead document.
