### PR TITLE
e2ee: fix initial setting of useCryptoOffset

### DIFF
--- a/src/content/peerconnection/endtoend-encryption/js/worker.js
+++ b/src/content/peerconnection/endtoend-encryption/js/worker.js
@@ -13,7 +13,7 @@
 
 'use strict';
 let currentCryptoKey;
-let useCryptoOffset;
+let useCryptoOffset = true;
 let currentKeyIdentifier = 0;
 
 // If using crypto offset (controlled by a checkbox):


### PR DESCRIPTION
it seems I broke funny-pictures middlebox mode with moving to the worker. This doesn't fix it sadly
