### PR TITLE
device selection: remove flag note

### DIFF
--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -51,9 +51,7 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a><span>Select sources &amp; outputs</span></h1>
 
-    <p>Get available audio, video sources and audio output devices<b>*</b> from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>deviceId</code> constraint.</p>
-
-    <p class="small"><b>*</b>Enable experimental support in <b>Chrome 45.0.2441.x</b> or later by selecting <b>Enable experimental Web Platform features</b> in <b>chrome://flags</b> or by using command line flag "<b>--enable-blink-features=EnumerateDevices,AudioOutputDevices</b>". Use the <code>setSinkID()</code> method on the video element and provide a audio or video element and a sinkId (<code>deviceId</code> for where <code>deviceInfo.kind === 'audiooutput'</code>) as arguments. Also the web page must be served over HTTPS.</p>
+    <p>Get available audio, video sources and audio output devices from <code>mediaDevices.enumerateDevices()</code> then set the source for <code>getUserMedia()</code> using a <code>deviceId</code> constraint.</p>
 
     <div class="select">
       <label for="audioSource">Audio input source: </label><select id="audioSource"></select>


### PR DESCRIPTION
**Description**
removes the flag note since a long time has passed since Chrome 45.

**Purpose**
 This seems to [confuse people](http://stackoverflow.com/questions/40791581/webrtc-getusermedia-works-only-on-firefox/40793349?noredirect=1#comment68824647_40793349)