### PR TITLE
Add redirects for moved pages

### DIFF
--- a/src/content/insertable-streams/video/index.html
+++ b/src/content/insertable-streams/video/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+   <meta http-equiv="refresh"
+   content="0; url=//webrtc.github.io/samples/src/content/insertable-streams/video-processing/">
+   <title>Page move</title>
+</head>
+<body>
+   <p>The page has moved to:
+   <a href="//webrtc.github.io/samples/src/content/insertable-streams/video-processing/">this page</a></p>
+</body>
+</html>

--- a/src/content/peerconnection/endtoend-encryption/index.html
+++ b/src/content/peerconnection/endtoend-encryption/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+   <meta http-equiv="refresh"
+   content="0; url=//webrtc.github.io/samples/src/content/insertable-streams/endtoend-encryption/">
+   <title>Page move</title>
+</head>
+<body>
+   <p>The page has moved to:
+   <a href="//webrtc.github.io/samples/src/content/insertable-streams/endtoend-encryption/">this page</a></p>
+</body>
+</html>

--- a/src/content/peerconnection/video-analyzer/index.html
+++ b/src/content/peerconnection/video-analyzer/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+   <meta http-equiv="refresh"
+   content="0; url=//webrtc.github.io/samples/src/content/insertable-streams/video-analyzer/">
+   <title>Page move</title>
+</head>
+<body>
+   <p>The page has moved to:
+   <a href="//webrtc.github.io/samples/src/content/insertable-streams/video-analyzer/">this page</a></p>
+</body>
+</html>


### PR DESCRIPTION
Several pages were moved in https://github.com/webrtc/samples/pull/1381, which may have broken external links. Add redirect pages in their place.

The new files were copied from src/content/getusermedia/source/index.html.