### PR TITLE
Correct variable names to in instructions

### DIFF
--- a/src/content/peerconnection/pc1/index.html
+++ b/src/content/peerconnection/pc1/index.html
@@ -48,7 +48,7 @@
       <button id="hangupButton">Hang Up</button>
     </div>
 
-    <p>View the console to see logging. The <code>MediaStream</code> object <code>localStream</code>, and the <code>RTCPeerConnection</code> objects <code>localPeerConnection</code> and <code>remotePeerConnection</code> are in global scope, so you can inspect them in the console as well.</p>
+    <p>View the console to see logging. The <code>MediaStream</code> object <code>localStream</code>, and the <code>RTCPeerConnection</code> objects <code>pc1</code> and <code>pc2</code> are in global scope, so you can inspect them in the console as well.</p>
 
     <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/" title="HTML5 Rocks article about WebRTC by Sam Dutton">Getting Started With WebRTC</a>.</p>
 


### PR DESCRIPTION
**Description**

The the text under the action buttons describes what to look for in the console. This PR changes the variable names mentioned for the RTCPeerConnectionObjects.

**Purpose**

The variable names `localPeerConnection` and  `remotePeerConnection` given in the instructions are not up to date. These variables that are in the global object are the ones called pc1 and pc2.
