### PR TITLE
audio/bandwidth/constraints: get rid of legacy stats

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -283,9 +283,7 @@ window.setInterval(function() {
       var bytes;
       var packets;
       var now = report.timestamp;
-      if ((report.type === 'outboundrtp') ||
-          (report.type === 'outbound-rtp') ||
-          (report.type === 'ssrc' && report.bytesSent)) {
+      if (report.type === 'outbound-rtp') {
         bytes = report.bytesSent;
         packets = report.packetsSent;
         if (lastResult && lastResult.get(report.id)) {

--- a/src/content/peerconnection/audio/js/test.js
+++ b/src/content/peerconnection/audio/js/test.js
@@ -53,8 +53,15 @@ test('Audio-only sample codec preference', function(t) {
     .then(function(stats) {
       // Find the sending audio track.
       stats.forEach(function(report) {
-        if (report.type === 'ssrc' && report.googTrackId === trackId) {
-          t.ok(codecName === report.googCodecName, 'preferring ' + codecName);
+        if (report.type === 'outbound-rtp') {
+          var trackStats = stats.get(report.trackId);
+          if (trackStats && trackStats.trackIdentifier === trackId) {
+            var codecStats = stats.get(report.codecId);
+            if (codecStats) {
+              t.ok('audio/' + codecName === codecStats.mimeType,
+                  'preferring ' + codecName);
+            }
+          }
         }
       });
       return driver.findElement(webdriver.By.id('hangupButton')).click();

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -237,9 +237,7 @@ window.setInterval(function() {
       var bytes;
       var packets;
       var now = report.timestamp;
-      if ((report.type === 'outboundrtp') ||
-          (report.type === 'outbound-rtp') ||
-          (report.type === 'ssrc' && report.bytesSent)) {
+      if (report.type === 'outbound-rtp') {
         bytes = report.bytesSent;
         packets = report.packetsSent;
         if (lastResult && lastResult.get(report.id)) {

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -231,13 +231,7 @@ function showRemoteStats(results) {
     var now = report.timestamp;
 
     var bitrate;
-    if (report.type === 'inboundrtp' && report.mediaType === 'video') {
-      // firefox calculates the bitrate for us
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=951496
-      bitrate = Math.floor(report.bitrateMean / 1024);
-    } else if (report.type === 'ssrc' && report.bytesReceived &&
-         report.googFrameHeightReceived) {
-      // chrome does not so we need to do it ourselves
+    if (report.type === 'inbound-rtp' && report.mediaType === 'video') {
       var bytes = report.bytesReceived;
       if (timestampPrev) {
         bitrate = 8 * (bytes - bytesPrev) / (now - timestampPrev);


### PR DESCRIPTION
gets rid of chrome-legacy stats and non-hyphenated stats types

@henbos / @jan-ivar  PTAL. There is still a case of goog-stats in the test that i'll try to get rid of as well (now done)