### PR TITLE
munge-sdp: fix onicecandidate handler for Edge

### DIFF
--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -154,10 +154,10 @@ function createPeerConnection() {
 
   localPeerConnection = new RTCPeerConnection(servers);
   trace('Created local peer connection object localPeerConnection');
+  localPeerConnection.onicecandidate = iceCallback1;
   if (RTCPeerConnection.prototype.createDataChannel) {
     sendChannel = localPeerConnection.createDataChannel('sendDataChannel',
         dataChannelOptions);
-    localPeerConnection.onicecandidate = iceCallback1;
     sendChannel.onopen = onSendChannelStateChange;
     sendChannel.onclose = onSendChannelStateChange;
     sendChannel.onerror = onSendChannelStateChange;


### PR DESCRIPTION
the onicecandidate handler somehow ended up inside the check for
createDataChannel so it was not hooked up in edge which lead to ice failures.

Many thanks to @shijuns for reporting this!
