### PR TITLE
Migrate from VideoFrame.destroy() to VideoFrame.close()

### DIFF
--- a/src/content/insertable-streams/video-processing/js/canvas-transform.js
+++ b/src/content/insertable-streams/video-processing/js/canvas-transform.js
@@ -44,7 +44,7 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
   async transform(frame, controller) {
     const ctx = this.ctx_;
     if (!this.canvas_ || !ctx) {
-      frame.destroy();
+      frame.close();
       return;
     }
     const width = frame.displayWidth;
@@ -57,7 +57,7 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
     // non-optional.
     const timestamp = /** @type {number} */ (frame.timestamp);
     const inputBitmap = await frame.createImageBitmap();
-    frame.destroy();
+    frame.close();
 
     ctx.drawImage(inputBitmap, 0, 0);
     inputBitmap.close();

--- a/src/content/insertable-streams/video-processing/js/main.js
+++ b/src/content/insertable-streams/video-processing/js/main.js
@@ -17,6 +17,11 @@ if (typeof MediaStreamTrackProcessor === 'undefined' ||
       'page.');
 }
 
+// In Chrome 88, VideoFrame.close() was called VideoFrame.destroy()
+if (VideoFrame.prototype.close === undefined) {
+  VideoFrame.prototype.close = VideoFrame.prototype.destroy;
+}
+
 /* global CameraSource */ // defined in camera-source.js
 /* global CanvasTransform */ // defined in canvas-transform.js
 /* global PeerConnectionSink */ // defined in peer-connection-sink.js
@@ -39,7 +44,7 @@ let debug = {};
  * FrameTransformFn applies a transform to a frame and queues the output frame
  * (if any) using the controller. The first argument is the input frame and the
  * second argument is the stream controller.
- * The VideoFrame should be destroyed as soon as it is no longer needed to free
+ * The VideoFrame should be closed as soon as it is no longer needed to free
  * resources and maintain good performance.
  * @typedef {function(
  *     !VideoFrame,

--- a/src/content/insertable-streams/video-processing/js/simple-transforms.js
+++ b/src/content/insertable-streams/video-processing/js/simple-transforms.js
@@ -35,7 +35,7 @@ class DropTransform { // eslint-disable-line no-unused-vars
     if (Math.random() < 0.5) {
       controller.enqueue(frame);
     } else {
-      frame.destroy();
+      frame.close();
     }
   }
   /** @override */

--- a/src/content/insertable-streams/video-processing/js/webcodec-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webcodec-transform.js
@@ -37,7 +37,7 @@ class WebCodecTransform { // eslint-disable-line no-unused-vars
   /** @override */
   async transform(frame, controller) {
     if (!this.encoder_) {
-      frame.destroy();
+      frame.close();
       return;
     }
     this.controller_ = controller;
@@ -54,7 +54,7 @@ class WebCodecTransform { // eslint-disable-line no-unused-vars
 
   handleDecodedFrame(videoFrame) {
     if (!this.controller_) {
-      videoFrame.destroy();
+      videoFrame.close();
       return;
     }
     this.controller_.enqueue(videoFrame);

--- a/src/content/insertable-streams/video-processing/js/webgl-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webgl-transform.js
@@ -153,7 +153,7 @@ class WebGLTransform { // eslint-disable-line no-unused-vars
   async transform(frame, controller) {
     const gl = this.gl_;
     if (!gl || !this.canvas_) {
-      frame.destroy();
+      frame.close();
       return;
     }
     const width = frame.displayWidth;
@@ -169,7 +169,7 @@ class WebGLTransform { // eslint-disable-line no-unused-vars
     // non-optional.
     const timestamp = /** @type {number} */ (frame.timestamp);
     const inputBitmap = await frame.createImageBitmap();
-    frame.destroy();
+    frame.close();
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.texture_);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);


### PR DESCRIPTION
In https://chromium.googlesource.com/chromium/src/+/4eab15e1d4e2c0c9e4a6369c9d65ac2f543d489a, the destroy method was renamed to close. Using the old name results in tons of messages in the console, which affects perf tests.
