### PR TITLE
remove extra getStats call

### DIFF
--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -234,5 +234,4 @@ function hangup() {
   pc2 = null;
   hangupButton.disabled = true;
   callButton.disabled = false;
-  pc1.getStats(); // just to have something testing getstats-after-close.
 }


### PR DESCRIPTION
it did not even work because the peerconnection was null'd.
Also we have updated the constraints sample to make sure this
case is covered