### PR TITLE
video-processing: discard alpha

### DIFF
--- a/src/content/insertable-streams/video-processing/js/canvas-transform.js
+++ b/src/content/insertable-streams/video-processing/js/canvas-transform.js
@@ -95,7 +95,8 @@ class CanvasTransform { // eslint-disable-line no-unused-vars
 
     if (!this.use_image_bitmap_) {
       try {
-        controller.enqueue(new VideoFrame(this.canvas_, {timestamp}));
+        // alpha: 'discard' is needed in order to send frames to a PeerConnection.
+        controller.enqueue(new VideoFrame(this.canvas_, {timestamp, alpha: 'discard'}));
       } catch (e) {
         // This should only happen on Chrome <91.
         console.log(

--- a/src/content/insertable-streams/video-processing/js/webgl-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webgl-transform.js
@@ -207,7 +207,8 @@ class WebGLTransform { // eslint-disable-line no-unused-vars
     gl.bindTexture(gl.TEXTURE_2D, null);
     if (!this.use_image_bitmap_) {
       try {
-        controller.enqueue(new VideoFrame(this.canvas_, {timestamp}));
+        // alpha: 'discard' is needed in order to send frames to a PeerConnection.
+        controller.enqueue(new VideoFrame(this.canvas_, {timestamp, alpha: 'discard'}));
       } catch (e) {
         // This should only happen on Chrome <91.
         console.log(


### PR DESCRIPTION
In the Insertable Streams Video Processing sample, discard alpha when creating VideoFrames so that the frames can be passed to a PeerConnection. Currently WebRTC can only handle opaque frames (and we don't want the alpha channel in this case anyway).