### PR TITLE
Fix broken regex replacement in bandwidth sample

### DIFF
--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -112,7 +112,7 @@ function gotDescription2(desc) {
       trace('Answer from pc2 \n' + desc.sdp);
       // insert b=AS after c= line.
       desc.sdp = desc.sdp.replace(/c=IN IP4 (.*)\r\n/,
-          'c=IN IP4 $(1)\r\nb=AS:512\r\n');
+          'c=IN IP4 $1\r\nb=AS:512\r\n');
       pc1.setRemoteDescription(desc).then(
         function() {
         },


### PR DESCRIPTION
**Description**
The syntax for referring to the first matched group is $1, not $(1).
The previous incorrect use added the string $(1) to the SDP.

**Purpose**
Fix bug.
