### PR TITLE
fix: Don't try to add null ice candidate

### DIFF
--- a/src/content/datachannel/basic/js/main.js
+++ b/src/content/datachannel/basic/js/main.js
@@ -116,14 +116,14 @@ function getName(pc) {
   return (pc === localConnection) ? 'localPeerConnection' : 'remotePeerConnection';
 }
 
-function onIceCandidate(pc, event) {
-  getOtherPc(pc)
-      .addIceCandidate(event.candidate)
+function onIceCandidate(pc, {candidate}) {
+  candidate && getOtherPc(pc)
+      .addIceCandidate(candidate)
       .then(
           () => onAddIceCandidateSuccess(pc),
           err => onAddIceCandidateError(pc, err)
       );
-  console.log(`${getName(pc)} ICE candidate: ${event.candidate ? event.candidate.candidate : '(null)'}`);
+  console.log(`${getName(pc)} ICE candidate: ${candidate ? candidate.candidate : '(null)'}`);
 }
 
 function onAddIceCandidateSuccess() {


### PR DESCRIPTION
**Description**

Add a null check before calling addIceCandidate in datachannel/basic sample.

**Purpose**

Avoid logging errors during normal operation.