### PR TITLE
Live web audio link rediection fixup (#953)

### DIFF
--- a/src/content/peerconnection/webaudio-input/index.html
+++ b/src/content/peerconnection/webaudio-input/index.html
@@ -53,7 +53,7 @@
     <p>The audio stream is:</p>
 
     <ul>
-      <li>Recorded using <a href="http://www.html5audio.org/2012/09/live-audio-input-comes-to-googles-chrome-canary.html" title="Live audio input comes to Google's Chrome Canary">live audio input</a>.</li>
+      <li>Recorded using <a href="https://developers.google.com/web/updates/2012/09/Live-Web-Audio-Input-Enabled" title="Live web input comes to Google's Chrome Canary">live web audio input in chrome://flags </a>.</li>
       <li>Filtered using an HP filter with fc=1500 Hz.</li>
       <li>Encoded using <a href="http://www.opus-codec.org/" title="Opus Codec">Opus</a>.</li>
       <li>Transmitted (in loopback) to a remote peer using <a href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface" title="RTCPeerConnection Interface">RTCPeerConnection</a> where it is decoded.</li>

--- a/src/content/peerconnection/webaudio-input/index.html
+++ b/src/content/peerconnection/webaudio-input/index.html
@@ -53,7 +53,7 @@
     <p>The audio stream is:</p>
 
     <ul>
-      <li>Recorded using <a href="https://developers.google.com/web/updates/2012/09/Live-Web-Audio-Input-Enabled" title="Live web input comes to Google's Chrome Canary">live web audio input in chrome://flags </a>.</li>
+      <li>Recorded using <a href="https://developers.google.com/web/updates/2012/09/Live-Web-Audio-Input-Enabled" title="Live web audio input comes to Google's Chrome Canary">live web audio input in chrome://flags </a>.</li>
       <li>Filtered using an HP filter with fc=1500 Hz.</li>
       <li>Encoded using <a href="http://www.opus-codec.org/" title="Opus Codec">Opus</a>.</li>
       <li>Transmitted (in loopback) to a remote peer using <a href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface" title="RTCPeerConnection Interface">RTCPeerConnection</a> where it is decoded.</li>


### PR DESCRIPTION
**Description**
Removed html5audio link and sending the page to google dev link since its taking the user to a spam page.

**Purpose**
Redirect the user to the correct page. 