### PR TITLE
bandwidth: Use RTCRtpSender.setParameters in Firefox 64 and up

### DIFF
--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -173,11 +173,16 @@ bandwidthSelector.onchange = () => {
   // In Chrome, use RTCRtpSender.setParameters to change bandwidth without
   // (local) renegotiation. Note that this will be within the envelope of
   // the initial maximum bandwidth negotiated via SDP.
-  if (adapter.browserDetails.browser === 'chrome' &&
+  if ((adapter.browserDetails.browser === 'chrome' ||
+       (adapter.browserDetails.browser === 'firefox' &&
+        adapter.browserDetails.version >= 64)) &&
       'RTCRtpSender' in window &&
       'setParameters' in window.RTCRtpSender.prototype) {
     const sender = pc1.getSenders()[0];
     const parameters = sender.getParameters();
+    if (!parameters.encodings) {
+      parameters.encodings = [{}];
+    }
     if (bandwidth === 'unlimited') {
       delete parameters.encodings[0].maxBitrate;
     } else {


### PR DESCRIPTION
Firefox [bug 1253499](https://bugzilla.mozilla.org/show_bug.cgi?id=1253499) has fixed calling setParameters during a call.