### PR TITLE
Fix average send time calculation

### DIFF
--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -106,8 +106,8 @@ function sendData() {
     if (timeUsed > maxTimeUsedInSend) {
       maxTimeUsedInSend = timeUsed;
       totalTimeUsedInSend += timeUsed;
-      numberOfSendCalls += 1;
     }
+    numberOfSendCalls += 1;
     bufferedAmount += chunkSize;
     sendProgress.value += chunkSize;
 


### PR DESCRIPTION
The "total sends" variable was only incremented when the max was updated, resulting in a highly inflated average.