### PR TITLE
endtoend-encryption: allow easy wiresharking

### DIFF
--- a/src/content/peerconnection/endtoend-encryption/js/main.js
+++ b/src/content/peerconnection/endtoend-encryption/js/main.js
@@ -101,7 +101,20 @@ function hangup() {
   callButton.disabled = false;
 }
 
+function dump(chunk, direction, max = 16) {
+  const data = new Uint8Array(chunk.data);
+  let bytes = '';
+  for (let j = 0; j < data.length && j < max; j++) {
+    bytes += (data[j] < 16 ? '0' : '') + data[j].toString(16) + ' ';
+  }
+  console.log(performance.now().toFixed(2), direction, bytes.trim(), chunk.data.byteLength, (data[0] & 0x1) === 0);
+}
+
+let scount = 0;
 function encodeFunction(chunk, controller) {
+  if (scount++ < 30) { // dump the first 30 packets.
+    dump(chunk, 'send');
+  }
   if (currentCryptoKey) {
     const view = new DataView(chunk.data);
     // Any length that is needed can be used for the new buffer.
@@ -130,7 +143,11 @@ function encodeFunction(chunk, controller) {
   controller.enqueue(chunk);
 }
 
+let rcount = 0;
 function decodeFunction(chunk, controller) {
+  if (rcount++ < 30) { // dump the first 30 packets
+    dump(chunk, 'recv');
+  }
   const view = new DataView(chunk.data);
   const checksum = view.getUint32(chunk.data.byteLength - 4);
   if (currentCryptoKey) {

--- a/src/content/peerconnection/endtoend-encryption/js/videopipe.js
+++ b/src/content/peerconnection/endtoend-encryption/js/videopipe.js
@@ -65,7 +65,7 @@ VideoPipe.prototype.negotiate = async function() {
   this.pc2.onicecandidate = e => this.pc1.addIceCandidate(e.candidate);
 
   const offer = await this.pc1.createOffer();
-  await this.pc2.setRemoteDescription(offer);
+  await this.pc2.setRemoteDescription({type: 'offer', sdp: offer.sdp.replace('red/90000', 'green/90000')});
   await this.pc1.setLocalDescription(offer);
 
   const answer = await this.pc2.createAnswer();


### PR DESCRIPTION
This removes RED as payload which allows using wirehark as described in
  https://webrtchacks.com/wireshark-debug-vp8/
together with the
  --disable-webrtc-encryption
flag (chrome canary/beta) to capture raw packets.

@alvestrand largely documentation, feel free not to merge