### PR TITLE
Use new canvas/WebGL APIs to draw VideoFrame directly and create VideoFrame from canvas

### DIFF
--- a/src/content/insertable-streams/video-processing/js/canvas-transform.js
+++ b/src/content/insertable-streams/video-processing/js/canvas-transform.js
@@ -14,14 +14,27 @@
  */
 class CanvasTransform { // eslint-disable-line no-unused-vars
   constructor() {
-    // All fields are initialized in init()
-    /** @private {?OffscreenCanvas} canvas used to create the 2D context */
+    /**
+     * @private {?OffscreenCanvas} canvas used to create the 2D context.
+     *     Initialized in init.
+     */
     this.canvas_ = null;
     /**
      * @private {?CanvasRenderingContext2D} the 2D context used to draw the
-     *     effect
+     *     effect. Initialized in init.
      */
     this.ctx_ = null;
+    /**
+     * @private {boolean} If false, pass VideoFrame directly to
+     * CanvasRenderingContext2D.drawImage and create VideoFrame directly from
+     * this.canvas_. If either of these operations fail (it's not supported in
+     * Chrome <90 and broken in Chrome 90: https://crbug.com/1184128), we set
+     * this field to true; in that case we create an ImageBitmap from the
+     * VideoFrame and pass the ImageBitmap to drawImage on the input side and
+     * create the VideoFrame using an ImageBitmap of the canvas on the output
+     * side.
+     */
+    this.use_image_bitmap_ = false;
     /** @private {string} */
     this.debugPath_ = 'debug.pipeline.frameTransform_';
   }
@@ -51,16 +64,28 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
     const height = frame.displayHeight;
     this.canvas_.width = width;
     this.canvas_.height = height;
-    // VideoFrame.timestamp is technically optional, but that should never
-    // happen here.
-    // TODO(benjaminwagner): Follow up if we should change the spec so this is
-    // non-optional.
-    const timestamp = /** @type {number} */ (frame.timestamp);
-    const inputBitmap = await frame.createImageBitmap();
-    frame.close();
+    const timestamp = frame.timestamp;
 
-    ctx.drawImage(inputBitmap, 0, 0);
-    inputBitmap.close();
+    if (!this.use_image_bitmap_) {
+      try {
+        // Supported for Chrome 90+.
+        ctx.drawImage(frame, 0, 0);
+      } catch (e) {
+        // This should only happen on Chrome <90.
+        console.log(
+            '[CanvasTransform] Failed to draw VideoFrame directly. Falling ' +
+                'back to ImageBitmap.',
+            e);
+        this.use_image_bitmap_ = true;
+      }
+    }
+    if (this.use_image_bitmap_) {
+      // Supported for Chrome <92.
+      const inputBitmap = await frame.createImageBitmap();
+      ctx.drawImage(inputBitmap, 0, 0);
+      inputBitmap.close();
+    }
+    frame.close();
 
     ctx.shadowColor = '#000';
     ctx.shadowBlur = 20;
@@ -68,10 +93,24 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
     ctx.strokeStyle = '#000';
     ctx.strokeRect(0, 0, width, height);
 
-    const outputBitmap = await createImageBitmap(this.canvas_);
-    const outputFrame = new VideoFrame(outputBitmap, {timestamp});
-    outputBitmap.close();
-    controller.enqueue(outputFrame);
+    if (!this.use_image_bitmap_) {
+      try {
+        controller.enqueue(new VideoFrame(this.canvas_, {timestamp}));
+      } catch (e) {
+        // This should only happen on Chrome <91.
+        console.log(
+            '[CanvasTransform] Failed to create VideoFrame from ' +
+                'OffscreenCanvas directly. Falling back to ImageBitmap.',
+            e);
+        this.use_image_bitmap_ = true;
+      }
+    }
+    if (this.use_image_bitmap_) {
+      const outputBitmap = await createImageBitmap(this.canvas_);
+      const outputFrame = new VideoFrame(outputBitmap, {timestamp});
+      outputBitmap.close();
+      controller.enqueue(outputFrame);
+    }
   }
 
   /** @override */

