### PR TITLE
Camera exposure example

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,8 @@
             <li><a href="src/content/getusermedia/getdisplaymedia/">Screensharing with getDisplayMedia</a></li>
 
             <li><a href="src/content/getusermedia/pan-tilt-zoom/">Control camera pan, tilt, and zoom</a></li>
+			
+			<li><a href="src/content/getusermedia/exposure/">Control exposure</a></li>
         </ul>
         <h2 id="devices">Devices:</h2>
         <p class="description">Query media devices</p>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
             <li><a href="src/content/getusermedia/pan-tilt-zoom/">Control camera pan, tilt, and zoom</a></li>
 			
-			<li><a href="src/content/getusermedia/exposure/">Control exposure</a></li>
+            <li><a href="src/content/getusermedia/exposure/">Control exposure</a></li>
         </ul>
         <h2 id="devices">Devices:</h2>
         <p class="description">Query media devices</p>

--- a/src/content/getusermedia/exposure/index.html
+++ b/src/content/getusermedia/exposure/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2022 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -55,23 +55,23 @@
         <div class="label">Exposure Time:</div>
         <input name="exposureTime" type="range" disabled>
     </div>
-	
+
     <div>
         <div class="label">Exposure Compensation:</div>
         <input name="exposureCompensation" type="range" disabled>
     </div>
-	
+
 	<div>
         <div class="label">Brightness:</div>
         <input name="brightness" type="range" disabled>
     </div>
-	
+
 	<div>
         <div class="label">White Balance Mode:</div>
         <select name="whiteBalanceMode" id="whiteBalanceMode" disabled>
         </select>
     </div>
-	
+
 	<button id="refreshControls" onClick="loadProperties(true)" disabled>Refresh Controls</button>
 
     <div id="errorMsg"></div>

--- a/src/content/getusermedia/exposure/index.html
+++ b/src/content/getusermedia/exposure/index.html
@@ -31,7 +31,7 @@
             display: inline-block;
             font-weight: 400;
             margin: 0 0.5em 0 0;
-            width: 3.5em;
+            width: 10em;
         }
     </style>
 </head>
@@ -55,9 +55,21 @@
         <div class="label">Exposure Time:</div>
         <input name="exposureTime" type="range" disabled>
     </div>
+	
     <div>
         <div class="label">Exposure Compensation:</div>
         <input name="exposureCompensation" type="range" disabled>
+    </div>
+	
+	<div>
+        <div class="label">Brightness:</div>
+        <input name="brightness" type="range" disabled>
+    </div>
+	
+	<div>
+        <div class="label">White Balance Mode:</div>
+        <select name="whiteBalanceMode" id="whiteBalanceMode" disabled>
+        </select>
     </div>
 
     <div id="errorMsg"></div>

--- a/src/content/getusermedia/exposure/index.html
+++ b/src/content/getusermedia/exposure/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+
+    <meta charset="utf-8">
+    <meta name="description" content="WebRTC code samples">
+    <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1">
+    <meta itemprop="description" content="Client-side WebRTC code samples">
+    <meta itemprop="image" content="../../../images/webrtc-icon-192x192.png">
+    <meta itemprop="name" content="WebRTC code samples">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta id="theme-color" name="theme-color" content="#ffffff">
+
+    <base target="_blank">
+
+    <title>Control camera pan, tilt, and zoom</title>
+
+    <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
+    <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" href="../../../css/main.css">
+
+    <style>
+        div.label {
+            display: inline-block;
+            font-weight: 400;
+            margin: 0 0.5em 0 0;
+            width: 3.5em;
+        }
+    </style>
+</head>
+
+<body>
+
+<div id="container">
+    <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a>
+        <span>Control Exposure</span></h1>
+
+    <video id="gum-local" autoplay playsinline></video>
+    <button id="showVideo">Open camera</button>
+
+    <div>
+        <div class="label">Exposure Mode:</div>
+        <select name="exposureMode" id="exposureMode" disabled>
+            <option value="volvo">Volvo</option>
+            <option value="saab">Saab</option>
+            <option value="mercedes">Mercedes</option>
+            <option value="audi">Audi</option>
+        </select>
+    </div>
+
+    <div>
+        <div class="label">Exposure Time:</div>
+        <input name="exposureTime" type="range" disabled>
+    </div>
+    <div>
+        <div class="label">Exposure Compensation:</div>
+        <input name="exposureCompensation" type="range" disabled>
+    </div>
+
+    <div id="errorMsg"></div>
+
+    <p>Display the video stream from <code>getUserMedia()</code> in a video
+    element and control exposureMode, exposureTime and exposureCompensation if camera supports it.</p>
+
+    <p>The <code>MediaStreamTrack</code> object <code>track</code> is in
+        global scope, so you can inspect it from the console.</p>
+
+    <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/exposure"
+       title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+</div>
+
+<script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+<script src="js/main.js"></script>
+
+<script src="../../../js/lib/ga.js"></script>
+
+</body>
+</html>

