### PR TITLE
Fixed typo and removed trailing spaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
             </li>
 
             <li><a href="src/content/peerconnection/webaudio-output/">Peer connection as input to Web Audio</a></li>
-            <li><a href="src/content/peerconnection/negotiate-timing/">Measure how long renegotation takes</a></li>
+            <li><a href="src/content/peerconnection/negotiate-timing/">Measure how long renegotiation takes</a></li>
         </ul>
         <h2 id="datachannel"><a
                 href="https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel">RTCDataChannel:</a></h2>
@@ -183,7 +183,7 @@
             <li><a href="src/content/datachannel/filetransfer/">Transfer a file</a></li>
 
             <li><a href="src/content/datachannel/datatransfer/">Transfer data</a></li>
-            
+
             <li><a href="src/content/datachannel/messaging/">Messaging</a></li>
         </ul>
 
@@ -202,8 +202,8 @@
         <ul>
             <li><a href="src/content/insertable-streams/endtoend-encryption">End to end encryption using WebRTC Insertable Streams</a></li> (Experimental)
             <li><a href="src/content/insertable-streams/video-analyzer">Video analyzer using WebRTC Insertable Streams</a></li> (Experimental)
-            <li><a href="src/content/insertable-streams/video-processing">Video processing using MediaStream Insertable Streams</a></li> (Experimental)            
-            <li><a href="src/content/insertable-streams/audio-processing">Audio processing using MediaStream Insertable Streams</a></li> (Experimental)            
+            <li><a href="src/content/insertable-streams/video-processing">Video processing using MediaStream Insertable Streams</a></li> (Experimental)
+            <li><a href="src/content/insertable-streams/audio-processing">Audio processing using MediaStream Insertable Streams</a></li> (Experimental)
         </ul>
 
     </section>


### PR DESCRIPTION
Fixed typo and removed trailing spaces in `index.html`