### PR TITLE
Enable testing 4K in the test page (issue 963)

### DIFF
--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -83,6 +83,7 @@
       <button id="vga">VGA</button>
       <button id="hd">HD</button>
       <button id="full-hd">Full HD</button>
+      <button id="4k">4K</button>
     </div>
 
     <div id="videoblock">
@@ -91,7 +92,7 @@
       <video id="gum-res-local" autoplay></video>
       <div id="width">
         <label>Width <span></span>px:</label>
-        <input type="range" min="0" max="1920" value="0">
+        <input type="range" min="0" max="4096" value="0">
       </div>
       <input id="sizelock" type="checkbox">Lock video size<br>
       <input id="aspectlock" type="checkbox">Lock aspect ratio<br>

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -83,7 +83,7 @@
       <button id="vga">VGA</button>
       <button id="hd">HD</button>
       <button id="full-hd">Full HD</button>
-      <button id="4k">4K</button>
+      <button id="fourK">4K</button>
     </div>
 
     <div id="videoblock">

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -16,7 +16,7 @@ var vgaButton = document.querySelector('#vga');
 var qvgaButton = document.querySelector('#qvga');
 var hdButton = document.querySelector('#hd');
 var fullHdButton = document.querySelector('#full-hd');
-var 4kButton = document.querySelector('#4k');
+var fourKButton = document.querySelector('#fourK');
 
 var videoblock = document.querySelector('#videoblock');
 var messagebox = document.querySelector('#errormessage');
@@ -45,8 +45,8 @@ fullHdButton.onclick = function() {
   getMedia(fullHdConstraints);
 };
 
-4kButton.onclick = function() {
-  getMedia(4kConstraints);
+fourKButton.onclick = function() {
+  getMedia(fourKConstraints);
 };
 
 var qvgaConstraints = {
@@ -65,7 +65,7 @@ var fullHdConstraints = {
   video: {width: {exact: 1920}, height: {exact: 1080}}
 };
 
-var 4kConstraints = {
+var fourKConstraints = {
   video: {width: {exact: 4096}, height: {exact: 2160}}
 };
 

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -16,6 +16,7 @@ var vgaButton = document.querySelector('#vga');
 var qvgaButton = document.querySelector('#qvga');
 var hdButton = document.querySelector('#hd');
 var fullHdButton = document.querySelector('#full-hd');
+var 4kButton = document.querySelector('#4k');
 
 var videoblock = document.querySelector('#videoblock');
 var messagebox = document.querySelector('#errormessage');
@@ -44,6 +45,10 @@ fullHdButton.onclick = function() {
   getMedia(fullHdConstraints);
 };
 
+4kButton.onclick = function() {
+  getMedia(4kConstraints);
+};
+
 var qvgaConstraints = {
   video: {width: {exact: 320}, height: {exact: 240}}
 };
@@ -58,6 +63,10 @@ var hdConstraints = {
 
 var fullHdConstraints = {
   video: {width: {exact: 1920}, height: {exact: 1080}}
+};
+
+var 4kConstraints = {
+  video: {width: {exact: 4096}, height: {exact: 2160}}
 };
 
 function gotStream(mediaStream) {

--- a/src/content/getusermedia/resolution/js/test.js
+++ b/src/content/getusermedia/resolution/js/test.js
@@ -67,3 +67,7 @@ test('HD capture', function(t) {
 test('FULL HD capture', function(t) {
   resolutionTest(t, 'full-hd', 1920);
 });
+
+test('Four K capture', function(t) {
+  resolutionTest(t, 'fourK', 4096);
+});

--- a/src/content/getusermedia/resolution/js/test.js
+++ b/src/content/getusermedia/resolution/js/test.js
@@ -68,6 +68,6 @@ test('FULL HD capture', function(t) {
   resolutionTest(t, 'full-hd', 1920);
 });
 
-test('Four K capture', function(t) {
+test('4K capture', function(t) {
   resolutionTest(t, 'fourK', 4096);
 });

--- a/src/content/getusermedia/resolution/js/test.js
+++ b/src/content/getusermedia/resolution/js/test.js
@@ -55,7 +55,6 @@ test('QVGA capture', function(t) {
   resolutionTest(t, 'qvga', 320);
 });
 
-
 test('VGA capture', function(t) {
   resolutionTest(t, 'vga', 640);
 });
@@ -68,6 +67,9 @@ test('FULL HD capture', function(t) {
   resolutionTest(t, 'full-hd', 1920);
 });
 
+/*
+//Fake camera capture device does not support 4K yet.
 test('4K capture', function(t) {
   resolutionTest(t, 'fourK', 4096);
 });
+*/


### PR DESCRIPTION
**Description**
Adding 4k button in the testing page to test 4k camera and its resolution. 

**Purpose**
4096x2160 (4K) has to be added in the page https://webrtc.github.io/samples/src/content/getusermedia/resolution/ 

Added button 4k and all the related code to bring this button to test the resolution. 