### PR TITLE
fix autoplay woes detection in canvas-pc for  firefox

### DIFF
--- a/src/content/capture/canvas-pc/css/main.css
+++ b/src/content/capture/canvas-pc/css/main.css
@@ -22,3 +22,7 @@ video {
   margin: 1em;
   object-fit: cover;
 }
+
+#autoplay {
+  display: none;
+}

--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -26,11 +26,6 @@
     <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="../../../css/main.css"/>
     <link rel="stylesheet" href="css/main.css"/>
-    <style>
-        #autoplay {
-            display: none;
-        }
-    </style>
 </head>
 
 <body>

--- a/src/content/capture/canvas-pc/js/main.js
+++ b/src/content/capture/canvas-pc/js/main.js
@@ -19,6 +19,7 @@ let pc2;
 let startTime;
 
 video.addEventListener('loadedmetadata', function() {
+  document.getElementById('autoplay').style.display = 'none';
   console.log(`Remote video videoWidth: ${this.videoWidth}px,  videoHeight: ${this.videoHeight}px`);
 });
 


### PR DESCRIPTION
paused is initially true there, listening for the loadedmetadata
event allows hiding the text again

follow-up to #1513