### PR TITLE
e2ee: name the worker

### DIFF
--- a/src/content/peerconnection/endtoend-encryption/js/main.js
+++ b/src/content/peerconnection/endtoend-encryption/js/main.js
@@ -82,7 +82,7 @@ function start() {
 // See
 //   https://developer.mozilla.org/en-US/docs/Web/API/Worker
 // for basic concepts.
-const worker = new Worker('./js/worker.js');
+const worker = new Worker('./js/worker.js', {name: 'E2EE worker'});
 function setupSenderTransform(sender) {
   const senderStreams = sender.track.kind === 'video' ? sender.createEncodedVideoStreams() : sender.createEncodedAudioStreams();
   // Instead of creating the transform stream here, we do a postMessage to the worker. The first


### PR DESCRIPTION
this makes Chrome devtools show the name instead of the filename

This is currently ok, showing 'worker.js' but naming it might be a good practice for larger applications:
![image](https://user-images.githubusercontent.com/289731/79977978-7670ec80-849f-11ea-9a12-e20568c51fa0.png)
