### PR TITLE
Add Plan B mode to negotiation-timing page

### DIFF
--- a/src/content/peerconnection/negotiate-timing/index.html
+++ b/src/content/peerconnection/negotiate-timing/index.html
@@ -39,7 +39,8 @@
     <video id="remoteVideo" playsinline autoplay></video>
 
     <div>
-        <button id="startButton">Start</button>
+        <button id="startButton">Start<br>(standard)</button>
+        <button id="startButtonPlanB">Start<br>(legacy)</button>
         <button id="callButton">Call</button>
         <button id="renegotiateButton">Renegotiate</button>
         <button id="hangupButton">Hang Up</button>


### PR DESCRIPTION
This PR adds a "Start (legacy)" button that runs Plan B, and renames the old start-button to "Start (standard)".

Because transceivers are not available in Plan B, addTrack() is used instead of addTransceiver(). And because of Plan B limitations, the track has to actually exist at SDP offer time, so we can't replace(null) the dummy track immediately - we have to wait until after negotiation to do so.