### PR TITLE
pc1: remove getStats call

### DIFF
--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -234,5 +234,4 @@ function hangup() {
   pc2 = null;
   hangupButton.disabled = true;
   callButton.disabled = false;
-  pc1.getStats(); // just to have something testing getstats-after-close.
 }


### PR DESCRIPTION
we have a better place for getstats-after-close now. Also this was
just throwing an exception