### PR TITLE
In video processing sample, indicate when page is ready.

### DIFF
--- a/src/content/insertable-streams/video-processing/index.html
+++ b/src/content/insertable-streams/video-processing/index.html
@@ -46,17 +46,17 @@
 
     <div class="box">
         <span>Source:</span>
-        <select id="sourceSelector">
+        <select id="sourceSelector" disabled>
             <option selected value="">(stopped)</option>
             <option value="camera">Camera</option>
             <option value="video">Video</option>
             <option value="pc">Peer connection (from camera)</option>
         </select>
-        <span>Add to page: <input type="checkbox" id="sourceVisible"></span>
+        <span>Add to page: <input type="checkbox" id="sourceVisible" disabled></span>
     </div>
     <div class="box">
         <span>Transform:</span>
-        <select id="transformSelector">
+        <select id="transformSelector" disabled>
             <option selected value="webgl">WebGL</option>
             <option value="canvas2d">Canvas2D</option>
             <option value="drop">Drop frames at random</option>
@@ -65,7 +65,7 @@
     </div>
     <div class="box">
         <span>Destination:</span>
-        <select id="sinkSelector">
+        <select id="sinkSelector" disabled>
             <option selected value="video">Video</option>
             <option value="pc">Peer connection</option>
         </select>

--- a/src/content/insertable-streams/video-processing/index.html
+++ b/src/content/insertable-streams/video-processing/index.html
@@ -85,18 +85,18 @@
 </div>
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="js/camera-source.js" defer></script>
-<script src="js/canvas-transform.js" defer></script>
-<script src="js/peer-connection-pipe.js" defer></script>
-<script src="js/peer-connection-sink.js" defer></script>
-<script src="js/peer-connection-source.js" defer></script>
-<script src="js/pipeline.js" defer></script>
-<script src="js/simple-transforms.js" defer></script>
-<script src="js/video-mirror-helper.js" defer></script>
-<script src="js/video-sink.js" defer></script>
-<script src="js/video-source.js" defer></script>
-<script src="js/webgl-transform.js" defer></script>
-<script src="js/main.js" defer></script>
+<script src="js/camera-source.js" async></script>
+<script src="js/canvas-transform.js" async></script>
+<script src="js/peer-connection-pipe.js" async></script>
+<script src="js/peer-connection-sink.js" async></script>
+<script src="js/peer-connection-source.js" async></script>
+<script src="js/pipeline.js" async></script>
+<script src="js/simple-transforms.js" async></script>
+<script src="js/video-mirror-helper.js" async></script>
+<script src="js/video-sink.js" async></script>
+<script src="js/video-source.js" async></script>
+<script src="js/webgl-transform.js" async></script>
+<script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>
 </body>

--- a/src/content/insertable-streams/video-processing/js/main.js
+++ b/src/content/insertable-streams/video-processing/js/main.js
@@ -165,14 +165,19 @@ function updatePipelineSourceIfSet() {
  */
 function updatePipelineSource() {
   const sourceType = sourceSelector.options[sourceSelector.selectedIndex].value;
-  if (!sourceType) {
+  if (!sourceType || !pipeline) {
     initPipeline();
   } else {
     updatePipelineSourceIfSet();
   }
 }
 sourceSelector.oninput = updatePipelineSource;
-sourceVisibleCheckbox.oninput = () => {
+sourceSelector.disabled = false;
+
+/**
+ * Updates the source visibility, if the source is already started.
+ */
+function updatePipelineSourceVisibility() {
   console.log(`[UI] Changed source visibility: ${
       sourceVisibleCheckbox.checked ? 'added' : 'removed'}`);
   if (pipeline) {
@@ -181,7 +186,9 @@ sourceVisibleCheckbox.oninput = () => {
       source.setVisibility(sourceVisibleCheckbox.checked);
     }
   }
-};
+}
+sourceVisibleCheckbox.oninput = updatePipelineSourceVisibility;
+sourceVisibleCheckbox.disabled = false;
 
 const transformSelector = /** @type {!HTMLSelectElement} */ (
   document.getElementById('transformSelector'));
@@ -214,6 +221,7 @@ function updatePipelineTransform() {
   }
 }
 transformSelector.oninput = updatePipelineTransform;
+transformSelector.disabled = false;
 
 const sinkSelector = (/** @type {!HTMLSelectElement} */ (
   document.getElementById('sinkSelector')));
@@ -237,6 +245,7 @@ function updatePipelineSink() {
   }
 }
 sinkSelector.oninput = updatePipelineSink;
+sinkSelector.disabled = false;
 
 /**
  * Initializes/reinitializes the pipeline. Called on page load and after the
@@ -252,5 +261,3 @@ function initPipeline() {
   console.log(
       '[initPipeline] Created new Pipeline.', 'debug.pipeline =', pipeline);
 }
-
-initPipeline();

--- a/src/content/insertable-streams/video-processing/js/main.js
+++ b/src/content/insertable-streams/video-processing/js/main.js
@@ -127,137 +127,146 @@ function createProcessedMediaStreamTrack(sourceTrack, transform, signal) {
  */
 let pipeline;
 
