### PR TITLE
Differentiate television 4k and cinema 4k

### DIFF
--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -33,7 +33,7 @@
 
         button {
             margin: 0 10px 20px 0;
-            width: 90px;
+            min-width: 90px;
         }
 
         div#buttons {
@@ -85,7 +85,8 @@
         <button id="vga">VGA</button>
         <button id="hd">HD</button>
         <button id="full-hd">Full HD</button>
-        <button id="fourK">4K</button>
+        <button id="televisionFourK">Television 4K (3840x2160)</button>
+        <button id="cinemaFourK">Cinema 4K (4096x2160)</button>
         <button id="eightK">8K</button>
     </div>
 

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -16,7 +16,8 @@ const vgaButton = document.querySelector('#vga');
 const qvgaButton = document.querySelector('#qvga');
 const hdButton = document.querySelector('#hd');
 const fullHdButton = document.querySelector('#full-hd');
-const fourKButton = document.querySelector('#fourK');
+const cinemaFourKButton = document.querySelector('#cinemaFourK');
+const televisionFourKButton = document.querySelector('#televisionFourK');
 const eightKButton = document.querySelector('#eightK');
 
 const videoblock = document.querySelector('#videoblock');
@@ -46,8 +47,12 @@ fullHdButton.onclick = () => {
   getMedia(fullHdConstraints);
 };
 
-fourKButton.onclick = () => {
-  getMedia(fourKConstraints);
+televisionFourKButton.onclick = () => {
+  getMedia(televisionFourKConstraints);
+};
+
+cinemaFourKButton.onclick = () => {
+  getMedia(cinemaFourKConstraints);
 };
 
 eightKButton.onclick = () => {
@@ -70,7 +75,11 @@ const fullHdConstraints = {
   video: {width: {exact: 1920}, height: {exact: 1080}}
 };
 
-const fourKConstraints = {
+const televisionFourKConstraints = {
+  video: {width: {exact: 3840}, height: {exact: 2160}}
+};
+
+const cinemaFourKConstraints = {
   video: {width: {exact: 4096}, height: {exact: 2160}}
 };
 


### PR DESCRIPTION
**Description**
The current page considers 4K to be the far less common cinema 4K, instead of differentiating between the considerably more common consumer (UHD) 4k and cinema (DCI) 4K.

**Purpose**
This creates two different profiles at the top: Television 4K (3840x2160) and Cinema 4K (4096x2160). It should now work with most of the common 4K webcams and cameras on the market.