### PR TITLE
webrtc-adapter version selector

### DIFF
--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -64,7 +64,7 @@
   <script src="js/third_party/teapot-streams.js"></script>
   <script src="js/third_party/demo.js"></script>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/capture/canvas-record/index.html
+++ b/src/content/capture/canvas-record/index.html
@@ -68,7 +68,7 @@
   <script src="js/third_party/demo.js"></script>
 
   <!-- include adapter for srcObject shim -->
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -67,7 +67,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/capture/video-pc/index.html
+++ b/src/content/capture/video-pc/index.html
@@ -58,7 +58,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/datachannel/basic/index.html
+++ b/src/content/datachannel/basic/index.html
@@ -61,7 +61,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/basic" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -79,7 +79,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/datatransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/datachannel/filetransfer/index.html
+++ b/src/content/datachannel/filetransfer/index.html
@@ -80,7 +80,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/datachannel/filetransfer" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -72,7 +72,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/devices/input-output" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/devices/multi/index.html
+++ b/src/content/devices/multi/index.html
@@ -90,7 +90,7 @@
       <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/devices/multi" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/getusermedia/audio/index.html
+++ b/src/content/getusermedia/audio/index.html
@@ -46,7 +46,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/getusermedia/canvas/index.html
+++ b/src/content/getusermedia/canvas/index.html
@@ -46,7 +46,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/face/index.html
+++ b/src/content/getusermedia/face/index.html
@@ -11,7 +11,7 @@
   <script type="text/javascript" src="../../../js/lib/ccv.js"></script>
   <script type="text/javascript" src="../../../js/lib/face.js"></script>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <style type="text/css">
     display: block;display: block;* { margin:0; padding:0; } /* to remove the top and left whitespace */

--- a/src/content/getusermedia/filter/index.html
+++ b/src/content/getusermedia/filter/index.html
@@ -87,7 +87,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/filter" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -51,7 +51,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/gum" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/getusermedia/record/index.html
+++ b/src/content/getusermedia/record/index.html
@@ -51,7 +51,7 @@
   </div>
 
   <!-- include adapter for srcObject shim -->
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -103,7 +103,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/resolution" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -64,7 +64,7 @@
   </div>
 
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/soundmeter.js"></script>
   <script src="js/main.js"></script>

--- a/src/content/peerconnection/audio/index.html
+++ b/src/content/peerconnection/audio/index.html
@@ -71,7 +71,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/third_party/graph.js"></script>

--- a/src/content/peerconnection/bandwidth/index.html
+++ b/src/content/peerconnection/bandwidth/index.html
@@ -66,7 +66,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/third_party/graph.js"></script>

--- a/src/content/peerconnection/constraints/index.html
+++ b/src/content/peerconnection/constraints/index.html
@@ -105,7 +105,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/create-offer/index.html
+++ b/src/content/peerconnection/create-offer/index.html
@@ -66,7 +66,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/dtmf/index.html
+++ b/src/content/peerconnection/dtmf/index.html
@@ -86,7 +86,7 @@
 
 </div>
 
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="../../../js/adapter-loader.js"></script>
 <script src="../../../js/common.js"></script>
 <script src="js/main.js"></script>
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/multiple-relay/index.html
+++ b/src/content/peerconnection/multiple-relay/index.html
@@ -55,7 +55,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="../../../js/videopipe.js"></script>
   <script src="js/main.js"></script>

--- a/src/content/peerconnection/multiple/index.html
+++ b/src/content/peerconnection/multiple/index.html
@@ -54,7 +54,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/munge-sdp/index.html
+++ b/src/content/peerconnection/munge-sdp/index.html
@@ -83,7 +83,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/peerconnection/munge-sdp" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/pc1/index.html
+++ b/src/content/peerconnection/pc1/index.html
@@ -57,7 +57,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/pr-answer/index.html
+++ b/src/content/peerconnection/pr-answer/index.html
@@ -27,7 +27,7 @@
   <button id="btn2">Accept</button>
   <button id="btn3">Hang Up</button>
 </body>
-<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="../../../js/adapter-loader.js"></script>
 <script src="../../../js/common.js"></script>
 <script src="js/main.js"></script>
 </html>

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -64,7 +64,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/states/index.html
+++ b/src/content/peerconnection/states/index.html
@@ -68,7 +68,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -125,7 +125,7 @@
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/peerconnection/trickle-ice" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/upgrade/index.html
+++ b/src/content/peerconnection/upgrade/index.html
@@ -58,7 +58,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 

