### PR TITLE
audio: use replaceTrack for "hard" mute

### DIFF
--- a/src/content/peerconnection/audio/index.html
+++ b/src/content/peerconnection/audio/index.html
@@ -56,7 +56,8 @@
         <option value="PCMU">PCMU</option>
       </select>
       <button id="callButton">Call</button>
-      <button id="hangupButton">Hang Up</button>
+      <button id="muteButton" disabled>Mute</button>
+      <button id="hangupButton" disabled>Hang Up</button>
     </div>
     <div class="graph-container" id="bitrateGraph">
       <div>Bitrate</div>


### PR DESCRIPTION
**Description**
uses replaceTrack for hard muting. This is different from soft mute, i.e. setting track.enabled = false
which (in chrome) continues to send 50 packets/s at a slightly lower bitrate

**Purpose**
I want to use replaceTrack(null) so I would like to see some basic QA :-)

@henbos PTAL since you wanted this as well.
@KaptenJansson wdyt about adding "QA" instructions on the page?
@jan-ivar replaceTrack(null) is only supported in 59+, right? Graphs freeze after replaceTrack(null), afaics getStats() does not return any rtp stats?