### PR TITLE
all: use addTrack

### DIFF
--- a/src/content/capture/canvas-pc/js/main.js
+++ b/src/content/capture/canvas-pc/js/main.js
@@ -77,7 +77,14 @@ function call() {
   };
   pc2.onaddstream = gotRemoteStream;
 
-  pc1.addStream(stream);
+  stream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        stream
+      );
+    }
+  );
   trace('Added local stream to pc1');
 
   trace('pc1 createOffer start');

--- a/src/content/capture/video-contenthint/js/main.js
+++ b/src/content/capture/video-contenthint/js/main.js
@@ -87,7 +87,14 @@ function establishPC(videoTag, stream) {
     videoTag.srcObject = event.stream;
   };
 
-  pc1.addStream(stream);
+  stream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        stream
+      );
+    }
+  );
   pc1.createOffer(offerOptions).then(function(desc) {
     pc1.setLocalDescription(desc).then(function() {
       return pc2.setRemoteDescription(desc);

--- a/src/content/capture/video-pc/js/main.js
+++ b/src/content/capture/video-pc/js/main.js
@@ -98,7 +98,14 @@ function call() {
   };
   pc2.onaddstream = gotRemoteStream;
 
-  pc1.addStream(stream);
+  stream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        stream
+      );
+    }
+  );
   trace('Added local stream to pc1');
 
   trace('pc1 createOffer start');

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -43,7 +43,14 @@ function gotStream(stream) {
   if (audioTracks.length > 0) {
     trace('Using Audio device: ' + audioTracks[0].label);
   }
-  pc1.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Adding Local Stream to peer connection');
 
   pc1.createOffer(

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -40,7 +40,14 @@ function gotStream(stream) {
   trace('Received local stream');
   localStream = stream;
   localVideo.srcObject = stream;
-  pc1.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Adding Local Stream to peer connection');
 
   pc1.createOffer(

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -143,7 +143,14 @@ function createPeerConnection() {
   timestampPrev = 0;
   localPeerConnection = new RTCPeerConnection(null);
   remotePeerConnection = new RTCPeerConnection(null);
-  localPeerConnection.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      localPeerConnection.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   console.log('localPeerConnection creating offer');
   localPeerConnection.onnegotiationeeded = function() {
     console.log('Negotiation needed - localPeerConnection');

--- a/src/content/peerconnection/create-offer/js/main.js
+++ b/src/content/peerconnection/create-offer/js/main.js
@@ -43,7 +43,14 @@ function createOffer() {
     // Note that this fails if you try to do more than one track in Chrome
     // right now.
     var dst = acx.createMediaStreamDestination();
-    pc.addStream(dst.stream);
+    dst.stream.getTracks().forEach(
+      function(track) {
+        pc.addTrack(
+          track,
+          dst.stream
+        );
+      }
+    );
   }
 
   var offerOptions = {

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -62,7 +62,14 @@ function gotStream(stream) {
   if (audioTracks.length > 0) {
     trace('Using Audio device: ' + audioTracks[0].label);
   }
-  pc1.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Adding Local Stream to peer connection');
   pc1.createOffer(
     offerOptions

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -78,7 +78,14 @@ function call() {
   pc2Remote.onicecandidate = iceCallback2Remote;
   trace('pc2: created local and remote peer connection objects');
 
-  pc1Local.addStream(window.localStream);
+  window.localStream.getTracks().forEach(
+    function(track) {
+      pc1Local.addTrack(
+        track,
+        window.localStream
+      );
+    }
+  );
   trace('Adding local stream to pc1Local');
   pc1Local.createOffer(
     offerOptions
@@ -87,7 +94,14 @@ function call() {
     onCreateSessionDescriptionError
   );
 
-  pc2Local.addStream(window.localStream);
+  window.localStream.getTracks().forEach(
+    function(track) {
+      pc2Local.addTrack(
+        track,
+        window.localStream
+      );
+    }
+  );
   trace('Adding local stream to pc2Local');
   pc2Local.createOffer(
     offerOptions

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -173,7 +173,14 @@ function createPeerConnection() {
   remotePeerConnection.onaddstream = gotRemoteStream;
   remotePeerConnection.ondatachannel = receiveChannelCallback;
 
-  localPeerConnection.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      localPeerConnection.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Adding Local Stream to peer connection');
 }
 

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -111,7 +111,14 @@ function call() {
   };
   pc2.onaddstream = gotRemoteStream;
 
-  pc1.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Added local stream to pc1');
 
   trace('pc1 createOffer start');

--- a/src/content/peerconnection/pr-answer/js/main.js
+++ b/src/content/peerconnection/pr-answer/js/main.js
@@ -73,7 +73,14 @@ function start() {
   };
   pc2.onaddstream = gotRemoteStream;
 
-  pc1.addStream(localstream);
+  localstream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localstream
+      );
+    }
+  );
   trace('Adding Local Stream to peer connection');
 
   pc1.createOffer(

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -135,7 +135,14 @@ function call() {
   };
   pc2.onaddstream = gotRemoteStream;
 
-  pc1.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Added local stream to pc1');
 
   trace('pc1 createOffer start');

--- a/src/content/peerconnection/states/js/main.js
+++ b/src/content/peerconnection/states/js/main.js
@@ -94,7 +94,14 @@ function call() {
     onIceCandidate(pc2, e);
   };
   pc2.onaddstream = gotRemoteStream;
-  pc1.addStream(localstream);
+  localstream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localstream
+      );
+    }
+  );
   trace('Adding Local Stream to peer connection');
   pc1.createOffer(
     offerOptions

--- a/src/content/peerconnection/webaudio-input/js/main.js
+++ b/src/content/peerconnection/webaudio-input/js/main.js
@@ -78,7 +78,14 @@ function handleSuccess(stream) {
       onIceCandidate(pc2, e);
     };
     pc2.onaddstream = gotRemoteStream;
-    pc1.addStream(filteredStream);
+    filteredStream.getTracks().forEach(
+      function(track) {
+        pc1.addTrack(
+          track,
+          filteredStream
+        );
+      }
+    );
     pc1.createOffer().
         then(gotDescription1).
         catch(function(error) {

--- a/src/content/peerconnection/webaudio-output/js/main.js
+++ b/src/content/peerconnection/webaudio-output/js/main.js
@@ -115,7 +115,14 @@ function call() {
   };
   pc2.onaddstream = gotRemoteStream;
 
-  pc1.addStream(localStream);
+  localStream.getTracks().forEach(
+    function(track) {
+      pc1.addTrack(
+        track,
+        localStream
+      );
+    }
+  );
   trace('Added local stream to pc1');
 
   trace('pc1 createOffer start');


### PR DESCRIPTION
uses addTrack now that adapter shims it in Chrome.
Edge (the ORTC shim) should also be supported.

This is the result of running the addTrack codemod
```
jscodeshift -t addTrack src/content
```
https://github.com/fippo/webrtc-codemods