--- a/src/content/peerconnection/webaudio-input/index.html
+++ b/src/content/peerconnection/webaudio-input/index.html
@@ -77,7 +77,7 @@
 
     </div>
 
-    <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+    <script src="../../../js/adapter-loader.js"></script>
     <script src="../../../js/common.js"></script>
     <script src="js/webaudioextended.js"></script>
     <script src="js/main.js"></script>

--- a/src/content/peerconnection/webaudio-output/index.html
+++ b/src/content/peerconnection/webaudio-output/index.html
@@ -55,7 +55,7 @@
 
   </div>
 
-  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="../../../js/adapter-loader.js"></script>
   <script src="../../../js/common.js"></script>
   <script src="js/third_party/streamvisualizer.js"></script>
   <script src="js/main.js"></script>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -211,6 +211,10 @@ select {
   top: -1px;
 }
 
+select.versionselector {
+  margin: 1em 0 0 0;
+}
+
 h1 span {
   white-space: nowrap;
 }

--- a/src/js/adapter-loader.js
+++ b/src/js/adapter-loader.js
@@ -11,6 +11,7 @@
   firstOptionNode.appendChild(
     document.createTextNode(versionName + '; Select different webrtc-adapter version...')
   );
+  firstOptionNode.value = '';
   selectNode.className = 'versionselector';
   selectNode.appendChild(firstOptionNode);
 

--- a/src/js/adapter-loader.js
+++ b/src/js/adapter-loader.js
@@ -11,6 +11,7 @@
   firstOptionNode.appendChild(
     document.createTextNode(versionName + '; Select different webrtc-adapter version...')
   );
+  selectNode.className = 'versionselector';
   selectNode.appendChild(firstOptionNode);
 
   selectNode.onclick = function(e) {
@@ -55,5 +56,5 @@
     request.send();
   };
 
-  document.body.appendChild(selectNode);
+  document.getElementById('container').appendChild(selectNode);
 })();

--- a/src/js/adapter-loader.js
+++ b/src/js/adapter-loader.js
@@ -1,0 +1,59 @@
+(function() {
+  var adapterURL = localStorage.alternativeAdapterVersion
+    ? 'https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/' + localStorage.alternativeAdapterVersion + '/adapter.min.js'
+    : 'https://webrtc.github.io/adapter/adapter-latest.js';
+
+  document.write('<script src="' + adapterURL + '"></script>');
+
+  var versionName = localStorage.alternativeAdapterVersion || 'latest';
+  var selectNode = document.createElement('select');
+  var firstOptionNode = document.createElement('option');
+  firstOptionNode.appendChild(
+    document.createTextNode(versionName + '; Select different webrtc-adapter version...')
+  );
+  selectNode.appendChild(firstOptionNode);
+
+  selectNode.onclick = function(e) {
+    selectNode.blur();
+    selectNode.onclick = undefined;
+    function errorHandler() {
+      firstOptionNode.appendChild(
+        document.createTextNode('Loading failed.')
+      );
+    }
+    var request = new XMLHttpRequest();
+    request.open('GET', 'https://api.cdnjs.com/libraries/webrtc-adapter', true);
+
+    request.onload = function() {
+      if (request.status >= 200 && request.status < 400) {
+        var assets = JSON.parse(request.responseText).assets;
+        
+        [{ version: 'latest', value: '' }]
+        .concat(assets)
+        .forEach(function(asset) {
+          var newOption = document.createElement('option');
+          newOption.value = asset.value || asset.version;
+          if (asset.version === (localStorage.alternativeAdapterVersion || 'latest')) {
+            newOption.selected = true;
+          }
+          newOption.appendChild(
+            document.createTextNode(asset.version)
+          );
+          selectNode.appendChild(newOption);
+        });
+
+        selectNode.onchange = function(event) {
+          localStorage.alternativeAdapterVersion = event.target.value || '';
+          window.location.reload();
+        };  
+      } else {
+        errorHandler();
+      }
+    };
+    request.onerror = errorHandler;
+
+    request.send();
+  };
+
+  document.body.appendChild(selectNode);
+})();


### PR DESCRIPTION
This code is meant to help debugging regressions in adapter-webrtc.
User is able to select any version of the script available in cdnjs

example at the bottom: https://cezarydanielnowak.github.io/samples/src/content/getusermedia/gum/