### PR TITLE
Add call to AudioContext.close() to free up bluetooth device

### DIFF
--- a/src/content/getusermedia/volume/js/main.js
+++ b/src/content/getusermedia/volume/js/main.js
@@ -82,6 +82,7 @@ function stop() {
 
   window.stream.getTracks().forEach(track => track.stop());
   window.soundMeter.stop();
+  window.audioContext.close();
   clearInterval(meterRefresh);
   instantMeter.value = instantValueDisplay.innerText = '';
   slowMeter.value = slowValueDisplay.innerText = '';


### PR DESCRIPTION
**Description**
As detailed in #1514, bluetooth resources are not released by the AudioContext in Safari when using bluetooth headphones.
This PR adds a manual call to `audioContext.close()` to release the resource.

**Purpose**
Fix getusermedia/volume demo for safari users with bluetooth headphones 