### PR TITLE
Add aspect and size locks to resolution demo

### DIFF
--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -93,6 +93,8 @@
         <label>Width <span></span>px:</label>
         <input type="range" min="0" max="1920" value="0">
       </div>
+      <input id="sizelock" type="checkbox">Lock video size<br>
+      <input id="aspectlock" type="checkbox">Lock aspect ratio</br>
     </div>
     <p id="errormessage"></p>
 

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -94,7 +94,7 @@
         <input type="range" min="0" max="1920" value="0">
       </div>
       <input id="sizelock" type="checkbox">Lock video size<br>
-      <input id="aspectlock" type="checkbox">Lock aspect ratio</br>
+      <input id="aspectlock" type="checkbox">Lock aspect ratio<br>
     </div>
     <p id="errormessage"></p>
 

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -22,6 +22,8 @@ var messagebox = document.querySelector('#errormessage');
 
 var widthInput = document.querySelector('div#width input');
 var widthOutput = document.querySelector('div#width span');
+var aspectLock = document.querySelector('#aspectlock');
+var sizeLock = document.querySelector('#sizelock');
 
 var currentWidth = 0;
 var currentHeight = 0;
@@ -112,7 +114,15 @@ video.onresize = function() {
 function constraintChange(e) {
   widthOutput.textContent = e.target.value;
   let track = window.stream.getVideoTracks()[0];
-  let constraints = {width: {exact: e.target.value}};
+  let constraints;
+  if (aspectLock.checked) {
+    constraints = {width: {exact: e.target.value},
+                       aspectRatio: {
+                         exact: video.videoWidth / video.videoHeight
+                       }};
+  } else {
+    constraints = {width: {exact: e.target.value}};
+  }
   clearErrorMessage();
   console.log('applying ' + JSON.stringify(constraints));
   track.applyConstraints(constraints)
@@ -126,6 +136,16 @@ function constraintChange(e) {
 }
 
 widthInput.onchange = constraintChange;
+
+sizeLock.onchange = function() {
+  if (sizeLock.checked) {
+    console.log('Setting fixed size');
+    video.style.width = '100%';
+  } else {
+    console.log('Setting auto size');
+    video.style.width = 'auto';
+  }
+};
 
 function getMedia(constraints) {
   if (stream) {


### PR DESCRIPTION
This allows to constrain the size of the video (for
watching pixellated images) or the aspect ratio (for
making sure we get the same aspect ratio).

