### PR TITLE
getDisplayMedia: revert to old state

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/css/styles.css
+++ b/src/content/getusermedia/getdisplaymedia/css/styles.css
@@ -1,4 +1,0 @@
-video#captured-media {
-  width: 100%;
-  height: calc(width * 16 / 9);
-}

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -25,26 +25,26 @@
   <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
   <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="../../../css/main.css">
-  <link rel="stylesheet" href="css/styles.css">
-  <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
 </head>
 
 <body>
 
   <div id="container">
-    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Demo of getDisplayMedia and screen recording</span></h1>
+    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>getDisplayMedia</span></h1>
 
-    <h4>Screen capturing is currently an experimental feature which is only supported by latest Chrome and Firefox!</h4>
-    <p>To enable this feature in Chrome, toggle the Experimental Web Platform feature (See chrome://flags/#enable-experimental-web-platform-features).</p>
-    <screen-sharing></screen-sharing>
+    <video id="gum-local" autoplay playsinline muted></video>
+    <button id="startButton" disabled>Start</button>
 
-    <p>Display the screensharing stream from <code>getDisplayMedia()</code> in a video element and record the stream.</p>
+    <div id="errorMsg"></div>
+
+    <p>Display the screensharing stream from <code>getDisplayMedia()</code> in a video element.</p>
 
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/getdisplaymedia" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
   </div>
 
-  <script src="js/main.js" type="module"></script>
+  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+  <script src="js/main.js"></script>
 
   <script src="../../../js/lib/ga.js"></script>
 

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -6,125 +6,46 @@
  *  tree.
  */
 'use strict';
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.2/lit-element.js?module';
 
-class ScreenSharing extends LitElement {
-  constructor() {
-    super();
-    this.enableStartCapture = true;
-    this.enableStopCapture = false;
-    this.enableDownloadRecording = false;
-    this.stream = null;
-    this.chunks = [];
-    this.mediaRecorder = null;
-    this.status = 'Inactive';
-    this.recording = null;
-  }
-
-  static get properties() {
-    return {
-      status: String,
-      enableStartCapture: Boolean,
-      enableStopCapture: Boolean,
-      enableDownloadRecording: Boolean,
-      recording: {
-        type: {
-          fromAttribute: input => input
-        }
-      }
-    };
-  }
-
-  render() {
-    return html`<style>
-@import "../../../css/main.css";
-:host {
-  display: block;
-  padding: 10px;
-  width: 100%;
-  height: 100%;
+// Polyfill in Firefox.
+// See https://blog.mozilla.org/webrtc/getdisplaymedia-now-available-in-adapter-js/
+if (adapter.browserDetails.browser == 'firefox') {
+  adapter.browserShim.shimGetDisplayMedia(window, 'screen');
 }
-video {
-    --video-width: 100%;
-    width: var(--video-width);
-    height: calc(var(--video-width) * (16 / 9));
+
+function handleSuccess(stream) {
+  startButton.disabled = true;
+  const video = document.querySelector('video');
+  video.srcObject = stream;
+
+  // demonstrates how to detect that the user has stopped
+  // sharing the screen via the browser UI.
+  stream.getVideoTracks()[0].addEventListener('ended', () => {
+    errorMsg('The user has ended sharing the screen');
+    startButton.disabled = false;
+  });
 }
-</style>
-<video ?controls="${this.recording !== null}" playsinline autoplay loop muted .src="${this.recording}"></video>
-<div>
-<p>Status: ${this.status}</p>
-<button ?disabled="${!this.enableStartCapture}" @click="${e => this._startCapturing(e)}">Start screen capture</button>
-<button ?disabled="${!this.enableStopCapture}" @click="${e => this._stopCapturing(e)}">Stop screen capture</button>
-<button ?disabled="${!this.enableDownloadRecording}" @click="${e => this._downloadRecording(e)}">Download recording</button>
-<a id="downloadLink" type="video/webm" style="display: none"></a>
-</div>`;
-  }
 
-  static _startScreenCapture() {
-    if (navigator.getDisplayMedia) {
-      return navigator.getDisplayMedia({video: true});
-    } else if (navigator.mediaDevices.getDisplayMedia) {
-      return navigator.mediaDevices.getDisplayMedia({video: true});
-    } else {
-      return navigator.mediaDevices.getUserMedia({video: {mediaSource: 'screen'}});
-    }
-  }
+function handleError(error) {
+  errorMsg(`getDisplayMedia error: ${error.name}`, error);
+}
 
-  async _startCapturing(e) {
-    console.log('Start capturing.');
-    this.status = 'Screen recording started.';
-    this.enableStartCapture = false;
-    this.enableStopCapture = true;
-    this.enableDownloadRecording = false;
-    this.requestUpdate('buttons');
-
-    if (this.recording) {
-      window.URL.revokeObjectURL(this.recording);
-    }
-
-    this.chunks = [];
-    this.recording = null;
-    this.stream = await ScreenSharing._startScreenCapture();
-    this.stream.addEventListener('inactive', e => {
-      console.log('Capture stream inactive - stop recording!');
-      this._stopCapturing(e);
-    });
-    this.mediaRecorder = new MediaRecorder(this.stream, {mimeType: 'video/webm'});
-    this.mediaRecorder.addEventListener('dataavailable', event => {
-      if (event.data && event.data.size > 0) {
-        this.chunks.push(event.data);
-      }
-    });
-    this.mediaRecorder.start(10);
-  }
-
-  _stopCapturing(e) {
-    console.log('Stop capturing.');
-    this.status = 'Screen recorded completed.';
-    this.enableStartCapture = true;
-    this.enableStopCapture = false;
-    this.enableDownloadRecording = true;
-
-    this.mediaRecorder.stop();
-    this.mediaRecorder = null;
-    this.stream.getTracks().forEach(track => track.stop());
-    this.stream = null;
-
-    this.recording = window.URL.createObjectURL(new Blob(this.chunks, {type: 'video/webm'}));
-  }
-
-  _downloadRecording(e) {
-    console.log('Download recording.');
-    this.enableStartCapture = true;
-    this.enableStopCapture = false;
-    this.enableDownloadRecording = false;
-
-    const downloadLink = this.shadowRoot.querySelector('a#downloadLink');
-    downloadLink.addEventListener('progress', e => console.log(e));
-    downloadLink.href = this.recording;
-    downloadLink.download = 'screen-recording.webm';
-    downloadLink.click();
+function errorMsg(msg, error) {
+  const errorElement = document.querySelector('#errorMsg');
+  errorElement.innerHTML += `<p>${msg}</p>`;
+  if (typeof error !== 'undefined') {
+    console.error(error);
   }
 }
 
-customElements.define('screen-sharing', ScreenSharing);
+const startButton = document.getElementById('startButton');
+startButton.addEventListener('click', () => {
+  navigator.mediaDevices.getDisplayMedia({video: true})
+      .then(handleSuccess, handleError);
+});
+
+if ((navigator.mediaDevices && 'getDisplayMedia' in navigator.mediaDevices)) {
+  startButton.disabled = false;
+} else {
+  errorMsg('getDisplayMedia is not supported');
+}


### PR DESCRIPTION
reverts to the state of 21e9bc3e56bb8ec1e9e77036282a72c3af6cb8e7
and applies some fixes ontop of that such as the move of getDisplayMedia to navigator.mediaDevices
and that it has to be triggered from a gesture these days (in some browsers)

Fixes #1148
Fixes #1152