### PR TITLE
Substitute 'rightVideo' for 'this' in arrow function

### DIFF
--- a/src/content/capture/video-pc/js/main.js
+++ b/src/content/capture/video-pc/js/main.js
@@ -52,7 +52,7 @@ if (leftVideo.readyState >= 3) { // HAVE_FUTURE_DATA
 leftVideo.play();
 
 rightVideo.onloadedmetadata = () => {
-  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
+  console.log(`Remote video videoWidth: ${rightVideo.videoWidth}px,  videoHeight: ${rightVideo.videoHeight}px`);
 };
 
 rightVideo.onresize = () => {


### PR DESCRIPTION
**Description**
Substitute `rightVideo` for `this` in event handler that is an arrow function. 

**Purpose**
`this` is `globalThis`, `window` in arrow function, not `rightVideo`, resulting in 

```
Remote video videoWidth: undefinedpx,  videoHeight: undefinedpx
```
at

```
rightVideo.onloadedmetadata = () => {
  console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
};
```

![Screenshot_2021-10-11_17-07-22](https://user-images.githubusercontent.com/4174848/136869623-3e2d58ec-1030-4e7c-a65e-b7014652dfaf.png)


