### PR TITLE
Fix secure origin check

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
 
   <script type="application/javascript">
   var isSecureOrigin = location.protocol === 'https:' ||
-      location.host === 'localhost';
+      location.hostname === 'localhost';
   if (!isSecureOrigin) {
     console.log('These demos must be run from a secure origin. \n' +
         'Changing protocol to HTTPS');

--- a/src/content/capture/canvas-record/js/main.js
+++ b/src/content/capture/canvas-record/js/main.js
@@ -38,7 +38,7 @@ main();
 
 // window.isSecureContext could be used for Chrome
 var isSecureOrigin = location.protocol === 'https:' ||
-location.host === 'localhost';
+location.hostname === 'localhost';
 if (!isSecureOrigin) {
   alert('getUserMedia() must be run from a secure origin: HTTPS or localhost.' +
     '\n\nChanging protocol to HTTPS');

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -35,7 +35,7 @@ downloadButton.onclick = download;
 
 // window.isSecureContext could be used for Chrome
 var isSecureOrigin = location.protocol === 'https:' ||
-location.host === 'localhost';
+location.hostname === 'localhost';
 if (!isSecureOrigin) {
   alert('getUserMedia() must be run from a secure origin: HTTPS or localhost.' +
     '\n\nChanging protocol to HTTPS');


### PR DESCRIPTION
Fixes serving these samples from localhost, in a non-default port.  In this case, location.host can be "localhost:8000" and location.hostname will be "localhost".  Check for the latter when deciding if an origin is secure, before redirecting to HTTPS.
