### PR TITLE
Add iceCandidatePool option in trickle-ice example

### DIFF
--- a/src/content/peerconnection/trickle-ice/css/main.css
+++ b/src/content/peerconnection/trickle-ice/css/main.css
@@ -23,6 +23,12 @@ section#iceServers label {
   display: inline-block;
   width: 150px;
 }
+
+section#iceOptions label {
+  display: inline-block;
+  width: 200px;
+}
+
 select#servers {
   font-size: 1em;
   padding: 5px;
@@ -47,3 +53,11 @@ th:nth-child(6),td:nth-child(6) {
   text-align: left
 }
 
+.gray {
+  color: gray
+}
+
+#poolValue {
+  display: inline-block;
+  width: 30px
+}

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -87,8 +87,6 @@
         <span>all</span>
         <input type="radio" name="transports" value="relay" id="relay">
         <span>relay</span>
-        <input type="radio" name="transports" value="none" id="none">
-        <span>none</span>
       </div>
       <div>
         <label for="ipv6">Gather IPv6 candidates:</label>

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -82,12 +82,13 @@
       <h2>ICE options</h2>
 
       <div id="iceTransports">
-        <span>IceTransports value:</span>
-        <input type="radio" name="transports" value="all" id="all" checked><label for="all">all</label>
+        <label for="ipv6"><span>IceTransports value:</span></label>
+        <input type="radio" name="transports" value="all" id="all" checked>
+        <span>all</span>
         <input type="radio" name="transports" value="relay" id="relay">
-        <label for="relay">relay</label>
+        <span>relay</span>
         <input type="radio" name="transports" value="none" id="none">
-        <label for="none">none</label>
+        <span>none</span>
       </div>
       <div>
         <label for="ipv6">Gather IPv6 candidates:</label>
@@ -96,6 +97,13 @@
       <div>
         <label for="unmux">Gather RTCP candidates:</label>
         <input id="unmux" type="checkbox" checked>
+      </div>
+      <div>
+        <label>ICE Candidate Pool:</label>
+        <span id="poolValue">0</span>
+        <span class="gray">0</span>
+        <input id="iceCandidatePool" type="range" min="0" max="10" value="0">
+        <span class="gray">10</span>
       </div>
 
     </section>
@@ -110,7 +118,6 @@
         <tbody id="candidatesBody"></tbody>
       </table>
       <button id="gather">Gather candidates</button>
-
     </section>
 
 

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -18,10 +18,17 @@ var urlInput = document.querySelector('input#url');
 var usernameInput = document.querySelector('input#username');
 var ipv6Check = document.querySelector('input#ipv6');
 var rtcpMuxCheck = document.querySelector('input#unmux');
+var iceCandidatePoolInput = document.querySelector('input#iceCandidatePool');
 
 addButton.onclick = addServer;
 gatherButton.onclick = start;
 removeButton.onclick = removeServer;
+
+
+iceCandidatePoolInput.onchange = function (e) {
+  var span = e.target.parentElement.querySelector('span');
+  span.textContent = e.target.value;
+};
 
 var begin;
 var pc;
