### PR TITLE
all: remove legacy pc constraints

### DIFF
--- a/src/content/datachannel/basic/js/main.js
+++ b/src/content/datachannel/basic/js/main.js
@@ -12,7 +12,6 @@ var localConnection;
 var remoteConnection;
 var sendChannel;
 var receiveChannel;
-var pcConstraint;
 var dataConstraint;
 var dataChannelSend = document.querySelector('textarea#dataChannelSend');
 var dataChannelReceive = document.querySelector('textarea#dataChannelReceive');
@@ -35,7 +34,6 @@ function disableSendButton() {
 function createConnection() {
   dataChannelSend.placeholder = '';
   var servers = null;
-  pcConstraint = null;
   dataConstraint = null;
   trace('Using SCTP based data channels');
   // SCTP is supported from Chrome 31 and is supported in FF.
@@ -44,7 +42,7 @@ function createConnection() {
   // Add localConnection to global scope to make it visible
   // from the browser console.
   window.localConnection = localConnection =
-      new RTCPeerConnection(servers, pcConstraint);
+      new RTCPeerConnection(servers);
   trace('Created local peer connection object localConnection');
 
   sendChannel = localConnection.createDataChannel('sendDataChannel',
@@ -60,7 +58,7 @@ function createConnection() {
   // Add remoteConnection to global scope to make it visible
   // from the browser console.
   window.remoteConnection = remoteConnection =
-      new RTCPeerConnection(servers, pcConstraint);
+      new RTCPeerConnection(servers);
   trace('Created remote peer connection object remoteConnection');
 
   remoteConnection.onicecandidate = function(e) {

--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -12,7 +12,6 @@ var localConnection;
 var remoteConnection;
 var sendChannel;
 var receiveChannel;
-var pcConstraint;
 var megsToSend = document.querySelector('input#megsToSend');
 var sendButton = document.querySelector('button#sendTheData');
 var orderedCheckbox = document.querySelector('input#ordered');
@@ -40,14 +39,10 @@ function createConnection() {
   sendButton.disabled = true;
   megsToSend.disabled = true;
   var servers = null;
-  pcConstraint = null;
 
   bytesToSend = Math.round(megsToSend.value) * 1024 * 1024;
 
-  // Add localConnection to global scope to make it visible
-  // from the browser console.
-  window.localConnection = localConnection = new RTCPeerConnection(servers,
-      pcConstraint);
+  localConnection = localConnection = new RTCPeerConnection(servers);
   trace('Created local peer connection object localConnection');
 
   var dataChannelParams = {ordered: false};
@@ -71,10 +66,7 @@ function createConnection() {
     onCreateSessionDescriptionError
   );
 
-  // Add remoteConnection to global scope to make it visible
-  // from the browser console.
-  window.remoteConnection = remoteConnection = new RTCPeerConnection(servers,
-      pcConstraint);
+  remoteConnection = remoteConnection = new RTCPeerConnection(servers);
   trace('Created remote peer connection object remoteConnection');
 
   remoteConnection.onicecandidate = function(e) {

--- a/src/content/datachannel/filetransfer/js/main.js
+++ b/src/content/datachannel/filetransfer/js/main.js
@@ -11,7 +11,6 @@ var localConnection;
 var remoteConnection;
 var sendChannel;
 var receiveChannel;
-var pcConstraint;
 var bitrateDiv = document.querySelector('div#bitrate');
 var fileInput = document.querySelector('input#fileInput');
 var downloadAnchor = document.querySelector('a#download');
@@ -41,12 +40,8 @@ function handleFileInputChange() {
 
 function createConnection() {
   var servers = null;
-  pcConstraint = null;
 
-  // Add localConnection to global scope to make it visible
-  // from the browser console.
-  window.localConnection = localConnection = new RTCPeerConnection(servers,
-      pcConstraint);
+  localConnection = localConnection = new RTCPeerConnection(servers);
   trace('Created local peer connection object localConnection');
 
   sendChannel = localConnection.createDataChannel('sendDataChannel');
@@ -63,10 +58,7 @@ function createConnection() {
     gotDescription1,
     onCreateSessionDescriptionError
   );
-  // Add remoteConnection to global scope to make it visible
-  // from the browser console.
-  window.remoteConnection = remoteConnection = new RTCPeerConnection(servers,
-      pcConstraint);
+  remoteConnection = remoteConnection = new RTCPeerConnection(servers);
   trace('Created remote peer connection object remoteConnection');
 
   remoteConnection.onicecandidate = function(e) {

--- a/src/content/devices/input-output/js/test.js
+++ b/src/content/devices/input-output/js/test.js
@@ -81,12 +81,15 @@ test('Fake device selection and check video element dimensions ' +
 
         switch (browser) {
         case 'chrome':
-          fakeAudioDeviceNames = ['Fake Audio 1', 'Fake Default Audio Input'];
+          fakeAudioDeviceNames = [
+            'Fake Default Audio Input', // Chrome <= 63
+            'Fake Default Audio Input - Fake Audio Input 1', // Chrome 64+
+            'Fake Audio Input 1',
+            'Fake Audio Input 2'
+          ];
           break;
         case 'firefox':
-          // TODO: Remove the "deviceLabel === ''" check once Firefox ESR
-          // reaches 46 (supports device labels for fake devices).
-          fakeAudioDeviceNames = ['', 'Default Audio Device'];
+          fakeAudioDeviceNames = ['Default Audio Device'];
           break;
         default:
           t.skip('unsupported browser');

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -78,15 +78,12 @@ function call() {
   codecSelector.disabled = true;
   trace('Starting call');
   var servers = null;
-  var pcConstraints = {
-    'optional': []
-  };
-  pc1 = new RTCPeerConnection(servers, pcConstraints);
+  pc1 = new RTCPeerConnection(servers);
   trace('Created local peer connection object pc1');
   pc1.onicecandidate = function(e) {
     onIceCandidate(pc1, e);
   };
-  pc2 = new RTCPeerConnection(servers, pcConstraints);
+  pc2 = new RTCPeerConnection(servers);
   trace('Created remote peer connection object pc2');
   pc2.onicecandidate = function(e) {
     onIceCandidate(pc2, e);

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -75,14 +75,11 @@ function call() {
   bandwidthSelector.disabled = false;
   trace('Starting call');
   var servers = null;
-  var pcConstraints = {
-    'optional': []
-  };
-  pc1 = new RTCPeerConnection(servers, pcConstraints);
+  pc1 = new RTCPeerConnection(servers);
   trace('Created local peer connection object pc1');
   pc1.onicecandidate = onIceCandidate.bind(pc1);
 
-  pc2 = new RTCPeerConnection(servers, pcConstraints);
+  pc2 = new RTCPeerConnection(servers);
   trace('Created remote peer connection object pc2');
   pc2.onicecandidate = onIceCandidate.bind(pc2);
   pc2.ontrack = gotRemoteStream;

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -92,15 +92,12 @@ function onCreateSessionDescriptionError(error) {
 function call() {
   trace('Starting call');
   var servers = null;
-  var pcConstraints = {
-    'optional': []
-  };
-  pc1 = new RTCPeerConnection(servers, pcConstraints);
+  pc1 = new RTCPeerConnection(servers);
   trace('Created local peer connection object pc1');
   pc1.onicecandidate = function(e) {
     onIceCandidate(pc1, e);
   };
-  pc2 = new RTCPeerConnection(servers, pcConstraints);
+  pc2 = new RTCPeerConnection(servers);
   trace('Created remote peer connection object pc2');
   pc2.onicecandidate = function(e) {
     onIceCandidate(pc2, e);

--- a/src/content/peerconnection/states/js/main.js
+++ b/src/content/peerconnection/states/js/main.js
@@ -68,11 +68,8 @@ function call() {
     trace('Using Audio device: ' + audioTracks[0].label);
   }
   var servers = null;
-  var pcConstraints = {
-    'optional': []
-  };
 
-  pc1 = new RTCPeerConnection(servers, pcConstraints);
+  pc1 = new RTCPeerConnection(servers);
   trace('Created local peer connection object pc1');
   pc1StateDiv.textContent = pc1.signalingState || pc1.readyState;
   pc1.onsignalingstatechange = stateCallback1;
@@ -83,7 +80,7 @@ function call() {
     onIceCandidate(pc1, e);
   };
 
-  pc2 = new RTCPeerConnection(servers, pcConstraints);
+  pc2 = new RTCPeerConnection(servers);
   trace('Created remote peer connection object pc2');
   pc2StateDiv.textContent = pc2.signalingState || pc2.readyState;
   pc2.onsignalingstatechange = stateCallback2;

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -82,15 +82,11 @@
       <h2>ICE options</h2>
 
       <div id="iceTransports">
-        <label for="ipv6"><span>IceTransports value:</span></label>
+        <label for="transports"><span>IceTransports value:</span></label>
         <input type="radio" name="transports" value="all" id="all" checked>
         <span>all</span>
         <input type="radio" name="transports" value="relay" id="relay">
         <span>relay</span>
-      </div>
-      <div>
-        <label for="ipv6">Gather IPv6 candidates:</label>
-        <input id="ipv6" type="checkbox" checked>
       </div>
       <div>
         <label>ICE Candidate Pool:</label>

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -16,7 +16,6 @@ var removeButton = document.querySelector('button#remove');
 var servers = document.querySelector('select#servers');
 var urlInput = document.querySelector('input#url');
 var usernameInput = document.querySelector('input#username');
-var ipv6Check = document.querySelector('input#ipv6');
 var iceCandidatePoolInput = document.querySelector('input#iceCandidatePool');
 
 addButton.onclick = addServer;
@@ -104,15 +103,12 @@ function start() {
     iceCandidatePoolSize: iceCandidatePoolInput.value
   };
 
-  var pcConstraints = {};
   var offerOptions = {offerToReceiveAudio: 1};
   // Whether we gather IPv6 candidates.
-  pcConstraints.optional = [{'googIPv6': ipv6Check.checked}];
   // Whether we only gather a single set of candidates for RTP and RTCP.
 
-  trace('Creating new PeerConnection with config=' + JSON.stringify(config) +
-        ', constraints=' + JSON.stringify(pcConstraints));
-  pc = new RTCPeerConnection(config, pcConstraints);
+  trace('Creating new PeerConnection with config=' + JSON.stringify(config));
+  pc = new RTCPeerConnection(config);
   pc.onicecandidate = iceCallback;
   pc.onicegatheringstatechange = gatheringStateChange;
   pc.createOffer(


### PR DESCRIPTION
this was removed from the spec long ago and not used meaningful anymore
with the exception of the trickle-ice page. The use there was has been removed.