### PR TITLE
fix: error handling onIceCandidateError

### DIFF
--- a/src/content/datachannel/basic/js/main.js
+++ b/src/content/datachannel/basic/js/main.js
@@ -120,8 +120,8 @@ function onIceCandidate(pc, event) {
   getOtherPc(pc)
       .addIceCandidate(event.candidate)
       .then(
-          () => onAddIceCandidateSuccess(pc),
-          err => onAddIceCandidateError(pc, err)
+          onAddIceCandidateSuccess,
+          onAddIceCandidateError
       );
   console.log(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
 }


### PR DESCRIPTION
fix: error handling onIceCandidateError in datachannel sample

**Description**
error handler was reading the RTCPeerConnection in onError instead of the Error

**Purpose**
bug fix