### PR TITLE
Insertable Streams sample: Abort pipeThrough when switching/stopping sources.

### DIFF
--- a/src/content/insertable-streams/video/js/main.js
+++ b/src/content/insertable-streams/video/js/main.js
@@ -42,7 +42,7 @@ let debug = {};
  * resources and maintain good performance.
  * @typedef {function(
  *     !VideoFrame,
- *     !TransformStreamDefaultController<!VideoFrame>): undefined}
+ *     !TransformStreamDefaultController<!VideoFrame>): !Promise<undefined>}
  */
 let FrameTransformFn; // eslint-disable-line no-unused-vars
 

--- a/src/content/insertable-streams/video/js/pipeline.js
+++ b/src/content/insertable-streams/video/js/pipeline.js
@@ -148,9 +148,9 @@ class Pipeline { // eslint-disable-line no-unused-vars
     await this.frameTransform_.init();
     try {
       this.processedStream_ =
-          createProcessedMediaStream(sourceStream, (frame, controller) => {
+          createProcessedMediaStream(sourceStream, async (frame, controller) => {
             if (this.frameTransform_) {
-              this.frameTransform_.transform(frame, controller);
+              await this.frameTransform_.transform(frame, controller);
             }
           });
     } catch (e) {


### PR DESCRIPTION
Another bug in https://github.com/webrtc/samples/pull/1378 -- the streams need to be explicitly stopped, otherwise the transform function is still called.