### PR TITLE
Small cleanups to insertable streams video processing sample

### DIFF
--- a/src/content/insertable-streams/video-processing/js/canvas-transform.js
+++ b/src/content/insertable-streams/video-processing/js/canvas-transform.js
@@ -60,6 +60,8 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
     frame.destroy();
 
     ctx.drawImage(inputBitmap, 0, 0);
+    inputBitmap.close();
+
     ctx.shadowColor = '#000';
     ctx.shadowBlur = 20;
     ctx.lineWidth = 50;
@@ -68,6 +70,7 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
 
     const outputBitmap = await createImageBitmap(this.canvas_);
     const outputFrame = new VideoFrame(outputBitmap, {timestamp});
+    outputBitmap.close();
     controller.enqueue(outputFrame);
   }
 

--- a/src/content/insertable-streams/video-processing/js/peer-connection-pipe.js
+++ b/src/content/insertable-streams/video-processing/js/peer-connection-pipe.js
@@ -66,7 +66,6 @@ class PeerConnectionPipe { // eslint-disable-line no-unused-vars
     const outputStream = new MediaStream();
     const receiverStreamPromise = new Promise(resolve => {
       this.callee_.ontrack = (/** !RTCTrackEvent */ event) => {
-        if (!event.track) return;
         outputStream.addTrack(event.track);
         if (outputStream.getTracks().length == inputStream.getTracks().length) {
           resolve(outputStream);

--- a/src/content/insertable-streams/video-processing/js/simple-transforms.js
+++ b/src/content/insertable-streams/video-processing/js/simple-transforms.js
@@ -29,7 +29,6 @@ class DropTransform { // eslint-disable-line no-unused-vars
 
 /**
  * Delays all frames by 100ms.
- * TODO(benjaminwagner): Should the timestamp be adjusted?
  * @implements {FrameTransform} in pipeline.js
  */
 class DelayTransform { // eslint-disable-line no-unused-vars
@@ -37,8 +36,6 @@ class DelayTransform { // eslint-disable-line no-unused-vars
   async init() {}
   /** @override */
   async transform(frame, controller) {
-    // TODO(benjaminwagner): why is there a difference between await vs.
-    // callback?
     await new Promise(resolve => setTimeout(resolve, 100));
     controller.enqueue(frame);
   }

--- a/src/content/insertable-streams/video-processing/js/video-source.js
+++ b/src/content/insertable-streams/video-processing/js/video-source.js
@@ -69,11 +69,8 @@ class VideoSource { // eslint-disable-line no-unused-vars
     this.video_.controls = true;
     this.video_.loop = true;
     this.video_.muted = true;
-    // TODO(benjaminwagner): this isn't the best way to do this
-    this.video_.innerHTML = `
-        <source src="../../../video/chrome.webm" type="video/webm"/>
-        <source src="../../../video/chrome.mp4" type="video/mp4"/>
-        <p>This browser does not support the video element.</p>`;
+    // All browsers that support insertable streams also support WebM/VP8.
+    this.video_.src = '../../../video/chrome.webm';
     this.video_.load();
     this.video_.play();
     this.updateVideoVisibility();

--- a/src/content/insertable-streams/video-processing/js/webgl-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webgl-transform.js
@@ -175,12 +175,14 @@ class WebGLTransform { // eslint-disable-line no-unused-vars
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     gl.texImage2D(
         gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, inputBitmap);
+    inputBitmap.close();
     gl.useProgram(this.program_);
     gl.uniform1i(this.sampler_, 0);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
     gl.bindTexture(gl.TEXTURE_2D, null);
     const outputBitmap = await createImageBitmap(this.canvas_);
     const outputFrame = new VideoFrame(outputBitmap, {timestamp});
+    outputBitmap.close();
     controller.enqueue(outputFrame);
   }
 


### PR DESCRIPTION
A few small followup cleanups and fixes to https://github.com/webrtc/samples/pull/1378:

 * Call ImageBitmap.close() for more efficient resource utilization.
 * RTCTrackEvent fields are required; remove redundant null check.
 * Remove TODOs that I've investigated and require no code changes.
 * Cleanup use of innerHTML.
