### PR TITLE
Fix link to testing page in readme

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
         <p>Most of the samples use <a href="https://github.com/webrtc/adapter">adapter.js</a>, a shim to insulate apps
             from spec changes and prefix differences.</p>
 
-        <p><a href="http://www.webrtc.org/testing" title="Command-line flags for WebRTC testing">https://webrtc.org/getting-started/testing</a>
+        <p><a href="https://webrtc.org/getting-started/testing" title="Command-line flags for WebRTC testing">https://webrtc.org/getting-started/testing</a>
             lists command line flags useful for development and testing with Chrome.</p>
 
         <p>Patches and issues welcome! See <a href="https://github.com/webrtc/samples/blob/gh-pages/CONTRIBUTING.md">CONTRIBUTING.md</a>


### PR DESCRIPTION
**Description**

Current testing link `https://webrtc.org/getting-started/testing` points to `http://www.webrtc.org/testing` which results in 404

**Purpose**

Fix the link.