### PR TITLE
Re #710: Start Recording button disabled until gUM success

### DIFF
--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -43,7 +43,7 @@
     <video id="recorded" autoplay loop></video>
 
     <div>
-      <button id="record">Start Recording</button>
+      <button id="record" disabled>Start Recording</button>
       <button id="play" disabled>Play</button>
       <button id="download" disabled>Download</button>
     </div>

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -51,6 +51,7 @@ var constraints = {
 };
 
 function handleSuccess(stream) {
+  recordButton.disabled =
   console.log('getUserMedia() got stream: ', stream);
   window.stream = stream;
   if (window.URL) {

--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -51,7 +51,7 @@ var constraints = {
 };
 
 function handleSuccess(stream) {
-  recordButton.disabled =
+  recordButton.disabled = false;
   console.log('getUserMedia() got stream: ', stream);
   window.stream = stream;
   if (window.URL) {


### PR DESCRIPTION
**Description**
Add disabled attribute to **Start Recording** button. Enable button only if `getUserMedia()` succeeds.

**Purpose**
Fix problem described in #710.

