### PR TITLE
devices: enable output dropdown based on sinkId availability

### DIFF
--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -14,6 +14,8 @@ var audioOutputSelect = document.querySelector('select#audioOutput');
 var videoSelect = document.querySelector('select#videoSource');
 var selectors = [audioInputSelect, audioOutputSelect, videoSelect];
 
+audioOutputSelect.disabled = !('sinkId' in HTMLMediaElement.prototype);
+
 function gotDevices(deviceInfos) {
   // Handles being called several times to update labels. Preserve values.
   var values = selectors.map(function(select) {


### PR DESCRIPTION
checks whether the sinkId is settable before allowing to choose output.