### PR TITLE
Fix link to correct getUserMedia mozilla page

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
     <section>
 
-        <h2 id="getusermedia"><a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia">getUserMedia():</a>
+        <h2 id="getusermedia"><a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia">getUserMedia():</a>
         </h2>
         <p class="description">Access media devices</p>
         <ul>


### PR DESCRIPTION
**Description**

`getUserMedia()` header link is pointing to deprecated `Navigator.getUserMedia()` documentation page. Examples themselves are using new `MediaDevices.getUserMedia()` API. This change fixes the link to current API documentation.

**Purpose**

Fix documentation.
