### PR TITLE
Set frequency value via setValueAtTime

### DIFF
--- a/src/content/peerconnection/webaudio-input/js/webaudioextended.js
+++ b/src/content/peerconnection/webaudio-input/js/webaudioextended.js
@@ -20,7 +20,7 @@ function WebAudioExtended() {
 WebAudioExtended.prototype.start = function() {
   this.filter = this.context.createBiquadFilter();
   this.filter.type = 'highpass';
-  this.filter.frequency.value = 1500;
+  this.filter.frequency.setValueAtTime(1500, this.context.currentTime + 1);
 };
 
 WebAudioExtended.prototype.applyFilter = function(stream) {


### PR DESCRIPTION
**Description**
Set frequency value via setValueAtTime() instead of direct assignation.

**Purpose**
Chrome throws:

> webaudioextended.js:23 [Deprecation] BiquadFilterNode.frequency.value setter smoothing is deprecated and will be removed in M64, around January 2018. Please use setTargetAtTime() instead if smoothing is needed. See https://www.chromestatus.com/features/5287995770929152 for more details.

Fixes #982 - More discussion on the issue.