### PR TITLE
Update link to SDP semantics

### DIFF
--- a/src/content/peerconnection/pc1/index.html
+++ b/src/content/peerconnection/pc1/index.html
@@ -37,7 +37,7 @@
 
     <p>This sample shows how to setup a connection between two peers using
         <a href="https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a>.
-        An option to specify the <a href="https://webrtc.org/web-apis/chrome/unified-plan/">SDP semantics</a> for
+        An option to specify the <a href="https://webrtc.org/getting-started/unified-plan-transition-guide">SDP semantics</a> for
         the connection is also available (unified-plan, plan-b or default).
     </p>
 


### PR DESCRIPTION
https://webrtc.org/web-apis/chrome/unified-plan/ is 404

Given the current language is 

> An option to specify the SDP semantics for the connection is also available (unified-plan, plan-b or default).

and the updating link begins with 

> Unified Plan SDP format - transition plan

which includes links to

- “Unified Plan” Transition Guide (JavaScript) https://docs.google.com/document/d/1-ZfikoUtoJa9k-GZG1daN0BU3IjIanQ_JSscHxQesvU/edit#heading=h.wuu7dx8tnifl; and 
- Migrating your native/mobile application to Unified Plan/WebRTC 1.0 API https://docs.google.com/document/d/1PPHWV6108znP1tk_rkCnyagH9FK205hHeE9k5mhUzOg/edit#heading=h.cp7krlgejm 

is the current language and code re options for "Default",  "Unified Plan", "Plan B", in accord with the updated link to describing migration and transition to "unified-plan" SDP semantics?

**Description**


**Purpose**
