### PR TITLE
Get audio context on user interaction. Right now it is created suspen…

### DIFF
--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -56,6 +56,11 @@
         </div>
     </div>
 
+    <div>
+        <button type="button" id="startButton">Start</button> 
+        <button type="button" id="stopButton" disabled>Stop</button>
+    <div>
+
     <p>The 'instant' volume changes approximately every 50ms; the 'slow' volume approximates the average volume over
         about a second.</p>
     <p>Note that you will not hear your own voice; use the <a href="../audio">local audio rendering demo</a> for that.

--- a/src/content/getusermedia/volume/js/main.js
+++ b/src/content/getusermedia/volume/js/main.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const startButton = document.getElementById('startButton')
-const stopButton = document.getElementById('stopButton')
-startButton.onclick = start
-stopButton.onclick = stop
+const startButton = document.getElementById('startButton');
+const stopButton = document.getElementById('stopButton');
+startButton.onclick = start;
+stopButton.onclick = stop;
 
 const instantMeter = document.querySelector('#instant meter');
 const slowMeter = document.querySelector('#slow meter');
@@ -29,7 +29,7 @@ const constraints = window.constraints = {
   video: false
 };
 
-var meterRefresh = null;
+let meterRefresh = null;
 
 function handleSuccess(stream) {
   // Put variables in global scope to make them available to the

--- a/src/content/getusermedia/volume/js/main.js
+++ b/src/content/getusermedia/volume/js/main.js
@@ -10,6 +10,11 @@
 
 'use strict';
 
+const startButton = document.getElementById('startButton')
+const stopButton = document.getElementById('stopButton')
+startButton.onclick = start
+stopButton.onclick = stop
+
 const instantMeter = document.querySelector('#instant meter');
 const slowMeter = document.querySelector('#slow meter');
 const clipMeter = document.querySelector('#clip meter');
@@ -18,18 +23,13 @@ const instantValueDisplay = document.querySelector('#instant .value');
 const slowValueDisplay = document.querySelector('#slow .value');
 const clipValueDisplay = document.querySelector('#clip .value');
 
-try {
-  window.AudioContext = window.AudioContext || window.webkitAudioContext;
-  window.audioContext = new AudioContext();
-} catch (e) {
-  alert('Web Audio API not supported.');
-}
-
 // Put variables in global scope to make them available to the browser console.
 const constraints = window.constraints = {
   audio: true,
   video: false
 };
+
+var meterRefresh = null;
 
 function handleSuccess(stream) {
   // Put variables in global scope to make them available to the
@@ -41,7 +41,7 @@ function handleSuccess(stream) {
       alert(e);
       return;
     }
-    setInterval(() => {
+    meterRefresh = setInterval(() => {
       instantMeter.value = instantValueDisplay.innerText =
         soundMeter.instant.toFixed(2);
       slowMeter.value = slowValueDisplay.innerText =
@@ -56,4 +56,34 @@ function handleError(error) {
   console.log('navigator.MediaDevices.getUserMedia error: ', error.message, error.name);
 }
 
-navigator.mediaDevices.getUserMedia(constraints).then(handleSuccess).catch(handleError);
+
+function start() {
+  console.log('Requesting local stream');
+  startButton.disabled = true;
+  stopButton.disabled = false;
+
+  try {
+    window.AudioContext = window.AudioContext || window.webkitAudioContext;
+    window.audioContext = new AudioContext();
+  } catch (e) {
+    alert('Web Audio API not supported.');
+  }
+
+  navigator.mediaDevices
+      .getUserMedia(constraints)
+      .then(handleSuccess)
+      .catch(handleError);
+}
+
+function stop() {
+  console.log('Stopping local stream');
+  startButton.disabled = false;
+  stopButton.disabled = true;
+
+  window.stream.getTracks().forEach(track => track.stop());
+  window.soundMeter.stop();
+  clearInterval(meterRefresh);
+  instantMeter.value = instantValueDisplay.innerText = '';
+  slowMeter.value = slowValueDisplay.innerText = '';
+  clipMeter.value = clipValueDisplay.innerText = '';
+}

--- a/src/content/getusermedia/volume/js/soundmeter.js
+++ b/src/content/getusermedia/volume/js/soundmeter.js
@@ -56,6 +56,7 @@ SoundMeter.prototype.connectToSource = function(stream, callback) {
 };
 
 SoundMeter.prototype.stop = function() {
+  console.log('SoundMeter stopping');
   this.mic.disconnect();
   this.script.disconnect();
 };


### PR DESCRIPTION
**Description**
On page load audio context is created suspended (https://goo.gl/7K7WLu) and audio meter shows nothing. Controls are need to create it on user interaction.

**Purpose**
Add buttons to let user `start`(create audio context)/`stop`(stop it) the audio meter. This is aimed to fix #1317

+ @alvestrand for review