### PR TITLE
fix lit-element url

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -6,7 +6,7 @@
  *  tree.
  */
 'use strict';
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.2?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.2/lit-element.js?module';
 
 class ScreenSharing extends LitElement {
   constructor() {


### PR DESCRIPTION
**Description**
Current lit-element url cannot be loaded in Chrome 71.0.3578.98, change to https://unpkg.com/@polymer/lit-element@0.6.2/lit-element.js?module

**Purpose**
Fix lit-element url