### PR TITLE
Datatransfer example workarounds & maxMessageSize

### DIFF
--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -52,7 +52,7 @@
         </div>
         <div class="input">
             <input type="number" id="megsToSend" min="1" name="megs" value="16"/>
-            <label for="megsToSend">MB <b>(warning: very large values will likely cause problems)</b></label>
+            <label for="megsToSend">MB <b>(warning: very large values will potentially cause memory problems)</b></label>
             <div id="errorMsg"></div>
         </div>
         <div class="input">


### PR DESCRIPTION
Updates the datatransfer example to use `maxMessageSize`, a couple of bug fixes and adds a workaround to prevent racing with the underlying transport.

(As discussed in #1110)