### PR TITLE
Adding playsInline to the video element for iOS

### DIFF
--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -38,7 +38,7 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>getUserMedia</span></h1>
 
-    <video id="gum-local" autoplay></video>
+    <video id="gum-local" autoplay playsinline></video>
 
     <div id="errorMsg"></div>
 


### PR DESCRIPTION
iOS has some specificities with video playing (autoplay, playsInline) which are not always handled in the samples.
