### PR TITLE
Check navigator.mediaDevices.getDisplayMedia()

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -63,6 +63,8 @@ video {
   static _startScreenCapture() {
     if (navigator.getDisplayMedia) {
       return navigator.getDisplayMedia({video: true});
+    } else if (navigator.mediaDevices.getDisplayMedia) {
+      return navigator.mediaDevices.getDisplayMedia({video: true});
     } else {
       return navigator.mediaDevices.getUserMedia({video: {mediaSource: 'screen'}});
     }


### PR DESCRIPTION
**Description**
getDisplayMedia() is moved to navigator.mediaDevices following https://github.com/w3c/mediacapture-screen-share/pull/86.

**Purpose**
Fixes the demo page for Chrome 72+.
