### PR TITLE
fix getStats calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "grunt-htmlhint": ">=0.9.12",
     "pem": "^1.8.1",
     "webrtc-adapter": "^1.1.0",
-    "webrtc-utilities": ">=0.0.1"
+    "webrtc-utilities": "^1.0.0"
   }
 }

--- a/src/content/peerconnection/audio/js/test.js
+++ b/src/content/peerconnection/audio/js/test.js
@@ -51,8 +51,7 @@ test('Audio-only sample codec preference', function(t) {
     })
     .then(function(stats) {
       // Find the sending audio track.
-      Object.keys(stats).forEach(function(name) {
-        var report = stats[name];
+      stats.forEach(function(report) {
         if (report.type === 'ssrc' && report.googTrackId === trackId) {
           t.ok(codecName === report.googCodecName, 'preferring ' + codecName);
         }

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -243,18 +243,16 @@ function onIceStateChange(pc, event) {
         var remoteCandidate = null;
 
         // search for the candidate pair
-        Object.keys(results).forEach(function(result) {
-          var report = results[result];
-          if (report.type === 'candidatepair' && report.selected ||
+        results.forEach(function(report) {
+          if (report.type === 'candidate-pair' && report.selected ||
               report.type === 'googCandidatePair' &&
               report.googActiveConnection === 'true') {
             activeCandidatePair = report;
           }
         });
         if (activeCandidatePair && activeCandidatePair.remoteCandidateId) {
-          Object.keys(results).forEach(function(result) {
-            var report = results[result];
-            if (report.type === 'remotecandidate' &&
+          results.forEach(function(report) {
+            if (report.type === 'remote-candidate' &&
                 report.id === activeCandidatePair.remoteCandidateId) {
               remoteCandidate = report;
             }

--- a/src/content/peerconnection/restart-ice/js/test.js
+++ b/src/content/peerconnection/restart-ice/js/test.js
@@ -26,11 +26,10 @@ var seleniumHelpers = require('webrtc-utilities').seleniumLib;
 function getTransportAddresses(stats) {
   var localAddress;
   var remoteAddress;
-  Object.keys(stats).forEach(function(id) {
-    var report = stats[id];
+  stats.forEach(function(report) {
     if (report.googActiveConnection === 'true') {
-      var localCandidate = stats[report.localCandidateId];
-      var remoteCandidate = stats[report.remoteCandidateId];
+      var localCandidate = stats.get(report.localCandidateId);
+      var remoteCandidate = stats.get(report.remoteCandidateId);
       localAddress = localCandidate.ipAddress + ':' +
           localCandidate.portNumber;
       remoteAddress = remoteCandidate.ipAddress + ':' +


### PR DESCRIPTION
this fixes primarily the ice restart demo which was broken in the adapter 3.0
release. Some tests which rely on getStats are still broken, this needs to
be fixed in https://github.com/webrtc/utilities

Fixes #863. The issue with the test is that JSON.stringify(map) is {} and we use that for communication between webdriver and node. See https://github.com/webrtc/utilities/pull/21 for a fix to that