### PR TITLE
http-server: disable http caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "test": "gulp",
-    "start": "http-server . -c -1"
+    "start": "http-server . -c-1"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
there is a small difference between `-c -1` and `-c-1`. The latter is what the http-server readme file suggests.
To validate check the devtools, cache-control: no-cache, no-store, must-revalidate
