### PR TITLE
Remove duplicate assignment to localConnection

### DIFF
--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -42,7 +42,7 @@ function createConnection() {
 
   bytesToSend = Math.round(megsToSend.value) * 1024 * 1024;
 
-  localConnection = localConnection = new RTCPeerConnection(servers);
+  localConnection = new RTCPeerConnection(servers);
   trace('Created local peer connection object localConnection');
 
   var dataChannelParams = {ordered: false};


### PR DESCRIPTION
**Description**
Remove duplicate assignment to localConnection.

**Purpose**
To remove the overhead of assigning the localConnection variable twice in the same line.