### PR TITLE
Set up video tag capture after oncanplay events.

### DIFF
--- a/src/content/capture/video-pc/js/main.js
+++ b/src/content/capture/video-pc/js/main.js
@@ -22,7 +22,10 @@ var offerOptions = {
 
 var startTime;
 
-leftVideo.onplay = function() {
+function maybeCreateStream() {
+  if (stream) {
+    return;
+  }
   if (leftVideo.captureStream) {
     stream = leftVideo.captureStream();
     console.log('Captured stream from leftVideo with captureStream',
@@ -36,7 +39,15 @@ leftVideo.onplay = function() {
   } else {
     trace('captureStream() not supported');
   }
-};
+}
+
+// Video tag capture must be set up after video tracks are enumerated.
+leftVideo.oncanplay = maybeCreateStream;
+if (leftVideo.readyState >= 3) {  // HAVE_FUTURE_DATA
+  // Video is already ready to play, call maybeCreateStream in case oncanplay
+  // fired before we registered the event handler.
+  maybeCreateStream();
+}
 
 leftVideo.play();
 

--- a/src/content/capture/video-video/js/main.js
+++ b/src/content/capture/video-video/js/main.js
@@ -13,7 +13,10 @@ var rightVideo = document.getElementById('rightVideo');
 
 var stream;
 
-leftVideo.onplay = function() {
+function maybeCreateStream() {
+  if (stream) {
+    return;
+  }
   if (leftVideo.captureStream) {
     stream = leftVideo.captureStream();
     rightVideo.srcObject = stream;
@@ -27,6 +30,14 @@ leftVideo.onplay = function() {
   } else {
     console.log('captureStream() not supported');
   }
-};
+}
+
+// Video tag capture must be set up after video tracks are loaded.
+leftVideo.oncanplay = maybeCreateStream;
+if (leftVideo.readyState >= 3) {  // HAVE_FUTURE_DATA
+  // Video is already ready to play, call maybeCreateStream in case oncanplay
+  // fired before we registered the event handler.
+  maybeCreateStream();
+}
 
 leftVideo.play();


### PR DESCRIPTION
Previously tag capture was set up on the onplay event, when the video
tag started playing, but that happens on page load which can be before
the video file is loaded and video tracks enumerated.