### PR TITLE
Fix sample

### DIFF
--- a/src/content/capture/canvas-filter/js/main.js
+++ b/src/content/capture/canvas-filter/js/main.js
@@ -8,42 +8,43 @@
 
 'use strict';
 
-const source = document.querySelector('#source');
-// TODO(hta): Use OffscreenCanvas for the intermediate canvases.
-const canvasIn = document.querySelector('#canvas-source');
-const canvasOut = document.querySelector('#canvas-result');
-const result = document.querySelector('#result');
+window.onload = async () => {
+  const source = document.querySelector('#source');
+  // TODO(hta): Use OffscreenCanvas for the intermediate canvases.
+  const canvasIn = document.querySelector('#canvas-source');
+  const canvasOut = document.querySelector('#canvas-result');
+  const result = document.querySelector('#result');
 
-const stream = canvasOut.captureStream();
-let inputStream = null;
-let imageData = null;
+  canvasOut.getContext('2d'); // Firefox throws an error without this
+  const stream = canvasOut.captureStream();
+  let inputStream = null;
+  let imageData = null;
 
-result.srcObject = stream;
+  result.srcObject = stream;
 
-function loop() {
-  if (source.videoWidth > 0 && source.videoHeight > 0) {
-    canvasIn.width = source.videoWidth;
-    canvasIn.height = source.videoHeight;
-    let ctx = canvasIn.getContext('2d');
-    ctx.drawImage(source, 0, 0);
-    // Put a red square into the image, to mark it as "processed".
-    ctx.fillStyle = '#FF0000';
-    ctx.fillRect(10, 10, 80, 80);
-    imageData = ctx.getImageData(0, 0, canvasIn.width, canvasIn.height);
-    // At this point, we have data that can be transferred.
-    // We paint it on the second canvas.
-    canvasOut.width = source.videoWidth;
-    canvasOut.height = source.videoHeight;
-    let outCtx = canvasOut.getContext('2d');
-    outCtx.putImageData(imageData, 0, 0);
+  function loop() {
+    if (source.videoWidth > 0 && source.videoHeight > 0) {
+      canvasIn.width = source.videoWidth;
+      canvasIn.height = source.videoHeight;
+      let ctx = canvasIn.getContext('2d');
+      ctx.drawImage(source, 0, 0);
+      // Put a red square into the image, to mark it as "processed".
+      ctx.fillStyle = '#FF0000';
+      ctx.fillRect(10, 10, 80, 80);
+      imageData = ctx.getImageData(0, 0, canvasIn.width, canvasIn.height);
+      // At this point, we have data that can be transferred.
+      // We paint it on the second canvas.
+      canvasOut.width = source.videoWidth;
+      canvasOut.height = source.videoHeight;
+      let outCtx = canvasOut.getContext('2d');
+      outCtx.putImageData(imageData, 0, 0);
+    }
+    window.requestAnimationFrame(loop);
   }
-  window.requestAnimationFrame(loop);
-}
 
-(async () => {
   inputStream = await navigator.mediaDevices.getUserMedia({video: true});
   source.srcObject = inputStream;
   source.play();
   result.play();
   window.requestAnimationFrame(loop);
-})();
+};


### PR DESCRIPTION
Firefox (as of July 2019) will throw an error if `captureStream()` is called on a canvas without the context being touched.

Chrome (as of July 2019) seems to have page load hang indefinitely if `captureStream()` is called before the `window.onload` event.

I was not able to get this sample to work in either Chrome or Firefox without these changes.

@alvestrand