### PR TITLE
Fixes bufferedamoutnlow event not being fired (#1102)

### DIFF
--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -100,6 +100,7 @@ function sendGeneratedData() {
         } else {
           sendChannel.addEventListener('bufferedamountlow', listener);
         }
+        break;
       } else {
         sendProgress.value += chunkSize;
         sendChannel.send(stringToSendRepeatedly);


### PR DESCRIPTION
Missing break statement causing busy wait.

**ref**
https://github.com/webrtc/samples/issues/1102 and https://github.com/webrtc/samples/pull/1110