### PR TITLE
Demo Safari Bluetooth AudioContext error:  MediaStreamTrack ended due to a capture failure

### DIFF
--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -79,6 +79,15 @@ function changeAudioDestination() {
 function gotStream(stream) {
   window.stream = stream; // make stream available to console
   videoElement.srcObject = stream;
+
+  try {
+    window.AudioContext = window.AudioContext || window.webkitAudioContext;
+    window.audioContext = window.audioContext || new AudioContext();
+  } catch (e) {
+    alert('Web Audio API not supported.');
+  }
+  window.audioContext.createMediaStreamSource(stream);
+
   // Refresh button list in case labels have become available
   return navigator.mediaDevices.enumerateDevices();
 }


### PR DESCRIPTION
Add an AudioContext and node to stream to demo Safari bug:

Steps To Reproduce:
- with bluetooth headphones (able to reproduce using Sony WH-1000XM3 and Bose NC700 headphones)
- checkout branch and `npm i && npm start`
- in safari open http://localhost:8080/src/content/devices/input-output/
- bluetooth headphones should be selected
- select another input source
- select bluetooth headphones again
- Observe in console:  `A MediaStreamTrack ended due to a capture failure`
- audio track is not captured