### PR TITLE
Enable eslint cache, added all folders to HTML linting, supress eslint warning for 3rd party libs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,13 +11,14 @@ module.exports = function(grunt) {
       options: {
         csslintrc: '.csslintrc'
       },
-      src: ['src/content/**/*.css']
+      src: ['src/content/**/*.css', '!**/third_party/*.css' ]
     },
     eslint: {
       options: {
-        configFile: '.eslintrc'
+        configFile: '.eslintrc',
+        cache: true
       },
-      target: ['src/content/**/*.js', 'test/*.js']
+      target: ['src/content/**/*.js', 'test/*.js', '!**/third_party/*.js' ]
     },
     githooks: {
       all: {
@@ -27,9 +28,8 @@ module.exports = function(grunt) {
     htmlhint: {
       html1: {
         src: [
-          'src/content/datachannel/**/index.html',
-          'src/content/getusermedia/**/index.html',
-          'src/content/peerconnection/**/index.html'
+          'src/content/**/*.html',
+          '!**/third_party/*.html'
         ]
       }
     },

--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -36,18 +36,18 @@
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Guiding video encoding with content hints</span></h1>
 
     <div id="videos">
-      <div class='video-container'>
+      <div class="video-container">
       <h2>Source video file (high bitrate)</h2>
         <video id="srcVideo" controls muted loop>
           <source src="../../../video/mixed-content.webm" type="video/webm" />
           <p>This browser does not support the video element.</p>
         </video>
         </div>
-      <div class='video-container'>
+      <div class="video-container">
         <h2>"motion" video @ 50kbps</h2>
         <video id="motionVideo" autoplay muted></video>
       </div>
-      <div class='video-container'>
+      <div class="video-container">
         <h2>"detail" video @ 50kbps</h2>
         <video id="detailVideo" autoplay muted></video>
       </div>

--- a/src/content/devices/multi/index.html
+++ b/src/content/devices/multi/index.html
@@ -82,19 +82,19 @@
 
     </div>
 
-    <p>This demo must be run from localhost or over HTTPS 45.0.2441.x or later.<p>
+    <p>This demo must be run from localhost or over HTTPS 45.0.2441.x or later.</p>
       <p><strong>Enable experimental Web Platform features</strong> must be enabled from the chrome://flags page or run Chrome with the following flag:</p>
       <p>&nbsp;&nbsp;&nbsp;&nbsp;<code>--enable-blink-features=EnumerateDevices,AudioOutputDevices</code></p>
       <p>More information about running Chrome with flags is available from <a href="https://www.chromium.org/developers/how-tos/run-chromium-with-flags" title="The Chromium Projects: Run Chromium with flags">The Chromium Projects</a>.</p>
 
       <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/devices/multi" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
-    </div>
+  </div>
 
-    <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-    <script src="../../../js/common.js"></script>
-    <script src="js/main.js"></script>
+  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/common.js"></script>
+  <script src="js/main.js"></script>
 
-    <script src="../../../js/lib/ga.js"></script>
+  <script src="../../../js/lib/ga.js"></script>
 
-  </body>
-  </html>
+</body>
+</html>

--- a/src/content/extensions/multipleroutes/src/background.html
+++ b/src/content/extensions/multipleroutes/src/background.html
@@ -1,2 +1,10 @@
+<!doctype html>
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
 <script src="utils.js"></script>
 <script src="eventPage.js"></script>

--- a/src/content/extensions/multipleroutes/src/options.html
+++ b/src/content/extensions/multipleroutes/src/options.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
 <html>
 <body>
   <p id="Mode0">
@@ -6,6 +13,7 @@
     <label for="default">
       <span i18n-content="netli_default_radio"></span>
     </label>
+  </p>
   <p id="Mode1">
     <input type="radio" name="ip_policy_selection"
            id="default_public_and_private_interfaces"
@@ -13,6 +21,7 @@
     <label for="default_public_and_private_interfaces">
       <span i18n-content="netli_default_public_and_private_interfaces_radio"></span>
     </label>
+  </p>
   <p id="Mode2">
     <input type="radio" name="ip_policy_selection"
            id="default_public_interface_only"
@@ -20,16 +29,19 @@
     <label for="default_public_interface_only">
       <span i18n-content="netli_default_public_interface_only_radio"></span>
     </label>
+  </p>
   <p id="Mode3">
     <input type="radio" name="ip_policy_selection"
            id="disable_non_proxied_udp" value="disable_non_proxied_udp">
     <label for="disable_non_proxied_udp" id="for_disable_non_proxied_udp">
       <span i18n-content="netli_disable_non_proxied_udp_radio"></span>
     </label>
+  </p>
   <p>
     <label id="not_supported">
       <span i18n-content="netli_option_not_supported"></span>
     </label>
+  </p>
   <script src="utils.js"></script>
   <script src="options.js"></script>
 </body>


### PR DESCRIPTION
**Description**
* Explicitly excluding files for eslint suppress the warnings (https://github.com/sindresorhus/grunt-eslint/issues/119#issuecomment-261553449)
* Add all folders to the HTMLhinter and exclude third_party
* Exclude third_party for csslint
* Enable eslint caching
* Fix html lint errors

**Purpose**
Cleanup
