### PR TITLE
Remove the trace function and the file common.js

### DIFF
--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -75,7 +75,7 @@
 <script src="js/third_party/demo.js"></script>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
+
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/capture/canvas-pc/js/main.js
+++ b/src/content/capture/canvas-pc/js/main.js
@@ -23,16 +23,16 @@ const offerOptions = {
 let startTime;
 
 video.addEventListener('loadedmetadata', function() {
-  trace(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 video.onresize = () => {
-  trace(`Remote video size changed to ${video.videoWidth}x${video.videoHeight}`);
+  console.log(`Remote video size changed to ${video.videoWidth}x${video.videoHeight}`);
   // We'll use the first onsize callback as an indication that video has started
   // playing out.
   if (startTime) {
     const elapsedTime = window.performance.now() - startTime;
-    trace(`Setup time: ${elapsedTime.toFixed(3)}ms`);
+    console.log(`Setup time: ${elapsedTime.toFixed(3)}ms`);
     startTime = null;
   }
 };
@@ -41,27 +41,27 @@ video.onresize = () => {
 main();
 
 const stream = canvas.captureStream();
-trace('Got stream from canvas');
+console.log('Got stream from canvas');
 
 call();
 
 function call() {
-  trace('Starting call');
+  console.log('Starting call');
   startTime = window.performance.now();
   const videoTracks = stream.getVideoTracks();
   const audioTracks = stream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using video device: ${videoTracks[0].label}`);
+    console.log(`Using video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc1.oniceconnectionstatechange = e => onIceStateChange(pc1, e);
   pc2.oniceconnectionstatechange = e => onIceStateChange(pc2, e);
@@ -75,23 +75,23 @@ function call() {
       );
     }
   );
-  trace('Added local stream to pc1');
+  console.log('Added local stream to pc1');
 
-  trace('pc1 createOffer start');
+  console.log('pc1 createOffer start');
   pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError, offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function onCreateOfferSuccess(desc) {
-  trace(`Offer from pc1\n${desc.sdp}`);
-  trace('pc1 setLocalDescription start');
+  console.log(`Offer from pc1\n${desc.sdp}`);
+  console.log('pc1 setLocalDescription start');
   pc1.setLocalDescription(desc, () => onSetLocalSuccess(pc1), onSetSessionDescriptionError);
-  trace('pc2 setRemoteDescription start');
+  console.log('pc2 setRemoteDescription start');
   pc2.setRemoteDescription(desc, () => onSetRemoteSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc2 createAnswer start');
+  console.log('pc2 createAnswer start');
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
@@ -99,29 +99,29 @@ function onCreateOfferSuccess(desc) {
 }
 
 function onSetLocalSuccess(pc) {
-  trace(`${getName(pc)} setLocalDescription complete`);
+  console.log(`${getName(pc)} setLocalDescription complete`);
 }
 
 function onSetRemoteSuccess(pc) {
-  trace(`${getName(pc)} setRemoteDescription complete`);
+  console.log(`${getName(pc)} setRemoteDescription complete`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function gotRemoteStream(e) {
   if (video.srcObject !== e.streams[0]) {
     video.srcObject = e.streams[0];
-    trace('pc2 received remote stream');
+    console.log('pc2 received remote stream');
   }
 }
 
 function onCreateAnswerSuccess(desc) {
-  trace(`Answer from pc2:\n${desc.sdp}`);
-  trace('pc2 setLocalDescription start');
+  console.log(`Answer from pc2:\n${desc.sdp}`);
+  console.log('pc2 setLocalDescription start');
   pc2.setLocalDescription(desc, () => onSetLocalSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc1 setRemoteDescription start');
+  console.log('pc1 setRemoteDescription start');
   pc1.setRemoteDescription(desc, () => onSetRemoteSuccess(pc1), onSetSessionDescriptionError);
 }
 
@@ -131,20 +131,20 @@ function onIceCandidate(pc, event) {
       () => onAddIceCandidateSuccess(pc),
       err => onAddIceCandidateError(pc, err)
     );
-  trace(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess(pc) {
-  trace(`${getName(pc)} addIceCandidate success`);
+  console.log(`${getName(pc)} addIceCandidate success`);
 }
 
 function onAddIceCandidateError(pc, error) {
-  trace(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onIceStateChange(pc, event) {
   if (pc) {
-    trace(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
+    console.log(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
     console.log('ICE state change event: ', event);
   }
 }

--- a/src/content/capture/video-contenthint/index.html
+++ b/src/content/capture/video-contenthint/index.html
@@ -80,7 +80,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/capture/video-contenthint/js/main.js
+++ b/src/content/capture/video-contenthint/js/main.js
@@ -29,7 +29,7 @@ function maybeCreateStream() {
     srcStream = srcVideo.captureStream();
     call();
   } else {
-    trace('captureStream() not supported');
+    console.log('captureStream() not supported');
   }
 }
 
@@ -49,10 +49,10 @@ function setVideoTrackContentHints(stream, hint) {
     if ('contentHint' in track) {
       track.contentHint = hint;
       if (track.contentHint !== hint) {
-        trace('Invalid video track contentHint: \'' + hint + '\'');
+        console.log('Invalid video track contentHint: \'' + hint + '\'');
       }
     } else {
-      trace('MediaStreamTrack contentHint attribute not supported');
+      console.log('MediaStreamTrack contentHint attribute not supported');
     }
   });
 }
@@ -99,11 +99,11 @@ function establishPC(videoTag, stream) {
         .then(answerDesc => onCreateAnswerSuccess(pc1, pc2, answerDesc))
         .catch(onSetSessionDescriptionError);
     })
-    .catch(e => trace('Failed to create session description: ' + e.toString()));
+    .catch(e => console.log('Failed to create session description: ' + e.toString()));
 }
 
 function onSetSessionDescriptionError(error) {
-  trace('Failed to set session description: ' + error.toString());
+  console.log('Failed to set session description: ' + error.toString());
 }
 
 function onCreateAnswerSuccess(pc1, pc2, desc) {

--- a/src/content/capture/video-pc/index.html
+++ b/src/content/capture/video-pc/index.html
@@ -66,7 +66,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/capture/video-pc/js/main.js
+++ b/src/content/capture/video-pc/js/main.js
@@ -37,7 +37,7 @@ function maybeCreateStream() {
       stream);
     call();
   } else {
-    trace('captureStream() not supported');
+    console.log('captureStream() not supported');
   }
 }
 
@@ -52,61 +52,61 @@ if (leftVideo.readyState >= 3) {  // HAVE_FUTURE_DATA
 leftVideo.play();
 
 rightVideo.onloadedmetadata = () => {
-  trace(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 };
 
 rightVideo.onresize = () => {
-  trace(`Remote video size changed to ${rightVideo.videoWidth}x${rightVideo.videoHeight}`);
+  console.log(`Remote video size changed to ${rightVideo.videoWidth}x${rightVideo.videoHeight}`);
   // We'll use the first onresize callback as an indication that
   // video has started playing out.
   if (startTime) {
     const elapsedTime = window.performance.now() - startTime;
-    trace('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
+    console.log('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
     startTime = null;
   }
 };
 
 function call() {
-  trace('Starting call');
+  console.log('Starting call');
   startTime = window.performance.now();
   const videoTracks = stream.getVideoTracks();
   const audioTracks = stream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using video device: ${videoTracks[0].label}`);
+    console.log(`Using video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc1.oniceconnectionstatechange = e => onIceStateChange(pc1, e);
   pc2.oniceconnectionstatechange = e => onIceStateChange(pc2, e);
   pc2.ontrack = gotRemoteStream;
 
   stream.getTracks().forEach(track => pc1.addTrack(track, stream));
-  trace('Added local stream to pc1');
+  console.log('Added local stream to pc1');
 
-  trace('pc1 createOffer start');
+  console.log('pc1 createOffer start');
   pc1.createOffer(onCreateOfferSuccess, onCreateSessionDescriptionError, offerOptions);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function onCreateOfferSuccess(desc) {
-  trace(`Offer from pc1
+  console.log(`Offer from pc1
 ${desc.sdp}`);
-  trace('pc1 setLocalDescription start');
+  console.log('pc1 setLocalDescription start');
   pc1.setLocalDescription(desc, () => onSetLocalSuccess(pc1), onSetSessionDescriptionError);
-  trace('pc2 setRemoteDescription start');
+  console.log('pc2 setRemoteDescription start');
   pc2.setRemoteDescription(desc, () => onSetRemoteSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc2 createAnswer start');
+  console.log('pc2 createAnswer start');
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
@@ -114,15 +114,15 @@ ${desc.sdp}`);
 }
 
 function onSetLocalSuccess(pc) {
-  trace(`${getName(pc)} setLocalDescription complete`);
+  console.log(`${getName(pc)} setLocalDescription complete`);
 }
 
 function onSetRemoteSuccess(pc) {
-  trace(`${getName(pc)} setRemoteDescription complete`);
+  console.log(`${getName(pc)} setRemoteDescription complete`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function gotRemoteStream(event) {
@@ -133,11 +133,11 @@ function gotRemoteStream(event) {
 }
 
 function onCreateAnswerSuccess(desc) {
-  trace(`Answer from pc2:
+  console.log(`Answer from pc2:
 ${desc.sdp}`);
-  trace('pc2 setLocalDescription start');
+  console.log('pc2 setLocalDescription start');
   pc2.setLocalDescription(desc, () => onSetLocalSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc1 setRemoteDescription start');
+  console.log('pc1 setRemoteDescription start');
   pc1.setRemoteDescription(desc, () => onSetRemoteSuccess(pc1), onSetSessionDescriptionError);
 }
 
@@ -147,22 +147,22 @@ function onIceCandidate(pc, event) {
       () => onAddIceCandidateSuccess(pc),
       err => onAddIceCandidateError(pc, err)
     );
-  trace(`${getName(pc)} ICE candidate: 
+  console.log(`${getName(pc)} ICE candidate: 
 ${event.candidate ?
     event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess(pc) {
-  trace(`${getName(pc)} addIceCandidate success`);
+  console.log(`${getName(pc)} addIceCandidate success`);
 }
 
 function onAddIceCandidateError(pc, error) {
-  trace(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onIceStateChange(pc, event) {
   if (pc) {
-    trace(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
+    console.log(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
     console.log('ICE state change event: ', event);
   }
 }

--- a/src/content/datachannel/basic/index.html
+++ b/src/content/datachannel/basic/index.html
@@ -68,7 +68,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/basic/js/main.js
+++ b/src/content/datachannel/basic/js/main.js
@@ -34,10 +34,10 @@ function createConnection() {
   dataChannelSend.placeholder = '';
   const servers = null;
   window.localConnection = localConnection = new RTCPeerConnection(servers);
-  trace('Created local peer connection object localConnection');
+  console.log('Created local peer connection object localConnection');
 
   sendChannel = localConnection.createDataChannel('sendDataChannel');
-  trace('Created send data channel');
+  console.log('Created send data channel');
 
   localConnection.onicecandidate = e => {
     onIceCandidate(localConnection, e);
@@ -46,7 +46,7 @@ function createConnection() {
   sendChannel.onclose = onSendChannelStateChange;
 
   window.remoteConnection = remoteConnection = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object remoteConnection');
+  console.log('Created remote peer connection object remoteConnection');
 
   remoteConnection.onicecandidate = e => {
     onIceCandidate(remoteConnection, e);
@@ -62,26 +62,26 @@ function createConnection() {
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace('Failed to create session description: ' + error.toString());
+  console.log('Failed to create session description: ' + error.toString());
 }
 
 function sendData() {
   const data = dataChannelSend.value;
   sendChannel.send(data);
-  trace('Sent Data: ' + data);
+  console.log('Sent Data: ' + data);
 }
 
 function closeDataChannels() {
-  trace('Closing data channels');
+  console.log('Closing data channels');
   sendChannel.close();
-  trace('Closed data channel with label: ' + sendChannel.label);
+  console.log('Closed data channel with label: ' + sendChannel.label);
   receiveChannel.close();
-  trace('Closed data channel with label: ' + receiveChannel.label);
+  console.log('Closed data channel with label: ' + receiveChannel.label);
   localConnection.close();
   remoteConnection.close();
   localConnection = null;
   remoteConnection = null;
-  trace('Closed peer connections');
+  console.log('Closed peer connections');
   startButton.disabled = false;
   sendButton.disabled = true;
   closeButton.disabled = true;
@@ -94,7 +94,7 @@ function closeDataChannels() {
 
 function gotDescription1(desc) {
   localConnection.setLocalDescription(desc);
-  trace(`Offer from localConnection\n${desc.sdp}`);
+  console.log(`Offer from localConnection\n${desc.sdp}`);
   remoteConnection.setRemoteDescription(desc);
   remoteConnection.createAnswer().then(
     gotDescription2,
@@ -104,7 +104,7 @@ function gotDescription1(desc) {
 
 function gotDescription2(desc) {
   remoteConnection.setLocalDescription(desc);
-  trace(`Answer from remoteConnection\n${desc.sdp}`);
+  console.log(`Answer from remoteConnection\n${desc.sdp}`);
   localConnection.setRemoteDescription(desc);
 }
 
@@ -123,19 +123,19 @@ function onIceCandidate(pc, event) {
       () => onAddIceCandidateSuccess(pc),
       err => onAddIceCandidateError(pc, err)
     );
-  trace(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add Ice Candidate: ${error.toString()}`);
+  console.log(`Failed to add Ice Candidate: ${error.toString()}`);
 }
 
 function receiveChannelCallback(event) {
-  trace('Receive Channel Callback');
+  console.log('Receive Channel Callback');
   receiveChannel = event.channel;
   receiveChannel.onmessage = onReceiveMessageCallback;
   receiveChannel.onopen = onReceiveChannelStateChange;
@@ -143,13 +143,13 @@ function receiveChannelCallback(event) {
 }
 
 function onReceiveMessageCallback(event) {
-  trace('Received Message');
+  console.log('Received Message');
   dataChannelReceive.value = event.data;
 }
 
 function onSendChannelStateChange() {
   const readyState = sendChannel.readyState;
-  trace('Send channel state is: ' + readyState);
+  console.log('Send channel state is: ' + readyState);
   if (readyState === 'open') {
     dataChannelSend.disabled = false;
     dataChannelSend.focus();
@@ -164,5 +164,5 @@ function onSendChannelStateChange() {
 
 function onReceiveChannelStateChange() {
   const readyState = receiveChannel.readyState;
-  trace(`Receive channel state is: ${readyState}`);
+  console.log(`Receive channel state is: ${readyState}`);
 }

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -87,7 +87,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -50,7 +50,7 @@ function createConnection() {
   bytesToSend = number * 1024 * 1024;
 
   localConnection = new RTCPeerConnection(servers);
-  trace('Created local peer connection object localConnection');
+  console.log('Created local peer connection object localConnection');
 
   const dataChannelParams = {ordered: false};
   if (orderedCheckbox.checked) {
@@ -59,7 +59,7 @@ function createConnection() {
 
   sendChannel = localConnection.createDataChannel('sendDataChannel', dataChannelParams);
   sendChannel.binaryType = 'arraybuffer';
-  trace('Created send data channel');
+  console.log('Created send data channel');
 
   sendChannel.onopen = onSendChannelStateChange;
   sendChannel.onclose = onSendChannelStateChange;
@@ -68,14 +68,14 @@ function createConnection() {
   localConnection.createOffer().then(gotDescription1, onCreateSessionDescriptionError);
 
   remoteConnection = remoteConnection = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object remoteConnection');
+  console.log('Created remote peer connection object remoteConnection');
 
   remoteConnection.onicecandidate = e => onIceCandidate(remoteConnection, e);
   remoteConnection.ondatachannel = receiveChannelCallback;
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function randomAsciiString(length) {
@@ -116,7 +116,7 @@ function sendGeneratedData() {
   let bufferFullThreshold = 5 * chunkSize;
   let usePolling = true;
   if (typeof sendChannel.bufferedAmountLowThreshold === 'number') {
-    trace('Using the bufferedamountlow event for flow control');
+    console.log('Using the bufferedamountlow event for flow control');
     usePolling = false;
 
     // Reduce the buffer fullness threshold, since we now have more efficient
@@ -135,21 +135,21 @@ function sendGeneratedData() {
 }
 
 function closeDataChannels() {
-  trace('Closing data channels');
+  console.log('Closing data channels');
   sendChannel.close();
-  trace(`Closed data channel with label: ${sendChannel.label}`);
+  console.log(`Closed data channel with label: ${sendChannel.label}`);
   receiveChannel.close();
-  trace(`Closed data channel with label: ${receiveChannel.label}`);
+  console.log(`Closed data channel with label: ${receiveChannel.label}`);
   localConnection.close();
   remoteConnection.close();
   localConnection = null;
   remoteConnection = null;
-  trace('Closed peer connections');
+  console.log('Closed peer connections');
 }
 
 function gotDescription1(desc) {
   localConnection.setLocalDescription(desc);
-  trace(`Offer from localConnection 
+  console.log(`Offer from localConnection 
 ${desc.sdp}`);
   remoteConnection.setRemoteDescription(desc);
   remoteConnection.createAnswer().then(
@@ -160,7 +160,7 @@ ${desc.sdp}`);
 
 function gotDescription2(desc) {
   remoteConnection.setLocalDescription(desc);
-  trace(`Answer from remoteConnection\n${desc.sdp}`);
+  console.log(`Answer from remoteConnection\n${desc.sdp}`);
   localConnection.setRemoteDescription(desc);
 }
 
@@ -178,21 +178,21 @@ function onIceCandidate(pc, event) {
       () => onAddIceCandidateSuccess(pc),
       err => onAddIceCandidateError(pc, err)
     );
-  trace(`${getName(pc)} ICE candidate: 
+  console.log(`${getName(pc)} ICE candidate: 
 ${event.candidate ?
     event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add Ice Candidate: ${error.toString()}`);
+  console.log(`Failed to add Ice Candidate: ${error.toString()}`);
 }
 
 function receiveChannelCallback(event) {
-  trace('Receive Channel Callback');
+  console.log('Receive Channel Callback');
   receiveChannel = event.channel;
   receiveChannel.binaryType = 'arraybuffer';
   receiveChannel.onmessage = onReceiveMessageCallback;
@@ -213,7 +213,7 @@ function onReceiveMessageCallback(event) {
 
 function onSendChannelStateChange() {
   const readyState = sendChannel.readyState;
-  trace(`Send channel state is: ${readyState}`);
+  console.log(`Send channel state is: ${readyState}`);
   if (readyState === 'open') {
     sendGeneratedData();
   }

--- a/src/content/datachannel/filetransfer/index.html
+++ b/src/content/datachannel/filetransfer/index.html
@@ -81,7 +81,6 @@
   </div>
 
   <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-  <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/datachannel/filetransfer/js/main.js
+++ b/src/content/datachannel/filetransfer/js/main.js
@@ -32,7 +32,7 @@ fileInput.addEventListener('change', handleFileInputChange, false);
 function handleFileInputChange() {
   var file = fileInput.files[0];
   if (!file) {
-    trace('No file chosen');
+    console.log('No file chosen');
   } else {
     createConnection();
   }
@@ -42,11 +42,11 @@ function createConnection() {
   var servers = null;
 
   localConnection = localConnection = new RTCPeerConnection(servers);
-  trace('Created local peer connection object localConnection');
+  console.log('Created local peer connection object localConnection');
 
   sendChannel = localConnection.createDataChannel('sendDataChannel');
   sendChannel.binaryType = 'arraybuffer';
-  trace('Created send data channel');
+  console.log('Created send data channel');
 
   sendChannel.onopen = onSendChannelStateChange;
   sendChannel.onclose = onSendChannelStateChange;
@@ -59,7 +59,7 @@ function createConnection() {
     onCreateSessionDescriptionError
   );
   remoteConnection = remoteConnection = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object remoteConnection');
+  console.log('Created remote peer connection object remoteConnection');
 
   remoteConnection.onicecandidate = function(e) {
     onIceCandidate(remoteConnection, e);
@@ -70,12 +70,12 @@ function createConnection() {
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace('Failed to create session description: ' + error.toString());
+  console.log('Failed to create session description: ' + error.toString());
 }
 
 function sendData() {
   var file = fileInput.files[0];
-  trace('File is ' + [file.name, file.size, file.type,
+  console.log('File is ' + [file.name, file.size, file.type,
       file.lastModifiedDate
   ].join(' '));
 
@@ -109,18 +109,18 @@ function sendData() {
 }
 
 function closeDataChannels() {
-  trace('Closing data channels');
+  console.log('Closing data channels');
   sendChannel.close();
-  trace('Closed data channel with label: ' + sendChannel.label);
+  console.log('Closed data channel with label: ' + sendChannel.label);
   if (receiveChannel) {
     receiveChannel.close();
-    trace('Closed data channel with label: ' + receiveChannel.label);
+    console.log('Closed data channel with label: ' + receiveChannel.label);
   }
   localConnection.close();
   remoteConnection.close();
   localConnection = null;
   remoteConnection = null;
-  trace('Closed peer connections');
+  console.log('Closed peer connections');
 
   // re-enable the file select
   fileInput.disabled = false;
@@ -128,7 +128,7 @@ function closeDataChannels() {
 
 function gotDescription1(desc) {
   localConnection.setLocalDescription(desc);
-  trace('Offer from localConnection \n' + desc.sdp);
+  console.log('Offer from localConnection \n' + desc.sdp);
   remoteConnection.setRemoteDescription(desc);
   remoteConnection.createAnswer().then(
     gotDescription2,
@@ -138,7 +138,7 @@ function gotDescription1(desc) {
 
 function gotDescription2(desc) {
   remoteConnection.setLocalDescription(desc);
-  trace('Answer from remoteConnection \n' + desc.sdp);
+  console.log('Answer from remoteConnection \n' + desc.sdp);
   localConnection.setRemoteDescription(desc);
 }
 
@@ -161,20 +161,20 @@ function onIceCandidate(pc, event) {
       onAddIceCandidateError(pc, err);
     }
   );
-  trace(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
+  console.log(getName(pc) + ' ICE candidate: \n' + (event.candidate ?
       event.candidate.candidate : '(null)'));
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace('Failed to add Ice Candidate: ' + error.toString());
+  console.log('Failed to add Ice Candidate: ' + error.toString());
 }
 
 function receiveChannelCallback(event) {
-  trace('Receive Channel Callback');
+  console.log('Receive Channel Callback');
   receiveChannel = event.channel;
   receiveChannel.binaryType = 'arraybuffer';
   receiveChannel.onmessage = onReceiveMessageCallback;
@@ -192,7 +192,7 @@ function receiveChannelCallback(event) {
 }
 
 function onReceiveMessageCallback(event) {
-  // trace('Received Message ' + event.data.byteLength);
+  // console.log('Received Message ' + event.data.byteLength);
   receiveBuffer.push(event.data);
   receivedSize += event.data.byteLength;
 
@@ -227,7 +227,7 @@ function onReceiveMessageCallback(event) {
 
 function onSendChannelStateChange() {
   var readyState = sendChannel.readyState;
-  trace('Send channel state is: ' + readyState);
+  console.log('Send channel state is: ' + readyState);
   if (readyState === 'open') {
     sendData();
   }
@@ -235,7 +235,7 @@ function onSendChannelStateChange() {
 
 function onReceiveChannelStateChange() {
   var readyState = receiveChannel.readyState;
-  trace('Receive channel state is: ' + readyState);
+  console.log('Receive channel state is: ' + readyState);
   if (readyState === 'open') {
     timestampStart = (new Date()).getTime();
     timestampPrev = timestampStart;

--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -80,7 +80,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/devices/multi/index.html
+++ b/src/content/devices/multi/index.html
@@ -87,7 +87,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/audio/index.html
+++ b/src/content/getusermedia/audio/index.html
@@ -50,7 +50,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js"></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/canvas/index.html
+++ b/src/content/getusermedia/canvas/index.html
@@ -50,7 +50,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/filter/index.html
+++ b/src/content/getusermedia/filter/index.html
@@ -95,7 +95,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/gum/index.html
+++ b/src/content/getusermedia/gum/index.html
@@ -52,7 +52,6 @@
   </div>
 
   <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-  <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -111,7 +111,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -70,7 +70,6 @@
 
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/soundmeter.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/audio/index.html
+++ b/src/content/peerconnection/audio/index.html
@@ -92,7 +92,6 @@
 </table>
 <hr>
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js"></script>
 <script src="../../../js/third_party/graph.js"></script>
 

--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -37,14 +37,14 @@ const offerOptions = {
 
 function gotStream(stream) {
   hangupButton.disabled = false;
-  trace('Received local stream');
+  console.log('Received local stream');
   localStream = stream;
   const audioTracks = localStream.getAudioTracks();
   if (audioTracks.length > 0) {
-    trace(`Using Audio device: ${audioTracks[0].label}`);
+    console.log(`Using Audio device: ${audioTracks[0].label}`);
   }
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));
-  trace('Adding Local Stream to peer connection');
+  console.log('Adding Local Stream to peer connection');
 
   pc1.createOffer(offerOptions)
     .then(gotDescription1, onCreateSessionDescriptionError);
@@ -59,22 +59,22 @@ function gotStream(stream) {
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function call() {
   callButton.disabled = true;
   codecSelector.disabled = true;
-  trace('Starting call');
+  console.log('Starting call');
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc2.ontrack = gotRemoteStream;
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   navigator.mediaDevices
     .getUserMedia({
       audio: true,
@@ -87,7 +87,7 @@ function call() {
 }
 
 function gotDescription1(desc) {
-  trace(`Offer from pc1\n${desc.sdp}`);
+  console.log(`Offer from pc1\n${desc.sdp}`);
   pc1.setLocalDescription(desc)
     .then(() => {
       desc.sdp = forceChosenAudioCodec(desc.sdp);
@@ -98,7 +98,7 @@ function gotDescription1(desc) {
 }
 
 function gotDescription2(desc) {
-  trace(`Answer from pc2\n${desc.sdp}`);
+  console.log(`Answer from pc2\n${desc.sdp}`);
   pc2.setLocalDescription(desc).then(() => {
     desc.sdp = forceChosenAudioCodec(desc.sdp);
     pc1.setRemoteDescription(desc).then(() => {}, onSetSessionDescriptionError);
@@ -106,7 +106,7 @@ function gotDescription2(desc) {
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   localStream.getTracks().forEach(track => track.stop());
   pc1.close();
   pc2.close();
@@ -120,7 +120,7 @@ function hangup() {
 function gotRemoteStream(e) {
   if (audio2.srcObject !== e.streams[0]) {
     audio2.srcObject = e.streams[0];
-    trace('Received remote stream');
+    console.log('Received remote stream');
   }
 }
 
@@ -138,19 +138,19 @@ function onIceCandidate(pc, event) {
       () => onAddIceCandidateSuccess(pc),
       err => onAddIceCandidateError(pc, err)
     );
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`Failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function forceChosenAudioCodec(sdp) {
@@ -164,11 +164,11 @@ function forceChosenAudioCodec(sdp) {
 function maybePreferCodec(sdp, type, dir, codec) {
   const str = `${type} ${dir} codec`;
   if (codec === '') {
-    trace(`No preference on ${str}.`);
+    console.log(`No preference on ${str}.`);
     return sdp;
   }
 
-  trace(`Prefer ${str}: ${codec}`);
+  console.log(`Prefer ${str}: ${codec}`);
 
   const sdpLines = sdp.split('\r\n');
 

--- a/src/content/peerconnection/bandwidth/index.html
+++ b/src/content/peerconnection/bandwidth/index.html
@@ -69,7 +69,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/third_party/graph.js"></script>
 

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -41,11 +41,11 @@ const offerOptions = {
 
 function gotStream(stream) {
   hangupButton.disabled = false;
-  trace('Received local stream');
+  console.log('Received local stream');
   localStream = stream;
   localVideo.srcObject = stream;
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));
-  trace('Adding Local Stream to peer connection');
+  console.log('Adding Local Stream to peer connection');
 
   pc1.createOffer(
     offerOptions
@@ -64,31 +64,31 @@ function gotStream(stream) {
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace('Failed to create session description: ' + error.toString());
+  console.log('Failed to create session description: ' + error.toString());
 }
 
 function call() {
   callButton.disabled = true;
   bandwidthSelector.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = onIceCandidate.bind(pc1);
 
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = onIceCandidate.bind(pc2);
   pc2.ontrack = gotRemoteStream;
 
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   navigator.mediaDevices.getUserMedia({video: true})
     .then(gotStream)
     .catch(e => alert('getUserMedia() error: ' + e.name));
 }
 
 function gotDescription1(desc) {
-  trace('Offer from pc1 \n' + desc.sdp);
+  console.log('Offer from pc1 \n' + desc.sdp);
   pc1.setLocalDescription(desc).then(
     () => {
       pc2.setRemoteDescription(desc)
@@ -101,7 +101,7 @@ function gotDescription1(desc) {
 function gotDescription2(desc) {
   pc2.setLocalDescription(desc).then(
     () => {
-      trace('Answer from pc2 \n' + desc.sdp);
+      console.log('Answer from pc2 \n' + desc.sdp);
       let p;
       if (maxBandwidth) {
         p = pc1.setRemoteDescription({
@@ -118,7 +118,7 @@ function gotDescription2(desc) {
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   localStream.getTracks().forEach(track => track.stop());
   pc1.close();
   pc2.close();
@@ -132,7 +132,7 @@ function hangup() {
 function gotRemoteStream(e) {
   if (remoteVideo.srcObject !== e.streams[0]) {
     remoteVideo.srcObject = e.streams[0];
-    trace('Received remote stream');
+    console.log('Received remote stream');
   }
 }
 
@@ -150,19 +150,19 @@ function onIceCandidate(event) {
     .then(onAddIceCandidateSuccess)
     .catch(onAddIceCandidateError);
 
-  trace(`${getName(this)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(this)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace('Failed to add ICE Candidate: ' + error.toString());
+  console.log('Failed to add ICE Candidate: ' + error.toString());
 }
 
 function onSetSessionDescriptionError(error) {
-  trace('Failed to set session description: ' + error.toString());
+  console.log('Failed to set session description: ' + error.toString());
 }
 
 // renegotiate bandwidth on the fly.
@@ -201,7 +201,7 @@ bandwidthSelector.onchange = () => {
           ? removeBandwidthRestriction(pc1.remoteDescription.sdp)
           : updateBandwidthRestriction(pc1.remoteDescription.sdp, bandwidth)
       };
-      trace('Applying bandwidth restriction to setRemoteDescription:\n' +
+      console.log('Applying bandwidth restriction to setRemoteDescription:\n' +
         desc.sdp);
       return pc1.setRemoteDescription(desc);
     })

--- a/src/content/peerconnection/constraints/index.html
+++ b/src/content/peerconnection/constraints/index.html
@@ -111,7 +111,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -51,7 +51,7 @@ function main() {
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   localPeerConnection.close();
   remotePeerConnection.close();
 
@@ -190,11 +190,11 @@ function createPeerConnection() {
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add Ice Candidate: ${error.toString()}`);
+  console.log(`Failed to add Ice Candidate: ${error.toString()}`);
 }
 
 function showRemoteStats(results) {

--- a/src/content/peerconnection/create-offer/index.html
+++ b/src/content/peerconnection/create-offer/index.html
@@ -72,7 +72,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/dtmf/index.html
+++ b/src/content/peerconnection/dtmf/index.html
@@ -101,7 +101,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -56,11 +56,11 @@ function main() {
 }
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   localStream = stream;
   const audioTracks = localStream.getAudioTracks();
   if (audioTracks.length > 0) {
-    trace(`Using Audio device: ${audioTracks[0].label}`);
+    console.log(`Using Audio device: ${audioTracks[0].label}`);
   }
   if (adapter.browserDetails.browser !== 'chrome' ||
     adapter.browserDetails.version >= 66) {
@@ -70,28 +70,28 @@ function gotStream(stream) {
     // chrome does not yet support addTrack + dtmf until M66.
     pc1.addStream(localStream);
   }
-  trace('Adding Local Stream to peer connection');
+  console.log('Adding Local Stream to peer connection');
   pc1
     .createOffer(offerOptions)
     .then(gotDescription1, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function call() {
-  trace('Starting call');
+  console.log('Starting call');
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc2.ontrack = gotRemoteStream;
 
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   navigator.mediaDevices
     .getUserMedia({
       audio: true,
@@ -107,7 +107,7 @@ function call() {
 
 function gotDescription1(desc) {
   pc1.setLocalDescription(desc);
-  trace(`Offer from pc1\n${desc.sdp}`);
+  console.log(`Offer from pc1\n${desc.sdp}`);
   pc2.setRemoteDescription(desc);
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
@@ -117,13 +117,13 @@ function gotDescription1(desc) {
 
 function gotDescription2(desc) {
   pc2.setLocalDescription(desc);
-  trace(`Answer from pc2: 
+  console.log(`Answer from pc2: 
 ${desc.sdp}`);
   pc1.setRemoteDescription(desc);
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   pc1.close();
   pc2.close();
   pc1 = null;
@@ -139,7 +139,7 @@ function hangup() {
 function gotRemoteStream(e) {
   if (audio.srcObject !== e.streams[0]) {
     audio.srcObject = e.streams[0];
-    trace('Received remote stream');
+    console.log('Received remote stream');
 
     if (!pc1.getSenders) {
       alert('This demo requires the RTCPeerConnection method getSenders() which is not support by this browser.');
@@ -148,7 +148,7 @@ function gotRemoteStream(e) {
     const senders = pc1.getSenders();
     let audioSender = senders.find(sender => sender.track && sender.track.kind === 'audio');
     if (!audioSender) {
-      trace('No local audio track to send DTMF with\n');
+      console.log('No local audio track to send DTMF with\n');
       return;
     }
     if (!audioSender.dtmf) {
@@ -157,7 +157,7 @@ function gotRemoteStream(e) {
     }
     dtmfSender = audioSender.dtmf;
     dtmfStatusDiv.textContent = 'DTMF available';
-    trace('Got DTMFSender\n');
+    console.log('Got DTMFSender\n');
     dtmfSender.ontonechange = dtmfOnToneChange;
   }
 }
@@ -177,20 +177,20 @@ function onIceCandidate(pc, event) {
       () => onAddIceCandidateSuccess(pc),
       err => onAddIceCandidateError(pc, err)
     );
-  trace(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success');
+  console.log('AddIceCandidate success');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add Ice Candidate: ${error.toString()}`);
+  console.log(`Failed to add Ice Candidate: ${error.toString()}`);
 }
 
 function dtmfOnToneChange(tone) {
   if (tone) {
-    trace(`Sent DTMF tone: ${tone.tone}`);
+    console.log(`Sent DTMF tone: ${tone.tone}`);
     sentTonesDiv.textContent += `${tone.tone} `;
   }
 }

--- a/src/content/peerconnection/multiple-relay/index.html
+++ b/src/content/peerconnection/multiple-relay/index.html
@@ -58,7 +58,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="../../../js/videopipe.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/multiple-relay/js/main.js
+++ b/src/content/peerconnection/multiple-relay/js/main.js
@@ -33,7 +33,7 @@ let localStream;
 let remoteStream;
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   video1.srcObject = stream;
   localStream = stream;
   callButton.disabled = false;
@@ -42,14 +42,14 @@ function gotStream(stream) {
 function gotremoteStream(stream) {
   remoteStream = stream;
   video2.srcObject = stream;
-  trace('Received remote stream');
-  trace(`${pipes.length} element(s) in chain`);
+  console.log('Received remote stream');
+  console.log(`${pipes.length} element(s) in chain`);
   statusDiv.textContent = `${pipes.length} element(s) in chain`;
   insertRelayButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   const options = audioCheckbox.checked ? {audio: true, video: true} : {audio: false, video: true};
   navigator.mediaDevices
@@ -57,7 +57,7 @@ function start() {
     .then(gotStream)
     .catch(function(e) {
       alert('getUserMedia() failed');
-      trace('getUserMedia() error: ', e);
+      console.log('getUserMedia() error: ', e);
     });
 }
 
@@ -65,7 +65,7 @@ function call() {
   callButton.disabled = true;
   insertRelayButton.disabled = false;
   hangupButton.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   pipes.push(new VideoPipe(localStream, gotremoteStream));
 }
 
@@ -75,7 +75,7 @@ function insertRelay() {
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   while (pipes.length > 0) {
     const pipe = pipes.pop();
     pipe.close();

--- a/src/content/peerconnection/multiple/index.html
+++ b/src/content/peerconnection/multiple/index.html
@@ -59,7 +59,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -31,14 +31,14 @@ const offerOptions = {
 };
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   video1.srcObject = stream;
   window.localStream = stream;
   callButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   navigator.mediaDevices
     .getUserMedia({
@@ -52,14 +52,14 @@ function start() {
 function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
-  trace('Starting calls');
+  console.log('Starting calls');
   const audioTracks = window.localStream.getAudioTracks();
   const videoTracks = window.localStream.getVideoTracks();
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   if (videoTracks.length > 0) {
-    trace(`Using video device: ${videoTracks[0].label}`);
+    console.log(`Using video device: ${videoTracks[0].label}`);
   }
   // Create an RTCPeerConnection via the polyfill.
   const servers = null;
@@ -68,34 +68,34 @@ function call() {
   pc1Remote.ontrack = gotRemoteStream1;
   pc1Local.onicecandidate = iceCallback1Local;
   pc1Remote.onicecandidate = iceCallback1Remote;
-  trace('pc1: created local and remote peer connection objects');
+  console.log('pc1: created local and remote peer connection objects');
 
   pc2Local = new RTCPeerConnection(servers);
   pc2Remote = new RTCPeerConnection(servers);
   pc2Remote.ontrack = gotRemoteStream2;
   pc2Local.onicecandidate = iceCallback2Local;
   pc2Remote.onicecandidate = iceCallback2Remote;
-  trace('pc2: created local and remote peer connection objects');
+  console.log('pc2: created local and remote peer connection objects');
 
   window.localStream.getTracks().forEach(track => pc1Local.addTrack(track, window.localStream));
-  trace('Adding local stream to pc1Local');
+  console.log('Adding local stream to pc1Local');
   pc1Local
     .createOffer(offerOptions)
     .then(gotDescription1Local, onCreateSessionDescriptionError);
 
   window.localStream.getTracks().forEach(track => pc2Local.addTrack(track, window.localStream));
-  trace('Adding local stream to pc2Local');
+  console.log('Adding local stream to pc2Local');
   pc2Local.createOffer(offerOptions)
     .then(gotDescription2Local, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function gotDescription1Local(desc) {
   pc1Local.setLocalDescription(desc);
-  trace(`Offer from pc1Local\n${desc.sdp}`);
+  console.log(`Offer from pc1Local\n${desc.sdp}`);
   pc1Remote.setRemoteDescription(desc);
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
@@ -105,13 +105,13 @@ function gotDescription1Local(desc) {
 
 function gotDescription1Remote(desc) {
   pc1Remote.setLocalDescription(desc);
-  trace(`Answer from pc1Remote\n${desc.sdp}`);
+  console.log(`Answer from pc1Remote\n${desc.sdp}`);
   pc1Local.setRemoteDescription(desc);
 }
 
 function gotDescription2Local(desc) {
   pc2Local.setLocalDescription(desc);
-  trace(`Offer from pc2Local\n${desc.sdp}`);
+  console.log(`Offer from pc2Local\n${desc.sdp}`);
   pc2Remote.setRemoteDescription(desc);
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
@@ -121,12 +121,12 @@ function gotDescription2Local(desc) {
 
 function gotDescription2Remote(desc) {
   pc2Remote.setLocalDescription(desc);
-  trace(`Answer from pc2Remote\n${desc.sdp}`);
+  console.log(`Answer from pc2Remote\n${desc.sdp}`);
   pc2Local.setRemoteDescription(desc);
 }
 
 function hangup() {
-  trace('Ending calls');
+  console.log('Ending calls');
   pc1Local.close();
   pc1Remote.close();
   pc2Local.close();
@@ -140,14 +140,14 @@ function hangup() {
 function gotRemoteStream1(e) {
   if (video2.srcObject !== e.streams[0]) {
     video2.srcObject = e.streams[0];
-    trace('pc1: received remote stream');
+    console.log('pc1: received remote stream');
   }
 }
 
 function gotRemoteStream2(e) {
   if (video3.srcObject !== e.streams[0]) {
     video3.srcObject = e.streams[0];
-    trace('pc2: received remote stream');
+    console.log('pc2: received remote stream');
   }
 }
 
@@ -170,13 +170,13 @@ function iceCallback2Remote(event) {
 function handleCandidate(candidate, dest, prefix, type) {
   dest.addIceCandidate(candidate)
     .then(onAddIceCandidateSuccess, onAddIceCandidateError);
-  trace(`${prefix}New ${type} ICE candidate: ${candidate ? candidate.candidate : '(null)'}`);
+  console.log(`${prefix}New ${type} ICE candidate: ${candidate ? candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add ICE candidate: ${error.toString()}`);
+  console.log(`Failed to add ICE candidate: ${error.toString()}`);
 }

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -8,10 +8,6 @@
 
 'use strict';
 
-function console.log(msg, ...args) {
-  console.log(msg, args);
-}
-
 document.addEventListener('DOMContentLoaded', init);
 
 async function init() {

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -8,19 +8,19 @@
 
 'use strict';
 
-function trace(msg, ...args) {
+function console.log(msg, ...args) {
   console.log(msg, args);
 }
 
 document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
-  trace('DOMContentLoaded');
+  console.log('DOMContentLoaded');
   try {
     const enumerateDevices = await navigator.mediaDevices.enumerateDevices();
     gotSources(enumerateDevices);
   } catch (e) {
-    trace(e);
+    console.log(e);
   }
 
   const getMediaButton = document.querySelector('button#getMedia');
@@ -87,7 +87,7 @@ async function init() {
         }
         videoSelect.appendChild(option);
       } else {
-        trace('unknown', JSON.stringify(sourceInfos[i]));
+        console.log('unknown', JSON.stringify(sourceInfos[i]));
       }
     }
   }
@@ -101,9 +101,9 @@ async function init() {
       localStream.getTracks().forEach(track => track.stop());
     }
     const audioSource = audioSelect.value;
-    trace(`Selected audio source: ${audioSource}`);
+    console.log(`Selected audio source: ${audioSource}`);
     const videoSource = videoSelect.value;
-    trace(`Selected video source: ${videoSource}`);
+    console.log(`Selected video source: ${videoSource}`);
 
     const constraints = {
       audio: {
@@ -117,17 +117,17 @@ async function init() {
         }]
       }
     };
-    trace('Requested local stream');
+    console.log('Requested local stream');
     try {
       const userMedia = await navigator.mediaDevices.getUserMedia(constraints);
       gotStream(userMedia);
     } catch (e) {
-      trace('navigator.getUserMedia error: ', e);
+      console.log('navigator.getUserMedia error: ', e);
     }
   }
 
   function gotStream(stream) {
-    trace('Received local stream');
+    console.log('Received local stream');
     localVideo.srcObject = stream;
     localStream = stream;
   }
@@ -139,21 +139,21 @@ async function init() {
     setOfferButton.disabled = false;
     setAnswerButton.disabled = false;
     hangupButton.disabled = false;
-    trace('Starting call');
+    console.log('Starting call');
     const videoTracks = localStream.getVideoTracks();
     const audioTracks = localStream.getAudioTracks();
 
     if (videoTracks.length > 0) {
-      trace(`Using video device: ${videoTracks[0].label}`);
+      console.log(`Using video device: ${videoTracks[0].label}`);
     }
 
     if (audioTracks.length > 0) {
-      trace(`Using audio device: ${audioTracks[0].label}`);
+      console.log(`Using audio device: ${audioTracks[0].label}`);
     }
     const servers = null;
 
     localPeerConnection = new RTCPeerConnection(servers);
-    trace('Created local peer connection object localPeerConnection');
+    console.log('Created local peer connection object localPeerConnection');
     localPeerConnection.onicecandidate = e => onIceCandidate(localPeerConnection, e);
     sendChannel = localPeerConnection.createDataChannel('sendDataChannel', dataChannelOptions);
     sendChannel.onopen = onSendChannelStateChange;
@@ -161,22 +161,22 @@ async function init() {
     sendChannel.onerror = onSendChannelStateChange;
 
     remotePeerConnection = new RTCPeerConnection(servers);
-    trace('Created remote peer connection object remotePeerConnection');
+    console.log('Created remote peer connection object remotePeerConnection');
     remotePeerConnection.onicecandidate = e => onIceCandidate(remotePeerConnection, e);
     remotePeerConnection.ontrack = gotRemoteStream;
     remotePeerConnection.ondatachannel = receiveChannelCallback;
 
     localStream.getTracks()
       .forEach(track => localPeerConnection.addTrack(track, localStream));
-    trace('Adding Local Stream to peer connection');
+    console.log('Adding Local Stream to peer connection');
   }
 
   function onSetSessionDescriptionSuccess() {
-    trace('Set session description success.');
+    console.log('Set session description success.');
   }
 
   function onSetSessionDescriptionError(error) {
-    trace(`Failed to set session description: ${error.toString()}`);
+    console.log(`Failed to set session description: ${error.toString()}`);
   }
 
   async function createOffer() {
@@ -189,7 +189,7 @@ async function init() {
   }
 
   function onCreateSessionDescriptionError(error) {
-    trace(`Failed to create session description: ${error.toString()}`);
+    console.log(`Failed to create session description: ${error.toString()}`);
   }
 
   async function setOffer() {
@@ -198,7 +198,7 @@ async function init() {
       type: 'offer',
       sdp: sdp
     };
-    trace(`Modified Offer from localPeerConnection\n${sdp}`);
+    console.log(`Modified Offer from localPeerConnection\n${sdp}`);
 
     try {
       // eslint-disable-next-line no-unused-vars
@@ -249,7 +249,7 @@ async function init() {
       onSetSessionDescriptionError(e);
     }
 
-    trace(`Modified Answer from remotePeerConnection\n${sdp}`);
+    console.log(`Modified Answer from remotePeerConnection\n${sdp}`);
     try {
       // eslint-disable-next-line no-unused-vars
       const ignore = await localPeerConnection.setRemoteDescription(answer);
@@ -267,14 +267,14 @@ async function init() {
   function sendData() {
     if (sendChannel.readyState === 'open') {
       sendChannel.send(dataChannelCounter);
-      trace(`DataChannel send counter: ${dataChannelCounter}`);
+      console.log(`DataChannel send counter: ${dataChannelCounter}`);
       dataChannelCounter++;
     }
   }
 
   function hangup() {
     remoteVideo.srcObject = null;
-    trace('Ending call');
+    console.log('Ending call');
     localStream.getTracks().forEach(track => track.stop());
     sendChannel.close();
     if (receiveChannel) {
@@ -298,7 +298,7 @@ async function init() {
   function gotRemoteStream(e) {
     if (remoteVideo.srcObject !== e.streams[0]) {
       remoteVideo.srcObject = e.streams[0];
-      trace('Received remote stream');
+      console.log('Received remote stream');
     }
   }
 
@@ -319,19 +319,19 @@ async function init() {
       onAddIceCandidateError(pc, e);
     }
 
-    trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+    console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
   }
 
   function onAddIceCandidateSuccess() {
-    trace('AddIceCandidate success.');
+    console.log('AddIceCandidate success.');
   }
 
   function onAddIceCandidateError(error) {
-    trace(`Failed to add Ice Candidate: ${error.toString()}`);
+    console.log(`Failed to add Ice Candidate: ${error.toString()}`);
   }
 
   function receiveChannelCallback(event) {
-    trace('Receive Channel Callback');
+    console.log('Receive Channel Callback');
     receiveChannel = event.channel;
     receiveChannel.onmessage = onReceiveMessageCallback;
     receiveChannel.onopen = onReceiveChannelStateChange;
@@ -340,12 +340,12 @@ async function init() {
 
   function onReceiveMessageCallback(event) {
     dataChannelDataReceived = event.data;
-    trace(`DataChannel receive counter: ${dataChannelDataReceived}`);
+    console.log(`DataChannel receive counter: ${dataChannelDataReceived}`);
   }
 
   function onSendChannelStateChange() {
     const readyState = sendChannel.readyState;
-    trace(`Send channel state is: ${readyState}`);
+    console.log(`Send channel state is: ${readyState}`);
     if (readyState === 'open') {
       sendDataLoop = setInterval(sendData, 1000);
     } else {
@@ -355,6 +355,6 @@ async function init() {
 
   function onReceiveChannelStateChange() {
     const readyState = receiveChannel.readyState;
-    trace(`Receive channel state is: ${readyState}`);
+    console.log(`Receive channel state is: ${readyState}`);
   }
 }

--- a/src/content/peerconnection/old-new-stats/index.html
+++ b/src/content/peerconnection/old-new-stats/index.html
@@ -106,7 +106,6 @@
   </div>
 
   <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-  <script src="../../../js/common.js"></script>
   <script src="js/main.js"></script>
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/peerconnection/old-new-stats/js/main.js
+++ b/src/content/peerconnection/old-new-stats/js/main.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', async() => {
   // let timestampPrev;
 
   function hangup() {
-    trace('Ending call');
+    console.log('Ending call');
     localPeerConnection.close();
     remotePeerConnection.close();
     localPeerConnection = null;
@@ -76,14 +76,14 @@ document.addEventListener('DOMContentLoaded', async() => {
     } catch (e) {
       const message = `getUserMedia error: ${e.name}\nPermissionDeniedError may mean invalid constraints.`;
       alert(message);
-      trace(message);
+      console.log(message);
       getMediaButton.disabled = false;
     }
   }
 
   function gotStream(stream) {
     connectButton.disabled = false;
-    trace('GetUserMedia succeeded');
+    console.log('GetUserMedia succeeded');
     localStream = stream;
     localVideo.srcObject = stream;
   }
@@ -122,7 +122,7 @@ document.addEventListener('DOMContentLoaded', async() => {
 
   function displayGetUserMediaConstraints() {
     const constraints = getUserMediaConstraints();
-    trace('getUserMedia constraints', constraints);
+    console.log('getUserMedia constraints', constraints);
     getUserMediaConstraintsDiv.textContent = JSON.stringify(constraints, null, '    ');
   }
 
@@ -135,16 +135,16 @@ document.addEventListener('DOMContentLoaded', async() => {
     localPeerConnection = new RTCPeerConnection(null);
     remotePeerConnection = new RTCPeerConnection(null);
     localStream.getTracks().forEach(track => localPeerConnection.addTrack(track, localStream));
-    trace('localPeerConnection creating offer');
+    console.log('localPeerConnection creating offer');
     localPeerConnection.onnegotiationeeded = () => {
-      trace('Negotiation needed - localPeerConnection');
+      console.log('Negotiation needed - localPeerConnection');
     };
     remotePeerConnection.onnegotiationeeded = () => {
-      trace('Negotiation needed - remotePeerConnection');
+      console.log('Negotiation needed - remotePeerConnection');
     };
 
     localPeerConnection.onicecandidate = async event => {
-      trace('Candidate localPeerConnection');
+      console.log('Candidate localPeerConnection');
       try {
         // eslint-disable-next-line no-unused-vars
         const ignore = await remotePeerConnection.addIceCandidate(event.candidate);
@@ -154,7 +154,7 @@ document.addEventListener('DOMContentLoaded', async() => {
       }
     };
     remotePeerConnection.onicecandidate = async event => {
-      trace('Candidate remotePeerConnection');
+      console.log('Candidate remotePeerConnection');
       try {
         // eslint-disable-next-line no-unused-vars
         const ignore = await localPeerConnection.addIceCandidate(event.candidate);
@@ -165,32 +165,32 @@ document.addEventListener('DOMContentLoaded', async() => {
     };
     remotePeerConnection.ontrack = e => {
       if (remoteVideo.srcObject !== e.streams[0]) {
-        trace('remotePeerConnection got stream');
+        console.log('remotePeerConnection got stream');
         remoteVideo.srcObject = e.streams[0];
       }
     };
 
     try {
       const offer = await localPeerConnection.createOffer();
-      trace('localPeerConnection offering');
+      console.log('localPeerConnection offering');
       localPeerConnection.setLocalDescription(offer);
       remotePeerConnection.setRemoteDescription(offer);
 
       const answer = await remotePeerConnection.createAnswer();
-      trace('remotePeerConnection answering');
+      console.log('remotePeerConnection answering');
       remotePeerConnection.setLocalDescription(answer);
       localPeerConnection.setRemoteDescription(answer);
     } catch (e) {
-      trace(e);
+      console.log(e);
     }
   }
 
   function onAddIceCandidateSuccess() {
-    trace('AddIceCandidate success.');
+    console.log('AddIceCandidate success.');
   }
 
   function onAddIceCandidateError(error) {
-    trace('Failed to add Ice Candidate: ' + error.toString());
+    console.log('Failed to add Ice Candidate: ' + error.toString());
   }
 
   // Display statistics
@@ -211,10 +211,10 @@ document.addEventListener('DOMContentLoaded', async() => {
           const statsString = dumpStats(results);
           senderStatsDiv.innerHTML = '<h2>New stats</h2>' + statsString;
         }, err => {
-          trace(err);
+          console.log(err);
         });
     } else {
-      trace('Not connected yet');
+      console.log('Not connected yet');
     }
     // Collect some stats from the video tags.
     if (localVideo.videoWidth) {
@@ -246,9 +246,9 @@ document.addEventListener('DOMContentLoaded', async() => {
 
   function dumpOldStats(results) {
     let statsString = '';
-    trace(JSON.stringify(results));
+    console.log(JSON.stringify(results));
     results.result().forEach(res => {
-      trace(JSON.stringify(res));
+      console.log(JSON.stringify(res));
       statsString += '<h3>Report type=';
       statsString += res.type;
       statsString += '</h3>\n';

--- a/src/content/peerconnection/pc1/index.html
+++ b/src/content/peerconnection/pc1/index.html
@@ -65,7 +65,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -22,20 +22,20 @@ const localVideo = document.getElementById('localVideo');
 const remoteVideo = document.getElementById('remoteVideo');
 
 localVideo.addEventListener('loadedmetadata', function() {
-  trace(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.addEventListener('loadedmetadata', function() {
-  trace(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.onresize = () => {
-  trace(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
+  console.log(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
   // We'll use the first onsize callback as an indication that video has started
   // playing out.
   if (startTime) {
     const elapsedTime = window.performance.now() - startTime;
-    trace('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
+    console.log('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
     startTime = null;
   }
 };
@@ -57,14 +57,14 @@ function getOtherPc(pc) {
 }
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   localVideo.srcObject = stream;
   localStream = stream;
   callButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   navigator.mediaDevices
     .getUserMedia({
@@ -78,46 +78,46 @@ function start() {
 function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   startTime = window.performance.now();
   const videoTracks = localStream.getVideoTracks();
   const audioTracks = localStream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using video device: ${videoTracks[0].label}`);
+    console.log(`Using video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc1.oniceconnectionstatechange = e => onIceStateChange(pc1, e);
   pc2.oniceconnectionstatechange = e => onIceStateChange(pc2, e);
   pc2.ontrack = gotRemoteStream;
 
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));
-  trace('Added local stream to pc1');
+  console.log('Added local stream to pc1');
 
-  trace('pc1 createOffer start');
+  console.log('pc1 createOffer start');
   pc1.createOffer(offerOptions).then(onCreateOfferSuccess, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function onCreateOfferSuccess(desc) {
-  trace(`Offer from pc1
+  console.log(`Offer from pc1
 ${desc.sdp}`);
-  trace('pc1 setLocalDescription start');
+  console.log('pc1 setLocalDescription start');
   pc1.setLocalDescription(desc).then(() => onSetLocalSuccess(pc1), onSetSessionDescriptionError);
-  trace('pc2 setRemoteDescription start');
+  console.log('pc2 setRemoteDescription start');
   pc2.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc2 createAnswer start');
+  console.log('pc2 createAnswer start');
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
@@ -125,55 +125,55 @@ ${desc.sdp}`);
 }
 
 function onSetLocalSuccess(pc) {
-  trace(`${getName(pc)} setLocalDescription complete`);
+  console.log(`${getName(pc)} setLocalDescription complete`);
 }
 
 function onSetRemoteSuccess(pc) {
-  trace(`${getName(pc)} setRemoteDescription complete`);
+  console.log(`${getName(pc)} setRemoteDescription complete`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function gotRemoteStream(e) {
   if (remoteVideo.srcObject !== e.streams[0]) {
     remoteVideo.srcObject = e.streams[0];
-    trace('pc2 received remote stream');
+    console.log('pc2 received remote stream');
   }
 }
 
 function onCreateAnswerSuccess(desc) {
-  trace(`Answer from pc2:\n${desc.sdp}`);
-  trace('pc2 setLocalDescription start');
+  console.log(`Answer from pc2:\n${desc.sdp}`);
+  console.log('pc2 setLocalDescription start');
   pc2.setLocalDescription(desc).then(() => onSetLocalSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc1 setRemoteDescription start');
+  console.log('pc1 setRemoteDescription start');
   pc1.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc1), onSetSessionDescriptionError);
 }
 
 function onIceCandidate(pc, event) {
   getOtherPc(pc).addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess(pc) {
-  trace(`${getName(pc)} addIceCandidate success`);
+  console.log(`${getName(pc)} addIceCandidate success`);
 }
 
 function onAddIceCandidateError(pc, error) {
-  trace(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onIceStateChange(pc, event) {
   if (pc) {
-    trace(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
+    console.log(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
     console.log('ICE state change event: ', event);
   }
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   pc1.close();
   pc2.close();
   pc1 = null;

--- a/src/content/peerconnection/pr-answer/index.html
+++ b/src/content/peerconnection/pr-answer/index.html
@@ -50,7 +50,6 @@
     <p>View the console to see logging and to inspect the <code>MediaStream</code> object <code>localStream</code>.</p>
 </div>
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>
 </body>

--- a/src/content/peerconnection/pr-answer/js/main.js
+++ b/src/content/peerconnection/pr-answer/js/main.js
@@ -31,7 +31,7 @@ const offerOptions = {
 };
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   vid1.srcObject = stream;
   localstream = stream;
   callButton.disabled = false;
@@ -49,48 +49,48 @@ function start() {
   callButton.disabled = true;
   acceptButton.disabled = false;
   hangUpButton.disabled = false;
-  trace('Starting Call');
+  console.log('Starting Call');
   const videoTracks = localstream.getVideoTracks();
   const audioTracks = localstream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using Video device: ${videoTracks[0].label}`);
+    console.log(`Using Video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using Audio device: ${audioTracks[0].label}`);
+    console.log(`Using Audio device: ${audioTracks[0].label}`);
   }
 
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc2.ontrack = gotRemoteStream;
 
   localstream.getTracks().forEach(track => pc1.addTrack(track, localstream));
-  trace('Adding Local Stream to peer connection');
+  console.log('Adding Local Stream to peer connection');
 
   pc1.createOffer(offerOptions).then(gotDescription1, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
   stop();
 }
 
 function onCreateAnswerError(error) {
-  trace(`Failed to set createAnswer: ${error.toString()}`);
+  console.log(`Failed to set createAnswer: ${error.toString()}`);
   stop();
 }
 
 function onSetLocalDescriptionError(error) {
-  trace(`Failed to set setLocalDescription: ${error.toString()}`);
+  console.log(`Failed to set setLocalDescription: ${error.toString()}`);
   stop();
 }
 
 function onSetLocalDescriptionSuccess() {
-  trace('localDescription success.');
+  console.log('localDescription success.');
 }
 
 function gotDescription1(desc) {
@@ -98,7 +98,7 @@ function gotDescription1(desc) {
     onSetLocalDescriptionSuccess,
     onSetLocalDescriptionError
   );
-  trace(`Offer from pc1\n${desc.sdp}`);
+  console.log(`Offer from pc1\n${desc.sdp}`);
   pc2.setRemoteDescription(desc);
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
@@ -111,7 +111,7 @@ function gotDescription2(desc) {
   desc.sdp = desc.sdp.replace(/a=recvonly/g, 'a=inactive');
   desc.type = 'pranswer';
   pc2.setLocalDescription(desc).then(onSetLocalDescriptionSuccess, onSetLocalDescriptionError);
-  trace(`Pranswer from pc2\n${desc.sdp}`);
+  console.log(`Pranswer from pc2\n${desc.sdp}`);
   pc1.setRemoteDescription(desc);
 }
 
@@ -120,7 +120,7 @@ function gotDescription3(desc) {
   desc.sdp = desc.sdp.replace(/a=inactive/g, 'a=recvonly');
   desc.type = 'answer';
   pc2.setLocalDescription(desc).then(onSetLocalDescriptionSuccess, onSetLocalDescriptionError);
-  trace(`Answer from pc2\n${desc.sdp}`);
+  console.log(`Answer from pc2\n${desc.sdp}`);
   pc1.setRemoteDescription(desc);
 }
 
@@ -131,7 +131,7 @@ function accept() {
 }
 
 function stop() {
-  trace('Ending Call' + '\n\n');
+  console.log('Ending Call' + '\n\n');
   pc1.close();
   pc2.close();
   pc1 = null;
@@ -144,7 +144,7 @@ function stop() {
 function gotRemoteStream(e) {
   if (vid2.srcObject !== e.streams[0]) {
     vid2.srcObject = e.streams[0];
-    trace('Received remote stream');
+    console.log('Received remote stream');
   }
 }
 
@@ -160,13 +160,13 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
     .addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add Ice Candidate: ${error.toString()}`);
+  console.log(`Failed to add Ice Candidate: ${error.toString()}`);
 }

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -71,7 +71,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/restart-ice/js/main.js
+++ b/src/content/peerconnection/restart-ice/js/main.js
@@ -25,20 +25,20 @@ const localVideo = document.getElementById('localVideo');
 const remoteVideo = document.getElementById('remoteVideo');
 
 localVideo.addEventListener('loadedmetadata', function() {
-  trace(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.addEventListener('loadedmetadata', function() {
-  trace(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.onresize = () => {
-  trace(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
+  console.log(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
   // We'll use the first onsize callback as an indication that video has started
   // playing out.
   if (startTime) {
     const elapsedTime = window.performance.now() - startTime;
-    trace('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
+    console.log('Setup time: ' + elapsedTime.toFixed(3) + 'ms');
     startTime = null;
     // Have run these functions again in order to get the getStats() reports
     // with type candidatePair and populate the candidate id
@@ -65,14 +65,14 @@ function getOtherPc(pc) {
 }
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   localVideo.srcObject = stream;
   localStream = stream;
   callButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   navigator.mediaDevices
     .getUserMedia({
@@ -87,29 +87,29 @@ function start() {
 function restart() {
   restartButton.disabled = true;
   offerOptions.iceRestart = true;
-  trace('pc1 createOffer restart');
+  console.log('pc1 createOffer restart');
   pc1.createOffer(offerOptions).then(onCreateOfferSuccess, onCreateSessionDescriptionError);
 }
 
 function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   startTime = window.performance.now();
   const videoTracks = localStream.getVideoTracks();
   const audioTracks = localStream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using video device: ${videoTracks[0].label}`);
+    console.log(`Using video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc1.oniceconnectionstatechange = e => {
     onIceStateChange(pc1, e);
@@ -122,23 +122,23 @@ function call() {
 
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream)
   );
-  trace('Added local stream to pc1');
+  console.log('Added local stream to pc1');
 
-  trace('pc1 createOffer start');
+  console.log('pc1 createOffer start');
   pc1.createOffer(offerOptions).then(onCreateOfferSuccess, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function onCreateOfferSuccess(desc) {
-  trace(`Offer from pc1\n${desc.sdp}`);
-  trace('pc1 setLocalDescription start');
+  console.log(`Offer from pc1\n${desc.sdp}`);
+  console.log('pc1 setLocalDescription start');
   pc1.setLocalDescription(desc).then(() => onSetLocalSuccess(pc1), onSetSessionDescriptionError);
-  trace('pc2 setRemoteDescription start');
+  console.log('pc2 setRemoteDescription start');
   pc2.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc2 createAnswer start');
+  console.log('pc2 createAnswer start');
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
@@ -146,29 +146,29 @@ function onCreateOfferSuccess(desc) {
 }
 
 function onSetLocalSuccess(pc) {
-  trace(`${getName(pc)} setLocalDescription complete`);
+  console.log(`${getName(pc)} setLocalDescription complete`);
 }
 
 function onSetRemoteSuccess(pc) {
-  trace(`${getName(pc)} setRemoteDescription complete`);
+  console.log(`${getName(pc)} setRemoteDescription complete`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function gotRemoteStream(e) {
   if (remoteVideo.srcObject !== e.streams[0]) {
     remoteVideo.srcObject = e.streams[0];
-    trace('pc2 received remote stream');
+    console.log('pc2 received remote stream');
   }
 }
 
 function onCreateAnswerSuccess(desc) {
-  trace(`Answer from pc2:\n${desc.sdp}`);
-  trace('pc2 setLocalDescription start');
+  console.log(`Answer from pc2:\n${desc.sdp}`);
+  console.log('pc2 setLocalDescription start');
   pc2.setLocalDescription(desc).then(() => onSetLocalSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc1 setRemoteDescription start');
+  console.log('pc1 setRemoteDescription start');
   pc1.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc1), onSetSessionDescriptionError);
 }
 
@@ -176,20 +176,20 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
     .addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess(pc) {
-  trace(`${getName(pc)} addIceCandidate success`);
+  console.log(`${getName(pc)} addIceCandidate success`);
 }
 
 function onAddIceCandidateError(pc, error) {
-  trace(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onIceStateChange(pc, event) {
   if (pc) {
-    trace(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
+    console.log(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
     console.log('ICE state change event: ', event);
     // TODO: get rid of this in favor of http://w3c.github.io/webrtc-pc/#widl-RTCIceTransport-onselectedcandidatepairchange
     if (pc.iceConnectionState === 'connected' ||
@@ -235,7 +235,7 @@ function checkStats(pc) {
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   pc1.close();
   pc2.close();
   pc1 = null;

--- a/src/content/peerconnection/states/index.html
+++ b/src/content/peerconnection/states/index.html
@@ -79,7 +79,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/states/js/main.js
+++ b/src/content/peerconnection/states/js/main.js
@@ -36,14 +36,14 @@ const offerOptions = {
 };
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   video1.srcObject = stream;
   localstream = stream;
   callButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   navigator.mediaDevices
     .getUserMedia({
@@ -57,19 +57,19 @@ function start() {
 function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   const videoTracks = localstream.getVideoTracks();
   const audioTracks = localstream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using Video device: ${videoTracks[0].label}`);
+    console.log(`Using Video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using Audio device: ${audioTracks[0].label}`);
+    console.log(`Using Audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
 
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1StateDiv.textContent = pc1.signalingState || pc1.readyState;
   pc1.onsignalingstatechange = stateCallback1;
 
@@ -78,7 +78,7 @@ function call() {
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
 
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2StateDiv.textContent = pc2.signalingState || pc2.readyState;
   pc2.onsignalingstatechange = stateCallback2;
 
@@ -87,29 +87,29 @@ function call() {
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc2.ontrack = gotRemoteStream;
   localstream.getTracks().forEach(track => pc1.addTrack(track, localstream));
-  trace('Adding Local Stream to peer connection');
+  console.log('Adding Local Stream to peer connection');
   pc1.createOffer(offerOptions).then(gotDescription1, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function gotDescription1(description) {
   pc1.setLocalDescription(description);
-  trace(`Offer from pc1:\n${description.sdp}`);
+  console.log(`Offer from pc1:\n${description.sdp}`);
   pc2.setRemoteDescription(description);
   pc2.createAnswer().then(gotDescription2, onCreateSessionDescriptionError);
 }
 
 function gotDescription2(description) {
   pc2.setLocalDescription(description);
-  trace(`Answer from pc2\n${description.sdp}`);
+  console.log(`Answer from pc2\n${description.sdp}`);
   pc1.setRemoteDescription(description);
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   pc1.close();
   pc2.close();
   pc1StateDiv.textContent += ` => ${pc1.signalingState}` || pc1.readyState;
@@ -125,7 +125,7 @@ function hangup() {
 function gotRemoteStream(e) {
   if (video2.srcObject !== e.streams[0]) {
     video2.srcObject = e.streams[0];
-    trace('Got remote stream');
+    console.log('Got remote stream');
   }
 }
 
@@ -133,7 +133,7 @@ function stateCallback1() {
   let state;
   if (pc1) {
     state = pc1.signalingState || pc1.readyState;
-    trace(`pc1 state change callback, state: ${state}`);
+    console.log(`pc1 state change callback, state: ${state}`);
     pc1StateDiv.textContent += ` => ${state}`;
   }
 }
@@ -142,7 +142,7 @@ function stateCallback2() {
   let state;
   if (pc2) {
     state = pc2.signalingState || pc2.readyState;
-    trace(`pc2 state change callback, state: ${state}`);
+    console.log(`pc2 state change callback, state: ${state}`);
     pc2StateDiv.textContent += ` => ${state}`;
   }
 }
@@ -151,7 +151,7 @@ function iceStateCallback1() {
   let iceState;
   if (pc1) {
     iceState = pc1.iceConnectionState;
-    trace(`pc1 ICE connection state change callback, state: ${iceState}`);
+    console.log(`pc1 ICE connection state change callback, state: ${iceState}`);
     pc1IceStateDiv.textContent += ` => ${iceState}`;
   }
 }
@@ -160,7 +160,7 @@ function iceStateCallback2() {
   let iceState;
   if (pc2) {
     iceState = pc2.iceConnectionState;
-    trace(`pc2 ICE connection state change callback, state: ${iceState}`);
+    console.log(`pc2 ICE connection state change callback, state: ${iceState}`);
     pc2IceStateDiv.textContent += ` => ${iceState}`;
   }
 }
@@ -177,13 +177,13 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
     .addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
-  trace(`Failed to add Ice Candidate: ${error.toString()}`);
+  console.log(`Failed to add Ice Candidate: ${error.toString()}`);
 }

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -135,7 +135,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -148,7 +148,7 @@ function start() {
   // Whether we gather IPv6 candidates.
   // Whether we only gather a single set of candidates for RTP and RTCP.
 
-  trace(`Creating new PeerConnection with config=${JSON.stringify(config)}`);
+  console.log(`Creating new PeerConnection with config=${JSON.stringify(config)}`);
   pc = new RTCPeerConnection(config);
   pc.onicecandidate = iceCallback;
   pc.onicegatheringstatechange = gatheringStateChange;

--- a/src/content/peerconnection/upgrade/index.html
+++ b/src/content/peerconnection/upgrade/index.html
@@ -66,7 +66,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/upgrade/js/main.js
+++ b/src/content/peerconnection/upgrade/js/main.js
@@ -25,21 +25,21 @@ const localVideo = document.getElementById('localVideo');
 const remoteVideo = document.getElementById('remoteVideo');
 
 localVideo.addEventListener('loadedmetadata', function() {
-  trace(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.addEventListener('loadedmetadata', function() {
-  trace(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.onresize = () => {
-  trace(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
+  console.log(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
   console.warn('RESIZE', remoteVideo.videoWidth, remoteVideo.videoHeight);
   // We'll use the first onsize callback as an indication that video has started
   // playing out.
   if (startTime) {
     const elapsedTime = window.performance.now() - startTime;
-    trace(`Setup time: ${elapsedTime.toFixed(3)}ms`);
+    console.log(`Setup time: ${elapsedTime.toFixed(3)}ms`);
     startTime = null;
   }
 };
@@ -61,14 +61,14 @@ function getOtherPc(pc) {
 }
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   localVideo.srcObject = stream;
   localStream = stream;
   callButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   navigator.mediaDevices
     .getUserMedia({
@@ -83,41 +83,41 @@ function call() {
   callButton.disabled = true;
   upgradeButton.disabled = false;
   hangupButton.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   startTime = window.performance.now();
   const audioTracks = localStream.getAudioTracks();
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc1.oniceconnectionstatechange = e => onIceStateChange(pc1, e);
   pc2.oniceconnectionstatechange = e => onIceStateChange(pc2, e);
   pc2.ontrack = gotRemoteStream;
 
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));
-  trace('Added local stream to pc1');
+  console.log('Added local stream to pc1');
 
-  trace('pc1 createOffer start');
+  console.log('pc1 createOffer start');
   pc1.createOffer(offerOptions).then(onCreateOfferSuccess, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function onCreateOfferSuccess(desc) {
-  trace(`Offer from pc1\n${desc.sdp}`);
-  trace('pc1 setLocalDescription start');
+  console.log(`Offer from pc1\n${desc.sdp}`);
+  console.log('pc1 setLocalDescription start');
   pc1.setLocalDescription(desc).then(() => onSetLocalSuccess(pc1), onSetSessionDescriptionError);
-  trace('pc2 setRemoteDescription start');
+  console.log('pc2 setRemoteDescription start');
   pc2.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc2 createAnswer start');
+  console.log('pc2 createAnswer start');
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
@@ -125,15 +125,15 @@ function onCreateOfferSuccess(desc) {
 }
 
 function onSetLocalSuccess(pc) {
-  trace(`${getName(pc)} setLocalDescription complete`);
+  console.log(`${getName(pc)} setLocalDescription complete`);
 }
 
 function onSetRemoteSuccess(pc) {
-  trace(`${getName(pc)} setRemoteDescription complete`);
+  console.log(`${getName(pc)} setRemoteDescription complete`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function gotRemoteStream(e) {
@@ -145,11 +145,11 @@ function gotRemoteStream(e) {
 }
 
 function onCreateAnswerSuccess(desc) {
-  trace(`Answer from pc2:
+  console.log(`Answer from pc2:
 ${desc.sdp}`);
-  trace('pc2 setLocalDescription start');
+  console.log('pc2 setLocalDescription start');
   pc2.setLocalDescription(desc).then(() => onSetLocalSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc1 setRemoteDescription start');
+  console.log('pc1 setRemoteDescription start');
   pc1.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc1), onSetSessionDescriptionError);
 }
 
@@ -157,20 +157,20 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
     .addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess(pc) {
-  trace(`${getName(pc)} addIceCandidate success`);
+  console.log(`${getName(pc)} addIceCandidate success`);
 }
 
 function onAddIceCandidateError(pc, error) {
-  trace(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onIceStateChange(pc, event) {
   if (pc) {
-    trace(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
+    console.log(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
     console.log('ICE state change event: ', event);
   }
 }
@@ -182,7 +182,7 @@ function upgrade() {
     .then(stream => {
       const videoTracks = stream.getVideoTracks();
       if (videoTracks.length > 0) {
-        trace(`Using video device: ${videoTracks[0].label}`);
+        console.log(`Using video device: ${videoTracks[0].label}`);
       }
       localStream.addTrack(videoTracks[0]);
       localVideo.srcObject = null;
@@ -198,7 +198,7 @@ function upgrade() {
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   pc1.close();
   pc2.close();
   pc1 = null;

--- a/src/content/peerconnection/webaudio-input/index.html
+++ b/src/content/peerconnection/webaudio-input/index.html
@@ -90,7 +90,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/webaudioextended.js"></script>
 <script src="js/main.js" async></script>
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/peerconnection/webaudio-input/js/main.js
+++ b/src/content/peerconnection/webaudio-input/js/main.js
@@ -11,7 +11,6 @@
 /* global WebAudioExtended */
 
 const audioElement = document.querySelector('audio');
-const statusDiv = document.querySelector('div#status');
 
 const startButton = document.querySelector('button#start');
 const stopButton = document.querySelector('button#stop');
@@ -147,12 +146,6 @@ function toggleRenderLocally() {
   webAudio.renderLocally(renderLocallyCheckbox.checked);
 }
 
-function console.log(txt) {
-  statusDiv.innerHTML += `<p>${txt}</p>`;
-  console.log(txt);
-}
-
 function logError(error) {
-  console.log(error);
   document.querySelector('#errorMsg').innerHTML = error;
 }

--- a/src/content/peerconnection/webaudio-input/js/main.js
+++ b/src/content/peerconnection/webaudio-input/js/main.js
@@ -60,14 +60,14 @@ function handleSuccess(stream) {
   renderLocallyCheckbox.disabled = false;
   const audioTracks = stream.getAudioTracks();
   if (audioTracks.length === 1) {
-    trace('Got one audio track:', audioTracks);
+    console.log('Got one audio track:', audioTracks);
     const filteredStream = webAudio.applyFilter(stream);
     const servers = null;
     pc1 = new RTCPeerConnection(servers); // eslint-disable-line new-cap
-    trace('Created local peer connection object pc1');
+    console.log('Created local peer connection object pc1');
     pc1.onicecandidate = e => onIceCandidate(pc1, e);
     pc2 = new RTCPeerConnection(servers); // eslint-disable-line new-cap
-    trace('Created remote peer connection object pc2');
+    console.log('Created remote peer connection object pc2');
     pc2.onicecandidate = e => onIceCandidate(pc2, e);
     pc2.ontrack = gotRemoteStream;
     filteredStream.getTracks().forEach(track => pc1.addTrack(track, filteredStream));
@@ -105,7 +105,7 @@ function gotDescription1(desc) {
 
 function gotDescription2(desc) {
   pc2.setLocalDescription(desc);
-  trace(`Answer from pc2\n${desc.sdp}`);
+  console.log(`Answer from pc2\n${desc.sdp}`);
   pc1.setRemoteDescription(desc);
 }
 
@@ -127,11 +127,11 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
     .addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {
-  trace('AddIceCandidate success.');
+  console.log('AddIceCandidate success.');
 }
 
 function onAddIceCandidateError(error) {
@@ -143,11 +143,11 @@ function handleKeyDown() {
 }
 
 function toggleRenderLocally() {
-  trace('Render locally: ', renderLocallyCheckbox.checked);
+  console.log('Render locally: ', renderLocallyCheckbox.checked);
   webAudio.renderLocally(renderLocallyCheckbox.checked);
 }
 
-function trace(txt) {
+function console.log(txt) {
   statusDiv.innerHTML += `<p>${txt}</p>`;
   console.log(txt);
 }

--- a/src/content/peerconnection/webaudio-output/index.html
+++ b/src/content/peerconnection/webaudio-output/index.html
@@ -62,7 +62,6 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="../../../js/common.js"></script>
 <script src="js/third_party/streamvisualizer.js"></script>
 <script src="js/main.js" async></script>
 

--- a/src/content/peerconnection/webaudio-output/js/main.js
+++ b/src/content/peerconnection/webaudio-output/js/main.js
@@ -26,20 +26,20 @@ const localVideo = document.getElementById('localVideo');
 const remoteVideo = document.getElementById('remoteVideo');
 
 localVideo.addEventListener('loadedmetadata', () => {
-  return trace(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  return console.log(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.addEventListener('loadedmetadata', () => {
-  return trace(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  return console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
 remoteVideo.addEventListener('resize', () => {
-  trace(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
+  console.log(`Remote video size changed to ${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`);
   // We'll use the first onsize callback as an indication that video has started
   // playing out.
   if (startTime) {
     const elapsedTime = window.performance.now() - startTime;
-    trace(`Setup time: ${elapsedTime.toFixed(3)}ms`);
+    console.log(`Setup time: ${elapsedTime.toFixed(3)}ms`);
     startTime = null;
   }
 });
@@ -61,14 +61,14 @@ function getOtherPc(pc) {
 }
 
 function gotStream(stream) {
-  trace('Received local stream');
+  console.log('Received local stream');
   localVideo.srcObject = stream;
   localStream = stream;
   callButton.disabled = false;
 }
 
 function start() {
-  trace('Requesting local stream');
+  console.log('Requesting local stream');
   startButton.disabled = true;
   navigator.mediaDevices
     .getUserMedia({
@@ -82,45 +82,45 @@ function start() {
 function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
-  trace('Starting call');
+  console.log('Starting call');
   startTime = window.performance.now();
   const videoTracks = localStream.getVideoTracks();
   const audioTracks = localStream.getAudioTracks();
   if (videoTracks.length > 0) {
-    trace(`Using video device: ${videoTracks[0].label}`);
+    console.log(`Using video device: ${videoTracks[0].label}`);
   }
   if (audioTracks.length > 0) {
-    trace(`Using audio device: ${audioTracks[0].label}`);
+    console.log(`Using audio device: ${audioTracks[0].label}`);
   }
   const servers = null;
   pc1 = new RTCPeerConnection(servers);
-  trace('Created local peer connection object pc1');
+  console.log('Created local peer connection object pc1');
   pc1.onicecandidate = e => onIceCandidate(pc1, e);
   pc2 = new RTCPeerConnection(servers);
-  trace('Created remote peer connection object pc2');
+  console.log('Created remote peer connection object pc2');
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc1.oniceconnectionstatechange = e => onIceStateChange(pc1, e);
   pc2.oniceconnectionstatechange = e => onIceStateChange(pc2, e);
   pc2.ontrack = gotRemoteStream;
 
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));
-  trace('Added local stream to pc1');
+  console.log('Added local stream to pc1');
 
-  trace('pc1 createOffer start');
+  console.log('pc1 createOffer start');
   pc1.createOffer(offerOptions).then(onCreateOfferSuccess, onCreateSessionDescriptionError);
 }
 
 function onCreateSessionDescriptionError(error) {
-  trace(`Failed to create session description: ${error.toString()}`);
+  console.log(`Failed to create session description: ${error.toString()}`);
 }
 
 function onCreateOfferSuccess(desc) {
-  trace(`Offer from pc1\n${desc.sdp}`);
-  trace('pc1 setLocalDescription start');
+  console.log(`Offer from pc1\n${desc.sdp}`);
+  console.log('pc1 setLocalDescription start');
   pc1.setLocalDescription(desc).then(() => onSetLocalSuccess(pc1), onSetSessionDescriptionError);
-  trace('pc2 setRemoteDescription start');
+  console.log('pc2 setRemoteDescription start');
   pc2.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc2 createAnswer start');
+  console.log('pc2 createAnswer start');
   // Since the 'remote' side has no media stream we need
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
@@ -128,21 +128,21 @@ function onCreateOfferSuccess(desc) {
 }
 
 function onSetLocalSuccess(pc) {
-  trace(`${getName(pc)} setLocalDescription complete`);
+  console.log(`${getName(pc)} setLocalDescription complete`);
 }
 
 function onSetRemoteSuccess(pc) {
-  trace(`${getName(pc)} setRemoteDescription complete`);
+  console.log(`${getName(pc)} setRemoteDescription complete`);
 }
 
 function onSetSessionDescriptionError(error) {
-  trace(`Failed to set session description: ${error.toString()}`);
+  console.log(`Failed to set session description: ${error.toString()}`);
 }
 
 function gotRemoteStream(e) {
   if (remoteVideo.srcObject !== e.streams[0]) {
     remoteVideo.srcObject = e.streams[0];
-    trace('pc2 received remote stream');
+    console.log('pc2 received remote stream');
     const streamVisualizer = new StreamVisualizer(e.streams[0], canvas);
     streamVisualizer.start();
   }
@@ -150,10 +150,10 @@ function gotRemoteStream(e) {
 
 
 function onCreateAnswerSuccess(desc) {
-  trace(`Answer from pc2:\n${desc.sdp}`);
-  trace('pc2 setLocalDescription start');
+  console.log(`Answer from pc2:\n${desc.sdp}`);
+  console.log('pc2 setLocalDescription start');
   pc2.setLocalDescription(desc).then(() => onSetLocalSuccess(pc2), onSetSessionDescriptionError);
-  trace('pc1 setRemoteDescription start');
+  console.log('pc1 setRemoteDescription start');
   pc1.setRemoteDescription(desc).then(() => onSetRemoteSuccess(pc1), onSetSessionDescriptionError);
 }
 
@@ -161,26 +161,26 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
     .addIceCandidate(event.candidate)
     .then(() => onAddIceCandidateSuccess(pc), err => onAddIceCandidateError(pc, err));
-  trace(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate:\n${event.candidate ? event.candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess(pc) {
-  trace(`${getName(pc)} addIceCandidate success`);
+  console.log(`${getName(pc)} addIceCandidate success`);
 }
 
 function onAddIceCandidateError(pc, error) {
-  trace(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
+  console.log(`${getName(pc)} failed to add ICE Candidate: ${error.toString()}`);
 }
 
 function onIceStateChange(pc, event) {
   if (pc) {
-    trace(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
+    console.log(`${getName(pc)} ICE state: ${pc.iceConnectionState}`);
     console.log('ICE state change event: ', event);
   }
 }
 
 function hangup() {
-  trace('Ending call');
+  console.log('Ending call');
   pc1.close();
   pc2.close();
   pc1 = null;

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -1,7 +1,0 @@
- /* exported trace */
-
-// Logging utility function.
-function trace(arg) {
-  const now = (window.performance.now() / 1000).toFixed(3)
-  console.log(`${now}: `, arg);
-}


### PR DESCRIPTION
**Description**
Our old trace() utility fun ction only added timestamps to logs, but prevented modern use of console.log. It also made it hard to quickly find the line where the call was made, since it always tracked back to common.js.

**Purpose**
This change removes the function and changes all calls to trace to console.log instead. We'll loose the timestamp in the logs, but I believe this is more valuable as we now can properly log objects in the console as well as find the source of each call more easily.