--- a/src/content/insertable-streams/video-processing/js/webgl-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webgl-transform.js
@@ -25,6 +25,17 @@ class WebGLTransform { // eslint-disable-line no-unused-vars
     this.program_ = null;
     /** @private {?WebGLTexture} input texture */
     this.texture_ = null;
+    /**
+     * @private {boolean} If false, pass VideoFrame directly to
+     * WebGLRenderingContext.texImage2D and create VideoFrame directly from
+     * this.canvas_. If either of these operations fail (it's not supported in
+     * Chrome <90 and broken in Chrome 90: https://crbug.com/1184128), we set
+     * this field to true; in that case we create an ImageBitmap from the
+     * VideoFrame and pass the ImageBitmap to texImage2D on the input side and
+     * create the VideoFrame using an ImageBitmap of the canvas on the output
+     * side.
+     */
+    this.use_image_bitmap_ = false;
     /** @private {string} */
     this.debugPath_ = 'debug.pipeline.frameTransform_';
   }
@@ -163,27 +174,55 @@ class WebGLTransform { // eslint-disable-line no-unused-vars
       this.canvas_.height = height;
       gl.viewport(0, 0, width, height);
     }
-    // VideoFrame.timestamp is technically optional, but that should never
-    // happen here.
-    // TODO(benjaminwagner): Follow up if we should change the spec so this is
-    // non-optional.
-    const timestamp = /** @type {number} */ (frame.timestamp);
-    const inputBitmap = await frame.createImageBitmap();
-    frame.close();
+    const timestamp = frame.timestamp;
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.texture_);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    gl.texImage2D(
-        gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, inputBitmap);
-    inputBitmap.close();
+    if (!this.use_image_bitmap_) {
+      try {
+        // Supported for Chrome 90+.
+        gl.texImage2D(
+            gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, frame);
+      } catch (e) {
+        // This should only happen on Chrome <90.
+        console.log(
+            '[WebGLTransform] Failed to upload VideoFrame directly. Falling ' +
+                'back to ImageBitmap.',
+            e);
+        this.use_image_bitmap_ = true;
+      }
+    }
+    if (this.use_image_bitmap_) {
+      // Supported for Chrome <92.
+      const inputBitmap =
+            await frame.createImageBitmap({imageOrientation: 'flipY'});
+      gl.texImage2D(
+          gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, inputBitmap);
+      inputBitmap.close();
+    }
+    frame.close();
     gl.useProgram(this.program_);
     gl.uniform1i(this.sampler_, 0);
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
     gl.bindTexture(gl.TEXTURE_2D, null);
-    const outputBitmap = await createImageBitmap(this.canvas_);
-    const outputFrame = new VideoFrame(outputBitmap, {timestamp});
-    outputBitmap.close();
-    controller.enqueue(outputFrame);
+    if (!this.use_image_bitmap_) {
+      try {
+        controller.enqueue(new VideoFrame(this.canvas_, {timestamp}));
+      } catch (e) {
+        // This should only happen on Chrome <91.
+        console.log(
+            '[WebGLTransform] Failed to create VideoFrame from ' +
+                'OffscreenCanvas directly. Falling back to ImageBitmap.',
+            e);
+        this.use_image_bitmap_ = true;
+      }
+    }
+    if (this.use_image_bitmap_) {
+      const outputBitmap = await createImageBitmap(this.canvas_);
+      const outputFrame = new VideoFrame(outputBitmap, {timestamp});
+      outputBitmap.close();
+      controller.enqueue(outputFrame);
+    }
   }
 
   /** @override */


### PR DESCRIPTION
Use new canvas/WebGL APIs to draw VideoFrame directly and create VideoFrame from canvas

The new APIs are supported on Chrome 91+, and the old createImageBitmap API has been removed on Chrome 92. This patch enables the sample to work again on Chrome 92, and fixes an issue on Chrome 90 where the video is vertically flipped.

Tested on Chrome 90, 91, and 92 on Mac and Linux. A previous revision was also tested on Chrome 89.