### PR TITLE
Ensure WebCodecs BB sample closes VideoFrames

### DIFF
--- a/src/content/insertable-streams/video-processing/js/webcodec-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webcodec-transform.js
@@ -40,9 +40,12 @@ class WebCodecTransform { // eslint-disable-line no-unused-vars
       frame.close();
       return;
     }
-    this.controller_ = controller;
-    this.encoder_.encode(frame);
-    frame.close();
+    try {
+      this.controller_ = controller;
+      this.encoder_.encode(frame);
+    } finally {
+      frame.close();
+    }
   }
 
   /** @override */

--- a/src/content/insertable-streams/video-processing/js/webcodec-transform.js
+++ b/src/content/insertable-streams/video-processing/js/webcodec-transform.js
@@ -42,6 +42,7 @@ class WebCodecTransform { // eslint-disable-line no-unused-vars
     }
     this.controller_ = controller;
     this.encoder_.encode(frame);
+    frame.close();
   }
 
   /** @override */


### PR DESCRIPTION
Call frame.close() on received videoFrames after passing them to be
decoded. Without this, the video freezes due to too many VideoFrames
being kept around.