### PR TITLE
bandwidth: use RTCRtpSender.setParameters

### DIFF
--- a/src/content/peerconnection/bandwidth/index.html
+++ b/src/content/peerconnection/bandwidth/index.html
@@ -43,10 +43,10 @@
     <div id="buttons">
         <label>Bandwidth:</label>
         <select id="bandwidth" disabled>
-            <option value="unlimited">unlimited</option>
+            <option value="unlimited" selected>unlimited</option>
             <option value="2000">2000</option>
             <option value="1000">1000</option>
-            <option value="500" selected>500</option>
+            <option value="500">500</option>
             <option value="250">250</option>
             <option value="125">125</option>
         </select>


### PR DESCRIPTION
uses RTCRtpSender.setParameters to change the bandwidth. Only supported in Chrome 68+

For QA purposes this also allows setting the maximum bandwidth in the JS console before starting the call.  This allows testing that setParameters is operating within the envelope of the SDP b= restrictions.
For example you could set `maxBandwidth=750`, make a call and if you set the bandwidth to 1000 in the dropdown it should still only go to 750kbps.