@@ -94,8 +101,13 @@ function start() {
   // Create a PeerConnection with no streams, but force a m=audio line.
   // This will gather candidates for either 1 or 2 ICE components, depending
   // on whether the un-muxed RTCP checkbox is checked.
-  var config = {'iceServers': iceServers, iceTransportPolicy: iceTransports,
-      rtcpMuxPolicy: rtcpMuxCheck.checked ? 'negotiate' : 'require'};
+  var config = {
+    iceServers: iceServers,
+    iceTransportPolicy: iceTransports,
+    rtcpMuxPolicy: rtcpMuxCheck.checked ? 'negotiate' : 'require',
+    iceCandidatePoolSize: iceCandidatePoolInput.value
+  };
+
   var pcConstraints = {};
   var offerOptions = {offerToReceiveAudio: 1};
   // Whether we gather IPv6 candidates.
@@ -129,15 +141,15 @@ function noDescription(error) {
 function parseCandidate(text) {
   var candidateStr = 'candidate:';
   var pos = text.indexOf(candidateStr) + candidateStr.length;
-  var fields = text.substr(pos).split(' ');
+  var [foundation, component, protocol, priority, address, port, , type] = text.substr(pos).split(' ');
   return {
-    'component': fields[1],
-    'type': fields[7],
-    'foundation': fields[0],
-    'protocol': fields[2],
-    'address': fields[4],
-    'port': fields[5],
-    'priority': fields[3]
+    'component': component,
+    'type': type,
+    'foundation': foundation,
+    'protocol': protocol,
+    'address': address,
+    'port': port,
+    'priority': priority
   };
 }
 
@@ -145,13 +157,10 @@ function parseCandidate(text) {
 // type preference, local preference, and (256 - component ID).
 // ex: 126 | 32252 | 255 (126 is host preference, 255 is component ID 1)
 function formatPriority(priority) {
-  var s = '';
-  s += (priority >> 24);
-  s += ' | ';
-  s += (priority >> 8) & 0xFFFF;
-  s += ' | ';
-  s += priority & 0xFF;
-  return s;
+  var s = [priority >> 24,
+           (priority >> 8) & 0xFFFF,
+           priority & 0xFF];
+  return s.join(' | ');
 }
 
 function appendCell(row, val, span) {

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -18,10 +18,17 @@ var urlInput = document.querySelector('input#url');
 var usernameInput = document.querySelector('input#username');
 var ipv6Check = document.querySelector('input#ipv6');
 var rtcpMuxCheck = document.querySelector('input#unmux');
+var iceCandidatePoolInput = document.querySelector('input#iceCandidatePool');
 
 addButton.onclick = addServer;
 gatherButton.onclick = start;
 removeButton.onclick = removeServer;
+
+
+iceCandidatePoolInput.onchange = function (e) {
+  var span = e.target.parentElement.querySelector('span');
+  span.textContent = e.target.value;
+};
 
 var begin;
 var pc;
@@ -94,8 +101,13 @@ function start() {
   // Create a PeerConnection with no streams, but force a m=audio line.
   // This will gather candidates for either 1 or 2 ICE components, depending
   // on whether the un-muxed RTCP checkbox is checked.
-  var config = {'iceServers': iceServers, iceTransportPolicy: iceTransports,
-      rtcpMuxPolicy: rtcpMuxCheck.checked ? 'negotiate' : 'require'};
+  var config = {
+    iceServers: iceServers,
+    iceTransportPolicy: iceTransports,
+    rtcpMuxPolicy: rtcpMuxCheck.checked ? 'negotiate' : 'require',
+    iceCandidatePoolSize: iceCandidatePoolInput.value
+  };
+
   var pcConstraints = {};
   var offerOptions = {offerToReceiveAudio: 1};
   // Whether we gather IPv6 candidates.
@@ -128,15 +140,15 @@ function noDescription(error) {
 function parseCandidate(text) {
   var candidateStr = 'candidate:';
   var pos = text.indexOf(candidateStr) + candidateStr.length;
-  var fields = text.substr(pos).split(' ');
+  var [foundation, component, protocol, priority, address, port, , type] = text.substr(pos).split(' ');
   return {
-    'component': fields[1],
-    'type': fields[7],
-    'foundation': fields[0],
-    'protocol': fields[2],
-    'address': fields[4],
-    'port': fields[5],
-    'priority': fields[3]
+    'component': component,
+    'type': type,
+    'foundation': foundation,
+    'protocol': protocol,
+    'address': address,
+    'port': port,
+    'priority': priority
   };
 }
 
@@ -144,13 +156,10 @@ function parseCandidate(text) {
 // type preference, local preference, and (256 - component ID).
 // ex: 126 | 32252 | 255 (126 is host preference, 255 is component ID 1)
 function formatPriority(priority) {
-  var s = '';
-  s += (priority >> 24);
-  s += ' | ';
-  s += (priority >> 8) & 0xFFFF;
-  s += ' | ';
-  s += priority & 0xFF;
-  return s;
+  var s = [priority >> 24,
+           (priority >> 8) & 0xFFFF,
+           priority & 0xFF];
+  return s.join(' | ');
 }
 
 function appendCell(row, val, span) {

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -156,10 +156,11 @@ function parseCandidate(text) {
 // type preference, local preference, and (256 - component ID).
 // ex: 126 | 32252 | 255 (126 is host preference, 255 is component ID 1)
 function formatPriority(priority) {
-  var s = [priority >> 24,
-           (priority >> 8) & 0xFFFF,
-           priority & 0xFF];
-  return s.join(' | ');
+  return [
+    priority >> 24,
+    (priority >> 8) & 0xFFFF,
+    priority & 0xFF
+  ].join(' | ');
 }
 
 function appendCell(row, val, span) {

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -25,7 +25,7 @@ gatherButton.onclick = start;
 removeButton.onclick = removeServer;
 
 
-iceCandidatePoolInput.onchange = function (e) {
+iceCandidatePoolInput.onchange = function(e) {
   var span = e.target.parentElement.querySelector('span');
   span.textContent = e.target.value;
 };
@@ -141,7 +141,8 @@ function noDescription(error) {
 function parseCandidate(text) {
   var candidateStr = 'candidate:';
   var pos = text.indexOf(candidateStr) + candidateStr.length;
-  var [foundation, component, protocol, priority, address, port, , type] = text.substr(pos).split(' ');
+  var [foundation, component, protocol, priority, address, port, , type] =
+    text.substr(pos).split(' ');
   return {
     'component': component,
     'type': type,

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -157,10 +157,11 @@ function parseCandidate(text) {
 // type preference, local preference, and (256 - component ID).
 // ex: 126 | 32252 | 255 (126 is host preference, 255 is component ID 1)
 function formatPriority(priority) {
-  var s = [priority >> 24,
-           (priority >> 8) & 0xFFFF,
-           priority & 0xFF];
-  return s.join(' | ');
+  return [
+    priority >> 24,
+    (priority >> 8) & 0xFFFF,
+    priority & 0xFF
+  ].join(' | ');
 }
 
 function appendCell(row, val, span) {


### PR DESCRIPTION
**Description**
Expose the option to configure iceCandidatePool in trickle-ice examples.

**Purpose**

Chrome 59 implements the iceCandidatePoolSize member of RTCConfiguration, that instructs the RTCPeerConnection instance to gather, as a performance optimization, ICE candidates before calling setLocalDescription. No news about when Firefox will implement this functionality.

http://www.juandebravo.com/2017/04/01/improve-setup-time-webrtc

<img width="780" alt="screen shot 2017-04-13 at 14 37 55" src="https://cloud.githubusercontent.com/assets/367029/25004888/d7807cee-2056-11e7-8d71-c55e4fe13c64.png">
