### PR TITLE
allow ICE restarts from connected state

### DIFF
--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -121,7 +121,7 @@ function call() {
   };
   pc1.oniceconnectionstatechange = function(e) {
     onIceStateChange(pc1, e);
-    if (pc1 && pc1.iceConnectionState === 'completed') {
+    if (pc1 && pc1.iceConnectionState === 'connected') {
       restartButton.disabled = false;
     }
   };


### PR DESCRIPTION
**Description**
Allow the ICE Restart button to be pressed from the ICE 'connected' state instead of 'completed'.

**Purpose**
This allows to demo ICE restart with Firefox, and also works with Google Chrome.
