### PR TITLE
Add muted attr to enable auto-play(fixes #1308)

### DIFF
--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -38,7 +38,7 @@
     </h1>
 
     <canvas></canvas>
-    <video playsinline autoplay></video>
+    <video playsinline autoplay muted></video>
 
     <p>Click and drag on the canvas element (on the left) to move the teapot.</p>
 


### PR DESCRIPTION
**Description**

Add `muted` attribute to enable auto-play.

`MediaStream` from `canvas.captureStream()` does not contain audio track, but it doesn't seem to auto-play via pc.

**Purpose**

Refs #1308 