### PR TITLE
Video processing sample: remove workarounds

### DIFF
--- a/src/content/insertable-streams/video-processing/index.html
+++ b/src/content/insertable-streams/video-processing/index.html
@@ -77,10 +77,8 @@
     <p>View the console to see logging.</p>
 
     <p>
-        <b>Note</b>: This sample is using an experimental API that has not yet been standardized. As
-        of 2020-11-16, this API is available in Chrome M88 if the experimental code is enabled on
-        the command line with
-        <code>--enable-blink-features=WebCodecs,MediaStreamInsertableStreams</code>.
+        <b>Note</b>: This sample is using an experimental API that has not yet been standardized.
+        This API is available in Chrome 94 or later.
     </p>
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/insertable-streams/video-processing"
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>

--- a/src/content/insertable-streams/video-processing/js/main.js
+++ b/src/content/insertable-streams/video-processing/js/main.js
@@ -17,11 +17,6 @@ if (typeof MediaStreamTrackProcessor === 'undefined' ||
       'page.');
 }
 
-// In Chrome 88, VideoFrame.close() was called VideoFrame.destroy()
-if (VideoFrame.prototype.close === undefined) {
-  VideoFrame.prototype.close = VideoFrame.prototype.destroy;
-}
-
 /* global CameraSource */ // defined in camera-source.js
 /* global CanvasSource */ // defined in canvas-source.js
 /* global CanvasTransform */ // defined in canvas-transform.js


### PR DESCRIPTION
Remove workarounds for bugs and API changes in older versions of Chrome.