### PR TITLE
munge-sdp: make it work in Safari

### DIFF
--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -26,9 +26,7 @@ createAnswerButton.onclick = createAnswer;
 setAnswerButton.onclick = setAnswer;
 hangupButton.onclick = hangup;
 
-var offer;
 var offerSdpTextarea = document.querySelector('div#local textarea');
-var answer;
 var answerSdpTextarea = document.querySelector('div#remote textarea');
 
 var audioSelect = document.querySelector('select#audioSrc');
@@ -218,7 +216,10 @@ function setOffer() {
   var sdp = offerSdpTextarea.value;
   sdp = maybeAddLineBreakToEnd(sdp);
   sdp = sdp.replace(/\n/g, '\r\n');
-  offer.sdp = sdp;
+  var offer = {
+    type: 'offer',
+    sdp: sdp
+  };
   localPeerConnection.setLocalDescription(offer).then(
     onSetSessionDescriptionSuccess,
     onSetSessionDescriptionError
@@ -231,7 +232,6 @@ function setOffer() {
 }
 
 function gotDescription1(description) {
-  offer = description;
   offerSdpTextarea.disabled = false;
   offerSdpTextarea.value = description.sdp;
 }
@@ -250,7 +250,10 @@ function setAnswer() {
   var sdp = answerSdpTextarea.value;
   sdp = maybeAddLineBreakToEnd(sdp);
   sdp = sdp.replace(/\n/g, '\r\n');
-  answer.sdp = sdp;
+  var answer = {
+    type: 'answer',
+    sdp: sdp
+  };
   remotePeerConnection.setLocalDescription(answer).then(
     onSetSessionDescriptionSuccess,
     onSetSessionDescriptionError
@@ -263,7 +266,6 @@ function setAnswer() {
 }
 
 function gotDescription2(description) {
-  answer = description;
   answerSdpTextarea.disabled = false;
   answerSdpTextarea.value = description.sdp;
 }


### PR DESCRIPTION
Safaris RTCSessionDescritpion.sdp is read-only as specified
    http://w3c.github.io/webrtc-pc/#rtcsessiondescription-class
Adapts the munge-sdp demo to deal with this.