### PR TITLE
all: remove RTCIceCandidate

### DIFF
--- a/src/content/capture/canvas-pc/js/main.js
+++ b/src/content/capture/canvas-pc/js/main.js
@@ -137,7 +137,8 @@ function onCreateAnswerSuccess(desc) {
 
 function onIceCandidate(pc, event) {
   if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(new RTCIceCandidate(event.candidate),
+    getOtherPc(pc).addIceCandidate(event.candidate)
+    .then(
         function() {
           onAddIceCandidateSuccess(pc);
         },

--- a/src/content/capture/video-pc/js/main.js
+++ b/src/content/capture/video-pc/js/main.js
@@ -147,7 +147,8 @@ function onCreateAnswerSuccess(desc) {
 
 function onIceCandidate(pc, event) {
   if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(new RTCIceCandidate(event.candidate),
+    getOtherPc(pc).addIceCandidate(event.candidate)
+    .then(
       function() {
         onAddIceCandidateSuccess(pc);
       },

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -147,9 +147,8 @@ function gotRemoteStream(e) {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    pc2.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc2.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -159,9 +158,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    pc1.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc1.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -142,9 +142,8 @@ function gotRemoteStream(e) {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    pc2.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc2.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -154,9 +153,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    pc1.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc1.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -154,9 +154,8 @@ function createPeerConnection() {
   localPeerConnection.onicecandidate = function(e) {
     console.log('Candidate localPeerConnection');
     if (e.candidate) {
-      remotePeerConnection.addIceCandidate(
-        new RTCIceCandidate(e.candidate)
-      ).then(
+      remotePeerConnection.addIceCandidate(e.candidate)
+      .then(
         onAddIceCandidateSuccess,
         onAddIceCandidateError
       );
@@ -165,10 +164,8 @@ function createPeerConnection() {
   remotePeerConnection.onicecandidate = function(e) {
     console.log('Candidate remotePeerConnection');
     if (e.candidate) {
-      var newCandidate = new RTCIceCandidate(e.candidate);
-      localPeerConnection.addIceCandidate(
-        newCandidate
-      ).then(
+      localPeerConnection.addIceCandidate(e.candidate)
+      .then(
         onAddIceCandidateSuccess,
         onAddIceCandidateError
       );

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -153,9 +153,8 @@ function gotRemoteStream(e) {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    pc2.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc2.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -165,9 +164,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    pc1.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc1.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -179,9 +179,8 @@ function iceCallback2Remote(event) {
 
 function handleCandidate(candidate, dest, prefix, type) {
   if (candidate) {
-    dest.addIceCandidate(
-      new RTCIceCandidate(candidate)
-    ).then(
+    dest.addIceCandidate(candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -295,9 +295,8 @@ function gotRemoteStream(e) {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    remotePeerConnection.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    remotePeerConnection.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -307,9 +306,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    localPeerConnection.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    localPeerConnection.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -190,9 +190,8 @@ function onCreateAnswerSuccess(desc) {
 
 function onIceCandidate(pc, event) {
   if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    getOtherPc(pc).addIceCandidate(event.candidate)
+    .then(
       function() {
         onAddIceCandidateSuccess(pc);
       },

--- a/src/content/peerconnection/pr-answer/js/main.js
+++ b/src/content/peerconnection/pr-answer/js/main.js
@@ -166,9 +166,8 @@ function gotRemoteStream(e) {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    pc2.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc2.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -178,9 +177,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    pc1.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc1.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -209,9 +209,8 @@ function onCreateAnswerSuccess(desc) {
 
 function onIceCandidate(pc, event) {
   if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    getOtherPc(pc).addIceCandidate(event.candidate)
+    .then(
       function() {
         onAddIceCandidateSuccess(pc);
       },

--- a/src/content/peerconnection/states/js/main.js
+++ b/src/content/peerconnection/states/js/main.js
@@ -177,9 +177,8 @@ function iceStateCallback2() {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    pc2.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc2.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -191,9 +190,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    pc1.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc1.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/webaudio-input/js/main.js
+++ b/src/content/peerconnection/webaudio-input/js/main.js
@@ -113,10 +113,10 @@ function forceOpus(sdp) {
 
 function gotDescription1(desc) {
   console.log('Offer from pc1 \n' + desc.sdp);
-  var modifiedOffer = new RTCSessionDescription({
+  var modifiedOffer = {
     type: 'offer',
     sdp: forceOpus(desc.sdp)
-  });
+  };
 
   pc1.setLocalDescription(modifiedOffer);
   console.log('Offer from pc1 \n' + modifiedOffer.sdp);
@@ -140,9 +140,8 @@ function gotRemoteStream(e) {
 
 function iceCallback1(event) {
   if (event.candidate) {
-    pc2.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc2.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );
@@ -152,9 +151,8 @@ function iceCallback1(event) {
 
 function iceCallback2(event) {
   if (event.candidate) {
-    pc1.addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    pc1.addIceCandidate(event.candidate)
+    .then(
       onAddIceCandidateSuccess,
       onAddIceCandidateError
     );

--- a/src/content/peerconnection/webaudio-output/js/main.js
+++ b/src/content/peerconnection/webaudio-output/js/main.js
@@ -197,9 +197,8 @@ function onCreateAnswerSuccess(desc) {
 
 function onIceCandidate(pc, event) {
   if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(
-      new RTCIceCandidate(event.candidate)
-    ).then(
+    getOtherPc(pc).addIceCandidate(event.candidate)
+    .then(
       function() {
         onAddIceCandidateSuccess(pc);
       },


### PR DESCRIPTION
RTCIceCandidate is no longer required (when using adapter), this removes
it. Also cleans up some places where callback style was used.


(the next step in my evil plan is to remove the event.candidate existence checks and just call addIceCandidate(undefined) ;-))