### PR TITLE
Use new ('motion'/'detail') contenthint strings.

### DIFF
--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -44,12 +44,12 @@
         </video>
         </div>
       <div class='video-container'>
-        <h2>"Fluid" video @ 50kbps</h2>
-        <video id="fluidVideo" autoplay muted></video>
+        <h2>"motion" video @ 50kbps</h2>
+        <video id="motionVideo" autoplay muted></video>
       </div>
       <div class='video-container'>
-        <h2>"Detailed" video @ 50kbps</h2>
-        <video id="detailedVideo" autoplay muted></video>
+        <h2>"detail" video @ 50kbps</h2>
+        <video id="detailVideo" autoplay muted></video>
       </div>
     </div>
 
@@ -57,9 +57,9 @@
 
     <p>A stream is captured from the source video using the <code>captureStream()</code> method. The stream is cloned and transmitted via two separate PeerConnections using 50kbps of video bandwidth. This is insufficient to generate good quality in the encoded bitstream, so trade-offs have to be made.</p>
 
-    <p>The transmitted stream tracks are using <a href="https://wicg.github.io/mst-content-hint/">MediaStreamTrack Content Hints</a> to indicate characteristics in the video stream, which informs PeerConnection on how to encode the track (to prefer fluid motion or individual frame detail).</p>
+    <p>The transmitted stream tracks are using <a href="https://wicg.github.io/mst-content-hint/">MediaStreamTrack Content Hints</a> to indicate characteristics in the video stream, which informs PeerConnection on how to encode the track (to prefer motion or individual frame detail).</p>
 
-    <p>The text part of the clip shows a clear case for when <tt>'detailed'</tt> is better, and the fighting scene shows a clear case for when <tt>'fluid'</tt> is better. The spinning model however shows a case where <tt>'fluid'</tt> or <tt>'detailed'</tt> are not clear-cut decisions and even with good content detection what's preferred depends on what the user prefers.</p>
+    <p>The text part of the clip shows a clear case for when <tt>'detail'</tt> is better, and the fighting scene shows a clear case for when <tt>'motion'</tt> is better. The spinning model however shows a case where <tt>'motion'</tt> or <tt>'detail'</tt> are not clear-cut decisions and even with good content detection what's preferred depends on what the user prefers.</p>
 
     <p>Other MediaStreamTrack consumers such as MediaStreamRecorder can also make use of this information to guide encoding parameters for the stream without additional extensions to the MediaStreamRecorder specification, but this is currently not implemented in Chromium.</p>
 

--- a/src/content/capture/video-contenthint/js/main.js
+++ b/src/content/capture/video-contenthint/js/main.js
@@ -9,12 +9,12 @@
 'use strict';
 
 var srcVideo = document.getElementById('srcVideo');
-var fluidVideo = document.getElementById('fluidVideo');
-var detailedVideo = document.getElementById('detailedVideo');
+var motionVideo = document.getElementById('motionVideo');
+var detailVideo = document.getElementById('detailVideo');
 
 var srcStream;
-var fluidStream;
-var detailedStream;
+var motionStream;
+var detailStream;
 
 var offerOptions = {
   offerToReceiveAudio: 0,
@@ -61,12 +61,17 @@ function call() {
   // This creates multiple independent PeerConnections instead of multiple
   // streams on a single PeerConnection object so that b=AS (the bitrate
   // constraints) can be applied independently.
-  fluidStream = srcStream.clone();
-  setVideoTrackContentHints(fluidStream, 'fluid');
-  establishPC(fluidVideo, fluidStream);
-  detailedStream = srcStream.clone();
-  setVideoTrackContentHints(detailedStream, 'detailed');
-  establishPC(detailedVideo, detailedStream);
+  motionStream = srcStream.clone();
+  // TODO(pbos): Remove fluid when no clients use it, motion is the newer name.
+  setVideoTrackContentHints(motionStream, 'fluid');
+  setVideoTrackContentHints(motionStream, 'motion');
+  establishPC(motionVideo, motionStream);
+  detailStream = srcStream.clone();
+  // TODO(pbos): Remove detailed when no clients use it, detail is the newer
+  // name.
+  setVideoTrackContentHints(detailStream, 'detailed');
+  setVideoTrackContentHints(detailStream, 'detail');
+  establishPC(detailVideo, detailStream);
 }
 
 function establishPC(videoTag, stream) {


### PR DESCRIPTION
Old strings exist set as a fallback to not break existing canary. Once
all browser versions (dev, canary) are on the new strings the old ones
can be removed.

Strings were updated as part of
https://github.com/WICG/mst-content-hint/issues/20.

**Description**


**Purpose**
