### PR TITLE
audio/bandwidth: show headerBytes sent

### DIFF
--- a/src/content/peerconnection/audio/js/main.js
+++ b/src/content/peerconnection/audio/js/main.js
@@ -23,6 +23,7 @@ let localStream;
 
 let bitrateGraph;
 let bitrateSeries;
+let headerrateSeries;
 
 let packetGraph;
 let packetSeries;
@@ -52,6 +53,9 @@ function gotStream(stream) {
   bitrateSeries = new TimelineDataSeries();
   bitrateGraph = new TimelineGraphView('bitrateGraph', 'bitrateCanvas');
   bitrateGraph.updateEndDate();
+
+  headerrateSeries = new TimelineDataSeries();
+  headerrateSeries.setColor('green');
 
   packetSeries = new TimelineDataSeries();
   packetGraph = new TimelineGraphView('packetGraph', 'packetCanvas');
@@ -246,6 +250,7 @@ window.setInterval(() => {
   sender.getStats().then(res => {
     res.forEach(report => {
       let bytes;
+      let headerBytes;
       let packets;
       if (report.type === 'outbound-rtp') {
         if (report.isRemote) {
@@ -253,15 +258,20 @@ window.setInterval(() => {
         }
         const now = report.timestamp;
         bytes = report.bytesSent;
+        headerBytes = report.headerBytesSent;
+
         packets = report.packetsSent;
         if (lastResult && lastResult.has(report.id)) {
           // calculate bitrate
           const bitrate = 8 * (bytes - lastResult.get(report.id).bytesSent) /
             (now - lastResult.get(report.id).timestamp);
+          const headerrate = 8 * (headerBytes - lastResult.get(report.id).headerBytesSent) /
+            (now - lastResult.get(report.id).timestamp);
 
           // append to chart
           bitrateSeries.addPoint(now, bitrate);
-          bitrateGraph.setDataSeries([bitrateSeries]);
+          headerrateSeries.addPoint(now, headerrate);
+          bitrateGraph.setDataSeries([bitrateSeries, headerrateSeries]);
           bitrateGraph.updateEndDate();
 
           // calculate number of packets and append to chart

--- a/src/content/peerconnection/bandwidth/js/main.js
+++ b/src/content/peerconnection/bandwidth/js/main.js
@@ -28,6 +28,7 @@ const maxBandwidth = 0;
 
 let bitrateGraph;
 let bitrateSeries;
+let headerrateSeries;
 
 let packetGraph;
 let packetSeries;
@@ -57,6 +58,9 @@ function gotStream(stream) {
   bitrateSeries = new TimelineDataSeries();
   bitrateGraph = new TimelineGraphView('bitrateGraph', 'bitrateCanvas');
   bitrateGraph.updateEndDate();
+
+  headerrateSeries = new TimelineDataSeries();
+  headerrateSeries.setColor('green');
 
   packetSeries = new TimelineDataSeries();
   packetGraph = new TimelineGraphView('packetGraph', 'packetCanvas');
@@ -247,6 +251,7 @@ window.setInterval(() => {
   sender.getStats().then(res => {
     res.forEach(report => {
       let bytes;
+      let headerBytes;
       let packets;
       if (report.type === 'outbound-rtp') {
         if (report.isRemote) {
@@ -254,15 +259,20 @@ window.setInterval(() => {
         }
         const now = report.timestamp;
         bytes = report.bytesSent;
+        headerBytes = report.headerBytesSent;
+
         packets = report.packetsSent;
         if (lastResult && lastResult.has(report.id)) {
           // calculate bitrate
           const bitrate = 8 * (bytes - lastResult.get(report.id).bytesSent) /
             (now - lastResult.get(report.id).timestamp);
+          const headerrate = 8 * (headerBytes - lastResult.get(report.id).headerBytesSent) /
+            (now - lastResult.get(report.id).timestamp);
 
           // append to chart
           bitrateSeries.addPoint(now, bitrate);
-          bitrateGraph.setDataSeries([bitrateSeries]);
+          headerrateSeries.addPoint(now, headerrate);
+          bitrateGraph.setDataSeries([bitrateSeries, headerrateSeries]);
           bitrateGraph.updateEndDate();
 
           // calculate number of packets and append to chart


### PR DESCRIPTION
which visualizes the overhead the RTP header has on audio packets.
Screenshot:
![image](https://user-images.githubusercontent.com/289731/74714089-291b9900-522a-11ea-9577-d65baa5a1f2c.png)
@henbos as master-of-stats PTAL

cc @eladalon1983 -- shows *why* one wants to adapt the ptime to reduce the overhead