### PR TITLE
make getStats code better in FF65+

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -247,8 +247,11 @@ window.setInterval(() => {
     res.forEach(report => {
       let bytes;
       let packets;
-      const now = report.timestamp;
       if (report.type === 'outbound-rtp') {
+        if (report.isRemote) {
+          return;
+        }
+        const now = report.timestamp;
         bytes = report.bytesSent;
         packets = report.packetsSent;
         if (lastResult && lastResult.has(report.id)) {

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -243,8 +243,11 @@ window.setInterval(() => {
     res.forEach(report => {
       let bytes;
       let packets;
-      const now = report.timestamp;
       if (report.type === 'outbound-rtp') {
+        if (report.isRemote) {
+          return;
+        }
+        const now = report.timestamp;
         bytes = report.bytesSent;
         packets = report.packetsSent;
         if (lastResult && lastResult.has(report.id)) {


### PR DESCRIPTION
the code currently accesses a stats report.timestamp which
triggers the warnings described in
  https://blog.mozilla.org/webrtc/getstats-isremote-65/

Also adds the isRemote checks. While remote outbound-rtp
can not happen when using sender.getStats() people might
copy this technique and apply to pc.getStats() so it is
better to show

from discussion with @jan-ivar 