### PR TITLE
Allow later versions of chromedriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
-    "chromedriver": "^76.0.1",
+    "chromedriver": ">76.0.1",
     "eslint-config-google": "^0.14.0",
     "extend": "^3.0.2",
     "fs": "0.0.2",


### PR DESCRIPTION
**Description**
Allow major updates of Chromedriver.

The syntax "^76.0.1" did not accept later major versions.
Since chromedriver seems to increment major versions together with Chrome, this quickly leads to obsolesence.
The syntax ">76.0.1" will accept any later version according to semver.npmjs.com.

**Purpose**
Install on platforms that 76.0.1 does not support.

Fixes #1431