### PR TITLE
adding playsInline to input-output video element

### DIFF
--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -65,7 +65,7 @@
       <label for="videoSource">Video source: </label><select id="videoSource"></select>
     </div>
 
-    <video id="video" autoplay></video>
+    <video id="video" playsinline autoplay></video>
 
     <p class="small"><b>Note:</b> If you hear a reverb sound your microphone is picking up the output of your speakers/headset, lower the volume and/or move the microphone further away from your speakers/headset.</p>
 


### PR DESCRIPTION
iOS requires playsInline to play video inline and not fullscreen.