### PR TITLE
Fix broken for

### DIFF
--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -130,7 +130,7 @@ function start() {
   }
   const transports = document.getElementsByName('transports');
   let iceTransports;
-  for (i = 0; i < transports.length; ++i) {
+  for (let i = 0; i < transports.length; ++i) {
     if (transports[i].checked) {
       iceTransports = transports[i].value;
       break;


### PR DESCRIPTION
**Description**
I think latest changes to ES6 broke it:

![image](https://user-images.githubusercontent.com/8591547/43859438-fa7fbbe6-9b26-11e8-9bda-09809b5f6dfe.png)


**Purpose**
Make it work again 😄 
