### PR TITLE
Datachannel > Messaging demo: Prevent "undefined" in messages received locally and remotely

### DIFF
--- a/src/content/datachannel/messaging/main.js
+++ b/src/content/datachannel/messaging/main.js
@@ -14,6 +14,8 @@ class MessagingSample extends LitElement {
   constructor() {
     super();
     this.connected = false;
+    this.localMessages = '';
+    this.remoteMessages = '';
   }
 
   disconnect() {


### PR DESCRIPTION
**Description**
localMessages and remoteMessages are not initialised, hence first message received is concatenated with _undefined_.

**Purpose**
Check the screenshots please.

*BEFORE*
<img width="391" alt="screen shot 2019-01-28 at 08 15 37" src="https://user-images.githubusercontent.com/367029/51820343-b6194a80-22d5-11e9-9acb-307f4b532eaf.png">

*AFTER*
<img width="316" alt="screen shot 2019-01-28 at 08 15 11" src="https://user-images.githubusercontent.com/367029/51820351-bca7c200-22d5-11e9-9419-78c22d1c8fb6.png">
