### PR TITLE
Fix #999 Support 8K to test the overConstraintError with 4K

### DIFF
--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -84,6 +84,7 @@
       <button id="hd">HD</button>
       <button id="full-hd">Full HD</button>
       <button id="fourK">4K</button>
+      <button id="eightK">8K</button>
     </div>
 
     <div id="videoblock">
@@ -92,7 +93,7 @@
       <video id="gum-res-local" autoplay></video>
       <div id="width">
         <label>Width <span></span>px:</label>
-        <input type="range" min="0" max="4096" value="0">
+        <input type="range" min="0" max="7680" value="0">
       </div>
       <input id="sizelock" type="checkbox">Lock video size<br>
       <input id="aspectlock" type="checkbox">Lock aspect ratio<br>

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -17,6 +17,7 @@ var qvgaButton = document.querySelector('#qvga');
 var hdButton = document.querySelector('#hd');
 var fullHdButton = document.querySelector('#full-hd');
 var fourKButton = document.querySelector('#fourK');
+var eightKButton = document.querySelector('#eightK');
 
 var videoblock = document.querySelector('#videoblock');
 var messagebox = document.querySelector('#errormessage');
@@ -49,6 +50,10 @@ fourKButton.onclick = function() {
   getMedia(fourKConstraints);
 };
 
+eightKButton.onclick = function() {
+  getMedia(eightKConstraints);
+};
+
 var qvgaConstraints = {
   video: {width: {exact: 320}, height: {exact: 240}}
 };
@@ -67,6 +72,10 @@ var fullHdConstraints = {
 
 var fourKConstraints = {
   video: {width: {exact: 4096}, height: {exact: 2160}}
+};
+
+var eightKConstraints = {
+  video: {width: {exact: 7680}, height: {exact: 4320}}
 };
 
 function gotStream(mediaStream) {


### PR DESCRIPTION
**Description**
Based on the issue 999, we need to have a 8K resolution added in the test page. 

**Purpose**
With 8K resolution added in the test page, it is possible to test overConstrainedError when connected with a 4K camera. 

