### PR TITLE
use maplike instead of Object.keys in getStats

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -271,8 +271,7 @@ window.setInterval(function() {
     return;
   }
   window.pc1.getStats(null).then(function(res) {
-    Object.keys(res).forEach(function(key) {
-      var report = res[key];
+    res.forEach(function(report) {
       var bytes;
       var packets;
       var now = report.timestamp;
@@ -281,10 +280,10 @@ window.setInterval(function() {
           (report.type === 'ssrc' && report.bytesSent)) {
         bytes = report.bytesSent;
         packets = report.packetsSent;
-        if (lastResult && lastResult[report.id]) {
+        if (lastResult && lastResult.get(report.id)) {
           // calculate bitrate
-          var bitrate = 8 * (bytes - lastResult[report.id].bytesSent) /
-              (now - lastResult[report.id].timestamp);
+          var bitrate = 8 * (bytes - lastResult.get(report.id).bytesSent) /
+              (now - lastResult.get(report.id).timestamp);
 
           // append to chart
           bitrateSeries.addPoint(now, bitrate);
@@ -293,7 +292,7 @@ window.setInterval(function() {
 
           // calculate number of packets and append to chart
           packetSeries.addPoint(now, packets -
-              lastResult[report.id].packetsSent);
+              lastResult.get(report.id).packetsSent);
           packetGraph.setDataSeries([packetSeries]);
           packetGraph.updateEndDate();
         }

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -220,8 +220,7 @@ window.setInterval(function() {
     return;
   }
   window.pc1.getStats(null).then(function(res) {
-    Object.keys(res).forEach(function(key) {
-      var report = res[key];
+    res.forEach(function(report) {
       var bytes;
       var packets;
       var now = report.timestamp;
@@ -230,10 +229,10 @@ window.setInterval(function() {
           (report.type === 'ssrc' && report.bytesSent)) {
         bytes = report.bytesSent;
         packets = report.packetsSent;
-        if (lastResult && lastResult[report.id]) {
+        if (lastResult && lastResult.get(report.id)) {
           // calculate bitrate
-          var bitrate = 8 * (bytes - lastResult[report.id].bytesSent) /
-              (now - lastResult[report.id].timestamp);
+          var bitrate = 8 * (bytes - lastResult.get(report.id).bytesSent) /
+              (now - lastResult.get(report.id).timestamp);
 
           // append to chart
           bitrateSeries.addPoint(now, bitrate);
@@ -242,7 +241,7 @@ window.setInterval(function() {
 
           // calculate number of packets and append to chart
           packetSeries.addPoint(now, packets -
-              lastResult[report.id].packetsSent);
+              lastResult.get(report.id).packetsSent);
           packetGraph.setDataSeries([packetSeries]);
           packetGraph.updateEndDate();
         }

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -291,13 +291,13 @@ setInterval(function() {
 function dumpStats(results) {
   var statsString = '';
   results.forEach(function(res) {
-    statsString += '<h3>Report ';
+    statsString += '<h3>Report type=';
     statsString += res.type;
     statsString += '</h3>\n';
+    statsString += 'id ' + res.id + '<br>\n';
     statsString += 'time ' + res.timestamp + '<br>\n';
-    statsString += 'type ' + res.type + '<br>\n';
     Object.keys(res).forEach(function(k) {
-      if (k !== 'timestamp' && k !== 'type') {
+      if (k !== 'timestamp' && k !== 'type' && k !== 'id') {
         statsString += k + ': ' + res[k] + '<br>\n';
       }
     });

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -211,12 +211,12 @@ function onAddIceCandidateError(error) {
 // Display statistics
 setInterval(function() {
   if (remotePeerConnection && remotePeerConnection.getRemoteStreams()[0]) {
-    remotePeerConnection.getStats(null, function(results) {
+    remotePeerConnection.getStats(null)
+    .then(function(results) {
       var statsString = dumpStats(results);
       receiverStatsDiv.innerHTML = '<h2>Receiver stats</h2>' + statsString;
       // calculate video bitrate
-      Object.keys(results).forEach(function(result) {
-        var report = results[result];
+      results.forEach(function(report) {
         var now = report.timestamp;
 
         var bitrate;
@@ -246,8 +246,7 @@ setInterval(function() {
       var remoteCandidate = null;
 
       // search for the candidate pair
-      Object.keys(results).forEach(function(result) {
-        var report = results[result];
+      results.forEach(function(report) {
         if (report.type === 'candidatepair' && report.selected ||
             report.type === 'googCandidatePair' &&
             report.googActiveConnection === 'true') {
@@ -266,7 +265,8 @@ setInterval(function() {
     }, function(err) {
       console.log(err);
     });
-    localPeerConnection.getStats(null, function(results) {
+    localPeerConnection.getStats(null)
+    .then(function(results) {
       var statsString = dumpStats(results);
       senderStatsDiv.innerHTML = '<h2>Sender stats</h2>' + statsString;
     }, function(err) {
@@ -290,10 +290,9 @@ setInterval(function() {
 // might be named toString?
 function dumpStats(results) {
   var statsString = '';
-  Object.keys(results).forEach(function(key, index) {
-    var res = results[key];
+  results.forEach(function(res) {
     statsString += '<h3>Report ';
-    statsString += index;
+    statsString += res.type;
     statsString += '</h3>\n';
     statsString += 'time ' + res.timestamp + '<br>\n';
     statsString += 'type ' + res.type + '<br>\n';


### PR DESCRIPTION
this uses the maplike syntax instead of the older Object.keys() iteration. Maplike is shimmed by adapter for Chrome.

Code is similar to http://w3c.github.io/webrtc-pc/#example