-const sourceSelector = /** @type {!HTMLSelectElement} */ (
-  document.getElementById('sourceSelector'));
-const sourceVisibleCheckbox = (/** @type {!HTMLInputElement} */ (
-  document.getElementById('sourceVisible')));
 /**
- * Updates the pipeline based on the current settings of the sourceSelector and
- * sourceVisible UI elements. Unlike updatePipelineSource(), never
- * re-initializes the pipeline.
+ * Sets up handlers for interacting with the UI elements on the page.
  */
-function updatePipelineSourceIfSet() {
-  const sourceType = sourceSelector.options[sourceSelector.selectedIndex].value;
-  if (!sourceType) return;
-  console.log(`[UI] Selected source: ${sourceType}`);
-  let source;
-  switch (sourceType) {
-    case 'camera':
-      source = new CameraSource();
-      break;
-    case 'video':
-      source = new VideoSource();
-      break;
-    case 'pc':
-      source = new PeerConnectionSource(new CameraSource());
-      break;
-    default:
-      alert(`unknown source ${sourceType}`);
-      return;
+function initUI() {
+  const sourceSelector = /** @type {!HTMLSelectElement} */ (
+    document.getElementById('sourceSelector'));
+  const sourceVisibleCheckbox = (/** @type {!HTMLInputElement} */ (
+    document.getElementById('sourceVisible')));
+  /**
+   * Updates the pipeline based on the current settings of the sourceSelector
+   * and sourceVisible UI elements. Unlike updatePipelineSource(), never
+   * re-initializes the pipeline.
+   */
+  function updatePipelineSourceIfSet() {
+    const sourceType =
+        sourceSelector.options[sourceSelector.selectedIndex].value;
+    if (!sourceType) return;
+    console.log(`[UI] Selected source: ${sourceType}`);
+    let source;
+    switch (sourceType) {
+      case 'camera':
+        source = new CameraSource();
+        break;
+      case 'video':
+        source = new VideoSource();
+        break;
+      case 'pc':
+        source = new PeerConnectionSource(new CameraSource());
+        break;
+      default:
+        alert(`unknown source ${sourceType}`);
+        return;
+    }
+    source.setVisibility(sourceVisibleCheckbox.checked);
+    pipeline.updateSource(source);
   }
-  source.setVisibility(sourceVisibleCheckbox.checked);
-  pipeline.updateSource(source);
-}
-/**
- * Updates the pipeline based on the current settings of the sourceSelector and
- * sourceVisible UI elements. If the "stopped" option is selected, reinitializes
- * the pipeline instead.
- */
-function updatePipelineSource() {
-  const sourceType = sourceSelector.options[sourceSelector.selectedIndex].value;
-  if (!sourceType || !pipeline) {
-    initPipeline();
-  } else {
-    updatePipelineSourceIfSet();
-  }
-}
-sourceSelector.oninput = updatePipelineSource;
-sourceSelector.disabled = false;
-
-/**
- * Updates the source visibility, if the source is already started.
- */
-function updatePipelineSourceVisibility() {
-  console.log(`[UI] Changed source visibility: ${
-      sourceVisibleCheckbox.checked ? 'added' : 'removed'}`);
-  if (pipeline) {
-    const source = pipeline.getSource();
-    if (source) {
-      source.setVisibility(sourceVisibleCheckbox.checked);
+  /**
+   * Updates the pipeline based on the current settings of the sourceSelector
+   * and sourceVisible UI elements. If the "stopped" option is selected,
+   * reinitializes the pipeline instead.
+   */
+  function updatePipelineSource() {
+    const sourceType =
+        sourceSelector.options[sourceSelector.selectedIndex].value;
+    if (!sourceType || !pipeline) {
+      initPipeline();
+    } else {
+      updatePipelineSourceIfSet();
     }
   }
-}
-sourceVisibleCheckbox.oninput = updatePipelineSourceVisibility;
-sourceVisibleCheckbox.disabled = false;
+  sourceSelector.oninput = updatePipelineSource;
+  sourceSelector.disabled = false;
 
-const transformSelector = /** @type {!HTMLSelectElement} */ (
-  document.getElementById('transformSelector'));
-/**
- * Updates the pipeline based on the current settings of the transformSelector
- * UI element.
- */
-function updatePipelineTransform() {
-  const transformType =
-      transformSelector.options[transformSelector.selectedIndex].value;
-  console.log(`[UI] Selected transform: ${transformType}`);
-  switch (transformType) {
-    case 'webgl':
-      pipeline.updateTransform(new WebGLTransform());
-      break;
-    case 'canvas2d':
-      pipeline.updateTransform(new CanvasTransform());
-      break;
-    case 'drop':
-      // Defined in simple-transforms.js.
-      pipeline.updateTransform(new DropTransform());
-      break;
-    case 'delay':
-      // Defined in simple-transforms.js.
-      pipeline.updateTransform(new DelayTransform());
-      break;
-    default:
-      alert(`unknown transform ${transformType}`);
-      break;
+  /**
+   * Updates the source visibility, if the source is already started.
+   */
+  function updatePipelineSourceVisibility() {
+    console.log(`[UI] Changed source visibility: ${
+        sourceVisibleCheckbox.checked ? 'added' : 'removed'}`);
+    if (pipeline) {
+      const source = pipeline.getSource();
+      if (source) {
+        source.setVisibility(sourceVisibleCheckbox.checked);
+      }
+    }
+  }
+  sourceVisibleCheckbox.oninput = updatePipelineSourceVisibility;
+  sourceVisibleCheckbox.disabled = false;
+
+  const transformSelector = /** @type {!HTMLSelectElement} */ (
+    document.getElementById('transformSelector'));
+  /**
+   * Updates the pipeline based on the current settings of the transformSelector
+   * UI element.
+   */
+  function updatePipelineTransform() {
+    const transformType =
+        transformSelector.options[transformSelector.selectedIndex].value;
+    console.log(`[UI] Selected transform: ${transformType}`);
+    switch (transformType) {
+      case 'webgl':
+        pipeline.updateTransform(new WebGLTransform());
+        break;
+      case 'canvas2d':
+        pipeline.updateTransform(new CanvasTransform());
+        break;
+      case 'drop':
+        // Defined in simple-transforms.js.
+        pipeline.updateTransform(new DropTransform());
+        break;
+      case 'delay':
+        // Defined in simple-transforms.js.
+        pipeline.updateTransform(new DelayTransform());
+        break;
+      default:
+        alert(`unknown transform ${transformType}`);
+        break;
+    }
+  }
+  transformSelector.oninput = updatePipelineTransform;
+  transformSelector.disabled = false;
+
+  const sinkSelector = (/** @type {!HTMLSelectElement} */ (
+    document.getElementById('sinkSelector')));
+  /**
+   * Updates the pipeline based on the current settings of the sinkSelector UI
+   * element.
+   */
+  function updatePipelineSink() {
+    const sinkType = sinkSelector.options[sinkSelector.selectedIndex].value;
+    console.log(`[UI] Selected sink: ${sinkType}`);
+    switch (sinkType) {
+      case 'video':
+        pipeline.updateSink(new VideoSink());
+        break;
+      case 'pc':
+        pipeline.updateSink(new PeerConnectionSink());
+        break;
+      default:
+        alert(`unknown sink ${sinkType}`);
+        break;
+    }
+  }
+  sinkSelector.oninput = updatePipelineSink;
+  sinkSelector.disabled = false;
+
+  /**
+   * Initializes/reinitializes the pipeline. Called on page load and after the
+   * user chooses to stop the video source.
+   */
+  function initPipeline() {
+    if (pipeline) pipeline.destroy();
+    pipeline = new Pipeline();
+    debug = {pipeline};
+    updatePipelineSourceIfSet();
+    updatePipelineTransform();
+    updatePipelineSink();
+    console.log(
+        '[initPipeline] Created new Pipeline.', 'debug.pipeline =', pipeline);
   }
 }
-transformSelector.oninput = updatePipelineTransform;
-transformSelector.disabled = false;
 
-const sinkSelector = (/** @type {!HTMLSelectElement} */ (
-  document.getElementById('sinkSelector')));
-/**
- * Updates the pipeline based on the current settings of the sinkSelector UI
- * element.
- */
-function updatePipelineSink() {
-  const sinkType = sinkSelector.options[sinkSelector.selectedIndex].value;
-  console.log(`[UI] Selected sink: ${sinkType}`);
-  switch (sinkType) {
-    case 'video':
-      pipeline.updateSink(new VideoSink());
-      break;
-    case 'pc':
-      pipeline.updateSink(new PeerConnectionSink());
-      break;
-    default:
-      alert(`unknown sink ${sinkType}`);
-      break;
-  }
-}
-sinkSelector.oninput = updatePipelineSink;
-sinkSelector.disabled = false;
-
-/**
- * Initializes/reinitializes the pipeline. Called on page load and after the
- * user chooses to stop the video source.
- */
-function initPipeline() {
-  if (pipeline) pipeline.destroy();
-  pipeline = new Pipeline();
-  debug = {pipeline};
-  updatePipelineSourceIfSet();
-  updatePipelineTransform();
-  updatePipelineSink();
-  console.log(
-      '[initPipeline] Created new Pipeline.', 'debug.pipeline =', pipeline);
-}
+window.onload = initUI;


### PR DESCRIPTION
For slow connections, there can be a long delay between when the page is visible (and the user can interact with the UI elements) and when all the scripts are loaded and the event handlers have been installed. This PR changes the controls to be disabled on page load and enabled when the handlers have been added to indicate when the page is ready.