--- a/src/content/getusermedia/exposure/index.html
+++ b/src/content/getusermedia/exposure/index.html
@@ -20,7 +20,7 @@
 
     <base target="_blank">
 
-    <title>Control camera pan, tilt, and zoom</title>
+    <title>Control Exposure</title>
 
     <link rel="icon" sizes="192x192" href="../../../images/webrtc-icon-192x192.png">
     <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
@@ -48,10 +48,6 @@
     <div>
         <div class="label">Exposure Mode:</div>
         <select name="exposureMode" id="exposureMode" disabled>
-            <option value="volvo">Volvo</option>
-            <option value="saab">Saab</option>
-            <option value="mercedes">Mercedes</option>
-            <option value="audi">Audi</option>
         </select>
     </div>
 

--- a/src/content/getusermedia/exposure/index.html
+++ b/src/content/getusermedia/exposure/index.html
@@ -71,6 +71,8 @@
         <select name="whiteBalanceMode" id="whiteBalanceMode" disabled>
         </select>
     </div>
+	
+	<button id="refreshControls" onClick="loadProperties(true)" disabled>Refresh Controls</button>
 
     <div id="errorMsg"></div>
 

--- a/src/content/getusermedia/exposure/js/main.js
+++ b/src/content/getusermedia/exposure/js/main.js
@@ -21,7 +21,7 @@ function handleSuccess(stream) {
   video.srcObject = stream;
 
   // make track variable available to browser console.
-  const [track] = [window.track] = stream.getVideoTracks();
+  [window.track] = stream.getVideoTracks();
 
   loadProperties();
 
@@ -29,7 +29,6 @@ function handleSuccess(stream) {
 }
 
 function loadProperties(refreshValuesOnly) {
-
   const track = window.track;
   const capabilities = track.getCapabilities();
   const settings = track.getSettings();
@@ -65,20 +64,19 @@ function loadProperties(refreshValuesOnly) {
 
     element.value = settings[property];
     element.disabled = false;
-	if (!refreshValuesOnly) {
-		element.oninput = async event => {
+    if (!refreshValuesOnly) {
+      element.oninput = async event => {
         try {
           const constraints = {advanced: [{[property]: element.value}]};
           await track.applyConstraints(constraints);
-		  console.log('Did successfully apply new constraints: ', constraints);
-		  console.log('New camera settings: ', track.getSettings());
+          console.log('Did successfully apply new constraints: ', constraints);
+          console.log('New camera settings: ', track.getSettings());
         } catch (err) {
           console.error('applyConstraints() failed: ', err);
         }
-	  };
-	}
+      };
+    }
   }
-
 }
 
 function handleError(error) {

--- a/src/content/getusermedia/exposure/js/main.js
+++ b/src/content/getusermedia/exposure/js/main.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2022 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -9,9 +9,8 @@
 
 // Put variables in global scope to make them available to the browser console.
 const constraints = window.constraints = {
-  video: {
-    pan: true, tilt: true, zoom: true
-  }
+  audio: false,
+  video: true
 };
 
 function handleSuccess(stream) {
@@ -25,18 +24,18 @@ function handleSuccess(stream) {
   const [track] = [window.track] = stream.getVideoTracks();
 
   loadProperties();
-  
+
   document.querySelector(`button[id=refreshControls]`).disabled = false;
 }
 
 function loadProperties(refreshValuesOnly) {
-  
+
   const track = window.track;
   const capabilities = track.getCapabilities();
   const settings = track.getSettings();
   console.log('Capabilities: ', capabilities);
   console.log('Settings: ', settings);
-	
+
   for (const property of ['exposureMode', 'exposureTime', 'exposureCompensation', 'brightness', 'whiteBalanceMode']) {
     // Check whether camera supports exposure.
     if (!(property in settings)) {
@@ -79,7 +78,7 @@ function loadProperties(refreshValuesOnly) {
 	  };
 	}
   }
-	
+
 }
 
 function handleError(error) {

--- a/src/content/getusermedia/exposure/js/main.js
+++ b/src/content/getusermedia/exposure/js/main.js
@@ -28,7 +28,7 @@ function handleSuccess(stream) {
   console.log('Initial capabilities: ', capabilities);
   console.log('Initial settings: ', settings);
 
-  for (const ptz of ['exposureMode', 'exposureTime', 'exposureCompensation']) {
+  for (const ptz of ['exposureMode', 'exposureTime', 'exposureCompensation', 'brightness', 'whiteBalanceMode']) {
     // Check whether camera supports exposure.
     if (!(ptz in settings)) {
       errorMsg(`Camera does not support ${ptz}.`);
@@ -37,7 +37,7 @@ function handleSuccess(stream) {
 
     let element;
 
-    if (ptz === 'exposureMode') {
+    if (Array.isArray(capabilities[ptz])) {
       // Map it to a select element.
       const select = document.querySelector(`select[name=${ptz}]`);
       element = select;

--- a/src/content/getusermedia/exposure/js/main.js
+++ b/src/content/getusermedia/exposure/js/main.js
@@ -43,7 +43,7 @@ function handleSuccess(stream) {
       element = select;
       if (capabilities.exposureMode) {
         for (const mode of capabilities.exposureMode) {
-          select.innerHTML(`<option value="${mode}">mode</option>`);
+          select.insertAdjacentHTML('afterbegin', `<option value="${mode}">${mode}</option>`);
         }
       }
     } else {
@@ -61,6 +61,8 @@ function handleSuccess(stream) {
       try {
         const constraints = {advanced: [{[ptz]: element.value}]};
         await track.applyConstraints(constraints);
+		console.log('Did successfully apply new constraints: ', constraints);
+		console.log('New camera settings: ', track.getSettings());
       } catch (err) {
         console.error('applyConstraints() failed: ', err);
       }

--- a/src/content/getusermedia/exposure/js/main.js
+++ b/src/content/getusermedia/exposure/js/main.js
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+'use strict';
+
+// Put variables in global scope to make them available to the browser console.
+const constraints = window.constraints = {
+  video: {
+    pan: true, tilt: true, zoom: true
+  }
+};
+
+function handleSuccess(stream) {
+  const video = document.querySelector('video');
+  const videoTracks = stream.getVideoTracks();
+  console.log('Got stream with constraints:', constraints);
+  console.log(`Using video device: ${videoTracks[0].label}`);
+  video.srcObject = stream;
+
+  // make track variable available to browser console.
+  const [track] = [window.track] = stream.getVideoTracks();
+  const capabilities = track.getCapabilities();
+  const settings = track.getSettings();
+  console.log('Initial capabilities: ', capabilities);
+  console.log('Initial settings: ', settings);
+
+  for (const ptz of ['exposureMode', 'exposureTime', 'exposureCompensation']) {
+    // Check whether camera supports exposure.
+    if (!(ptz in settings)) {
+      errorMsg(`Camera does not support ${ptz}.`);
+      continue;
+    }
+
+    let element;
+
+    if (ptz === 'exposureMode') {
+      // Map it to a select element.
+      const select = document.querySelector(`select[name=${ptz}]`);
+      element = select;
+      if (capabilities.exposureMode) {
+        for (const mode of capabilities.exposureMode) {
+          select.innerHTML(`<option value="${mode}">mode</option>`);
+        }
+      }
+    } else {
+      // Map it to a slider element.
+      const input = document.querySelector(`input[name=${ptz}]`);
+      element = input;
+      input.min = capabilities[ptz].min;
+      input.max = capabilities[ptz].max;
+      input.step = capabilities[ptz].step;
+    }
+
+    element.value = settings[ptz];
+    element.disabled = false;
+    element.oninput = async event => {
+      try {
+        const constraints = {advanced: [{[ptz]: element.value}]};
+        await track.applyConstraints(constraints);
+      } catch (err) {
+        console.error('applyConstraints() failed: ', err);
+      }
+    };
+
+
+  }
+}
+
+function handleError(error) {
+  if (error.name === 'NotAllowedError') {
+    errorMsg('Permissions have not been granted to use your camera, ' +
+      'you need to allow the page access to your devices in ' +
+      'order for the demo to work.');
+  }
+  errorMsg(`getUserMedia error: ${error.name}`, error);
+}
+
+function errorMsg(msg, error) {
+  const errorElement = document.querySelector('#errorMsg');
+  errorElement.innerHTML += `<p>${msg}</p>`;
+  if (typeof error !== 'undefined') {
+    console.error(error);
+  }
+}
+
+async function init(e) {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
+    handleSuccess(stream);
+    e.target.disabled = true;
+  } catch (e) {
+    handleError(e);
+  }
+}
+
+document.querySelector('#showVideo').addEventListener('click', e => init(e));


### PR DESCRIPTION
**Description**
Added an example for exposure control based on getusermedia/ptz. 
Tested on Windows with Logitech Brio and C525 using official Logitech drivers.

**Purpose**
- The support for exposure controls differs between cameras, platforms and drivers. It's nice to have an easy way to test it.
- Keep @fippo busy 😉