### PR TITLE
Add chrome://flags to video-pc requirements.

### DIFF
--- a/src/content/capture/video-pc/index.html
+++ b/src/content/capture/video-pc/index.html
@@ -44,7 +44,7 @@
 
     <video id="rightVideo" autoplay controls></video>
 
-    <p>This demo requires Firefox 47, Chrome 53 (or later).</p>
+    <p>This demo requires Firefox 47, Chrome 53 with <strong>Experimental Web Platform features</strong> enabled from <tt>chrome://flags</tt>.</p>
 
     <p>A stream is captured from the video on the left using the <code>captureStream()</code> method, and streamed via a peer connection to the video element on the right.</p>
 

--- a/src/content/capture/video-video/index.html
+++ b/src/content/capture/video-video/index.html
@@ -44,7 +44,7 @@
 
     <video id="rightVideo" autoplay controls></video>
 
-    <p>This demo requires Firefox 47, or Chrome 53 with <strong>Experimental Web Platform features</strong> enabled from chrome://flags.</p>
+    <p>This demo requires Firefox 47, or Chrome 53 with <strong>Experimental Web Platform features</strong> enabled from <tt>chrome://flags</tt>.</p>
 
     <p>A stream is captured from the video element on the left using its <code>captureStream()</code> method and set as the <code>srcObject</code> of the video element on the right.</p>
 


### PR DESCRIPTION
Add Experimental Web Platform features under chrome://flags as a requirement for the video-pc demo.