### PR TITLE
connectionstatechange->loadedmetadata delay

### DIFF
--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -25,8 +25,10 @@ localVideo.addEventListener('loadedmetadata', function() {
   console.log(`Local video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 
+let connectedTime;
 remoteVideo.addEventListener('loadedmetadata', function() {
   console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Time between connectionStatechange(connected) and loadedmetadata: ${performance.now() - connectedTime}`);
 });
 
 remoteVideo.addEventListener('resize', () => {
@@ -99,6 +101,11 @@ async function call() {
   pc2.addEventListener('icecandidate', e => onIceCandidate(pc2, e));
   pc1.addEventListener('iceconnectionstatechange', e => onIceStateChange(pc1, e));
   pc2.addEventListener('iceconnectionstatechange', e => onIceStateChange(pc2, e));
+  pc2.addEventListener('connectionstatechange', e => {
+    if (pc2.connectionState === 'connected') {
+      connectedTime = performance.now();
+    }
+  });
   pc2.addEventListener('track', gotRemoteStream);
 
   localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));


### PR DESCRIPTION
STR:
- checkout the branch
- run the pc1 sample
- observe the console logs for "Time between connectionStatechange" (which should be close to the bottom

My expectation is that this is minor but it turns out to be in the order of ~150ms and the RTT should be close to 0. playoutDelayHint seems to have a small impact on that but even setting it to 0 only reduces the delay between the events to ~100ms.

Arguably we should be able to listen to track.onunmute but... ;-)