### PR TITLE
Remove capture preview and show recording after stop.

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -35,8 +35,8 @@
   <div id="container">
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Demo of getDisplayMedia and screen recording</span></h1>
 
-    <h4>Screen capturing is currently an experimental feature which is onyl supported by latest Chrome and Firefox!</h4>
-
+    <h4>Screen capturing is currently an experimental feature which is only supported by latest Chrome and Firefox!</h4>
+    <p>To enable this feature in Chrome, toggle the Experimental Web Platform feature (See chrome://flags/#enable-experimental-web-platform-features).</p>
     <screen-sharing></screen-sharing>
 
     <p>Display the screensharing stream from <code>getDisplayMedia()</code> in a video element and record the stream.</p>


### PR DESCRIPTION
Updated screen sharing sample.

- Screen capture no longer previewed
- Screen capture recording played back on stop