### PR TITLE
all: remove e.candidate check before addIceCandidate

### DIFF
--- a/src/content/capture/canvas-pc/js/main.js
+++ b/src/content/capture/canvas-pc/js/main.js
@@ -136,18 +136,17 @@ function onCreateAnswerSuccess(desc) {
 }
 
 function onIceCandidate(pc, event) {
-  if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(event.candidate)
-    .then(
-        function() {
-          onAddIceCandidateSuccess(pc);
-        },
-        function(err) {
-          onAddIceCandidateError(pc, err);
-        }
-    );
-    trace(getName(pc) + ' ICE candidate: \n' + event.candidate.candidate);
-  }
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess(pc) {

--- a/src/content/capture/video-contenthint/js/main.js
+++ b/src/content/capture/video-contenthint/js/main.js
@@ -110,7 +110,5 @@ function onCreateAnswerSuccess(pc1, pc2, desc) {
 }
 
 function onIceCandidate(pc, otherPc, event) {
-  if (event.candidate) {
-    otherPc.addIceCandidate(event.candidate);
-  }
+  otherPc.addIceCandidate(event.candidate);
 }

--- a/src/content/capture/video-pc/js/main.js
+++ b/src/content/capture/video-pc/js/main.js
@@ -157,18 +157,17 @@ function onCreateAnswerSuccess(desc) {
 }
 
 function onIceCandidate(pc, event) {
-  if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(event.candidate)
-    .then(
-      function() {
-        onAddIceCandidateSuccess(pc);
-      },
-      function(err) {
-        onAddIceCandidateError(pc, err);
-      }
-      );
-    trace(getName(pc) + ' ICE candidate: \n' + event.candidate.candidate);
-  }
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess(pc) {

--- a/src/content/datachannel/basic/js/main.js
+++ b/src/content/datachannel/basic/js/main.js
@@ -51,7 +51,9 @@ function createConnection() {
       dataConstraint);
   trace('Created send data channel');
 
-  localConnection.onicecandidate = iceCallback1;
+  localConnection.onicecandidate = function(e) {
+    onIceCandidate(localConnection, e);
+  };
   sendChannel.onopen = onSendChannelStateChange;
   sendChannel.onclose = onSendChannelStateChange;
 
@@ -61,7 +63,9 @@ function createConnection() {
       new RTCPeerConnection(servers, pcConstraint);
   trace('Created remote peer connection object remoteConnection');
 
-  remoteConnection.onicecandidate = iceCallback2;
+  remoteConnection.onicecandidate = function(e) {
+    onIceCandidate(remoteConnection, e);
+  };
   remoteConnection.ondatachannel = receiveChannelCallback;
 
   localConnection.createOffer().then(
@@ -119,30 +123,27 @@ function gotDescription2(desc) {
   localConnection.setRemoteDescription(desc);
 }
 
-function iceCallback1(event) {
-  trace('local ice callback');
-  if (event.candidate) {
-    remoteConnection.addIceCandidate(
-      event.candidate
-    ).then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Local ICE candidate: \n' + event.candidate.candidate);
-  }
+function getOtherPc(pc) {
+  return (pc === localConnection) ? remoteConnection : localConnection;
 }
 
-function iceCallback2(event) {
-  trace('remote ice callback');
-  if (event.candidate) {
-    localConnection.addIceCandidate(
-      event.candidate
-    ).then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
-  }
+function getName(pc) {
+  return (pc === localConnection) ? 'localPeerConnection' :
+      'remotePeerConnection';
+}
+
+function onIceCandidate(pc, event) {
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess() {

--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -62,7 +62,9 @@ function createConnection() {
 
   sendChannel.onopen = onSendChannelStateChange;
   sendChannel.onclose = onSendChannelStateChange;
-  localConnection.onicecandidate = iceCallback1;
+  localConnection.onicecandidate = function(e) {
+    onIceCandidate(localConnection, e);
+  };
 
   localConnection.createOffer().then(
     gotDescription1,
@@ -75,7 +77,9 @@ function createConnection() {
       pcConstraint);
   trace('Created remote peer connection object remoteConnection');
 
-  remoteConnection.onicecandidate = iceCallback2;
+  remoteConnection.onicecandidate = function(e) {
+    onIceCandidate(remoteConnection, e);
+  };
   remoteConnection.ondatachannel = receiveChannelCallback;
 }
 
@@ -168,30 +172,27 @@ function gotDescription2(desc) {
   localConnection.setRemoteDescription(desc);
 }
 
-function iceCallback1(event) {
-  trace('local ice callback');
-  if (event.candidate) {
-    remoteConnection.addIceCandidate(
-      event.candidate
-    ).then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Local ICE candidate: \n' + event.candidate.candidate);
-  }
+function getOtherPc(pc) {
+  return (pc === localConnection) ? remoteConnection : localConnection;
 }
 
-function iceCallback2(event) {
-  trace('remote ice callback');
-  if (event.candidate) {
-    localConnection.addIceCandidate(
-      event.candidate
-    ).then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
-  }
+function getName(pc) {
+  return (pc === localConnection) ? 'localPeerConnection' :
+      'remotePeerConnection';
+}
+
+function onIceCandidate(pc, event) {
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess() {

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -76,10 +76,14 @@ function call() {
   };
   pc1 = new RTCPeerConnection(servers, pcConstraints);
   trace('Created local peer connection object pc1');
-  pc1.onicecandidate = iceCallback1;
+  pc1.onicecandidate = function(e) {
+    onIceCandidate(pc1, e);
+  };
   pc2 = new RTCPeerConnection(servers, pcConstraints);
   trace('Created remote peer connection object pc2');
-  pc2.onicecandidate = iceCallback2;
+  pc2.onicecandidate = function(e) {
+    onIceCandidate(pc2, e);
+  };
   pc2.onaddstream = gotRemoteStream;
   trace('Requesting local stream');
   navigator.mediaDevices.getUserMedia({
@@ -145,26 +149,26 @@ function gotRemoteStream(e) {
   trace('Received remote stream');
 }
 
-function iceCallback1(event) {
-  if (event.candidate) {
-    pc2.addIceCandidate(event.candidate)
-    .then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Local ICE candidate: \n' + event.candidate.candidate);
-  }
+function getOtherPc(pc) {
+  return (pc === pc1) ? pc2 : pc1;
 }
 
-function iceCallback2(event) {
-  if (event.candidate) {
-    pc1.addIceCandidate(event.candidate)
-    .then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
-  }
+function getName(pc) {
+  return (pc === pc1) ? 'pc1' : 'pc2';
+}
+
+function onIceCandidate(pc, event) {
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess() {

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -84,10 +84,14 @@ function call() {
   };
   pc1 = new RTCPeerConnection(servers, pcConstraints);
   trace('Created local peer connection object pc1');
-  pc1.onicecandidate = iceCallback1;
+  pc1.onicecandidate = function(e) {
+    onIceCandidate(pc1, e);
+  };
   pc2 = new RTCPeerConnection(servers, pcConstraints);
   trace('Created remote peer connection object pc2');
-  pc2.onicecandidate = iceCallback2;
+  pc2.onicecandidate = function(e) {
+    onIceCandidate(pc2, e);
+  };
   pc2.onaddstream = gotRemoteStream;
 
   trace('Requesting local stream');
@@ -151,26 +155,26 @@ function gotRemoteStream(e) {
   }
 }
 
-function iceCallback1(event) {
-  if (event.candidate) {
-    pc2.addIceCandidate(event.candidate)
-    .then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Local ICE candidate: \n' + event.candidate.candidate);
-  }
+function getOtherPc(pc) {
+  return (pc === pc1) ? pc2 : pc1;
 }
 
-function iceCallback2(event) {
-  if (event.candidate) {
-    pc1.addIceCandidate(event.candidate)
-    .then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
-  }
+function getName(pc) {
+  return (pc === pc1) ? 'pc1' : 'pc2';
+}
+
+function onIceCandidate(pc, event) {
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess() {

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -189,18 +189,17 @@ function onCreateAnswerSuccess(desc) {
 }
 
 function onIceCandidate(pc, event) {
-  if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(event.candidate)
-    .then(
-      function() {
-        onAddIceCandidateSuccess(pc);
-      },
-      function(err) {
-        onAddIceCandidateError(pc, err);
-      }
-    );
-    trace(getName(pc) + ' ICE candidate: \n' + event.candidate.candidate);
-  }
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess(pc) {

--- a/src/content/peerconnection/pr-answer/js/main.js
+++ b/src/content/peerconnection/pr-answer/js/main.js
@@ -63,10 +63,14 @@ function start() {
   var servers = null;
   pc1 = new RTCPeerConnection(servers);
   trace('Created local peer connection object pc1');
-  pc1.onicecandidate = iceCallback1;
+  pc1.onicecandidate = function(e) {
+    onIceCandidate(pc1, e);
+  };
   pc2 = new RTCPeerConnection(servers);
   trace('Created remote peer connection object pc2');
-  pc2.onicecandidate = iceCallback2;
+  pc2.onicecandidate = function(e) {
+    onIceCandidate(pc2, e);
+  };
   pc2.onaddstream = gotRemoteStream;
 
   pc1.addStream(localstream);
@@ -164,26 +168,26 @@ function gotRemoteStream(e) {
   trace('Received remote stream');
 }
 
-function iceCallback1(event) {
-  if (event.candidate) {
-    pc2.addIceCandidate(event.candidate)
-    .then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Local ICE candidate: \n' + event.candidate.candidate);
-  }
+function getOtherPc(pc) {
+  return (pc === pc1) ? pc2 : pc1;
 }
 
-function iceCallback2(event) {
-  if (event.candidate) {
-    pc1.addIceCandidate(event.candidate)
-    .then(
-      onAddIceCandidateSuccess,
-      onAddIceCandidateError
-    );
-    trace('Remote ICE candidate: \n ' + event.candidate.candidate);
-  }
+function getName(pc) {
+  return (pc === pc1) ? 'pc1' : 'pc2';
+}
+
+function onIceCandidate(pc, event) {
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess() {

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -208,18 +208,17 @@ function onCreateAnswerSuccess(desc) {
 }
 
 function onIceCandidate(pc, event) {
-  if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(event.candidate)
-    .then(
-      function() {
-        onAddIceCandidateSuccess(pc);
-      },
-      function(err) {
-        onAddIceCandidateError(pc, err);
-      }
-    );
-    trace(getName(pc) + ' ICE candidate: \n' + event.candidate.candidate);
-  }
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess(pc) {

--- a/src/content/peerconnection/webaudio-output/js/main.js
+++ b/src/content/peerconnection/webaudio-output/js/main.js
@@ -196,18 +196,17 @@ function onCreateAnswerSuccess(desc) {
 }
 
 function onIceCandidate(pc, event) {
-  if (event.candidate) {
-    getOtherPc(pc).addIceCandidate(event.candidate)
-    .then(
-      function() {
-        onAddIceCandidateSuccess(pc);
-      },
-      function(err) {
-        onAddIceCandidateError(pc, err);
-      }
-    );
-    trace(getName(pc) + ' ICE candidate: \n' + event.candidate.candidate);
-  }
+  getOtherPc(pc).addIceCandidate(event.candidate)
+  .then(
+    function() {
+      onAddIceCandidateSuccess(pc);
+    },
+    function(err) {
+      onAddIceCandidateError(pc, err);
+    }
+  );
+  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+      event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess(pc) {


### PR DESCRIPTION
removes the
  if (e.candidate) otherPc.addIceCandidate(e.candidate)
check from all demos. addIceCandidate will act the right way
to e.candidate not being set.

Without this Edge broke in adapter 3.0 which removed the
  type endOfCandiates
hack.

Also unifies the onicecandidate handler style as much as possible.

@KaptenJansson extra nitpicky-mode please ;-)