### PR TITLE
add getDisplayMedia screensharing sample

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,8 @@
             <li><a href="src/content/getusermedia/volume/">Audio-only getUserMedia() displaying volume</a></li>
 
             <li><a href="src/content/getusermedia/record/">Record stream</a></li>
+
+            <li><a href="src/content/getusermedia/getdisplaymedia/">Screensharing with getDisplayMedia</a></li>
         </ul>
         <h2 id="devices">Devices:</h2>
         <p class="description">Query media devices</p>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="description" content="WebRTC code samples">
+  <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1">
+  <meta itemprop="description" content="Client-side WebRTC code samples">
+  <meta itemprop="image" content="../../../images/webrtc-icon-192x192.png">
+  <meta itemprop="name" content="WebRTC code samples">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta id="theme-color" name="theme-color" content="#ffffff">
+
+  <base target="_blank">
+
+  <title>getUserMedia</title>
+
+  <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
+  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="../../../css/main.css">
+
+</head>
+
+<body>
+
+  <div id="container">
+
+    <div class="highlight">
+      <p>New codelab: <a href="https://codelabs.developers.google.com/codelabs/webrtc-web">Realtime communication with WebRTC</a></p>
+    </div>
+
+    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>getDisplayMedia</span></h1>
+
+    <video id="gum-local" autoplay playsinline></video>
+
+    <div id="errorMsg"></div>
+
+    <p>Display the screensharing stream from <code>getDisplayMedia()</code> in a video element.</p>
+
+    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/getdisplaymedia" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+  </div>
+
+  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="js/main.js"></script>
+
+  <script src="../../../js/lib/ga.js"></script>
+
+</body>
+</html>

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+'use strict';
+
+// Polyfill in Firefox.
+// See https://blog.mozilla.org/webrtc/getdisplaymedia-now-available-in-adapter-js/
+if (adapter.browserDetails.browser == 'firefox') {
+  adapter.browserShim.shimGetDisplayMedia(window, 'screen');
+}
+
+function handleSuccess(stream) {
+  const video = document.querySelector('video');
+  video.srcObject = stream;
+}
+
+function handleError(error) {
+  errorMsg(`getDisplayMedia error: ${error.name}`, error);
+}
+
+function errorMsg(msg, error) {
+  const errorElement = document.querySelector('#errorMsg');
+  errorElement.innerHTML += `<p>${msg}</p>`;
+  if (typeof error !== 'undefined') {
+    console.error(error);
+  }
+}
+
+if ('getDisplayMedia' in navigator) {
+  navigator.getDisplayMedia({video: true})
+    .then(handleSuccess)
+    .catch(handleError);
+} else {
+  errorMsg('getDisplayMedia is not supported');
+}


### PR DESCRIPTION
works in Chrome (canary, with experimental web platform flags), Firefox (polyfilled via adapter) and Microsoft Edge.

:clap: @ https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/discuss-webrtc/Uf0SrR4uxzk/uO8sLrWuEAAJ