### PR TITLE
recording: fix demo in firefox

### DIFF
--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -53,6 +53,8 @@ playButton.addEventListener('click', () => {
           recordedVideo.play();
         };
       };
+    } else {
+      recordedVideo.play();
     }
   });
 });


### PR DESCRIPTION
currently this demo does not play in Firefox anymore which
actually has the duration metadata set properly.

cc @pehrsons