### PR TITLE
Update text in video-contenthint.

### DIFF
--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -57,11 +57,11 @@
 
     <p>A stream is captured from the source video using the <code>captureStream()</code> method. The stream is cloned and transmitted via two separate PeerConnections using 50kbps of video bandwidth. This is insufficient to generate good quality in the encoded bitstream, so trade-offs have to be made.</p>
 
-    <p>The transmitted stream tracks are using <a href="https://wicg.github.io/mst-content-hint/">MediaStreamTrack Content Hints</a> to indicate what type of content is being encoded (to prefer fluid motion or individual frame detail).</p>
+    <p>The transmitted stream tracks are using <a href="https://wicg.github.io/mst-content-hint/">MediaStreamTrack Content Hints</a> to indicate characteristics in the video stream, which informs PeerConnection on how to encode the track (to prefer fluid motion or individual frame detail).</p>
 
-    <p>The text part of the clip shows a clear case for when <tt>'detailed'</tt> is better, and the fighting scene shows a clear case for when <tt>'fluid'</tt> is better. The spinning model however shows a case where <tt>'fluid'</tt> or <tt>'detailed'</tt> are not clear-cut decisions and what's preferred is here up to the user, even with good content detection.</p>
+    <p>The text part of the clip shows a clear case for when <tt>'detailed'</tt> is better, and the fighting scene shows a clear case for when <tt>'fluid'</tt> is better. The spinning model however shows a case where <tt>'fluid'</tt> or <tt>'detailed'</tt> are not clear-cut decisions and even with good content detection what's preferred depends on what the user prefers.</p>
 
-    <p>Other MediaStreamTrack consumers such as MediaStreamRecorder can also make use of this decision to guide encoding parameters for the stream without additional extensions to the MediaStreamRecorder specification, but they are currently not implemented.</p>
+    <p>Other MediaStreamTrack consumers such as MediaStreamRecorder can also make use of this information to guide encoding parameters for the stream without additional extensions to the MediaStreamRecorder specification, but this is currently not implemented in Chromium.</p>
 
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/capture/video-pc" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 


### PR DESCRIPTION
Fixes a grammar error and rephrases the paragraph on what setting
MediaStreamTrack content hints does.