### PR TITLE
ice-restart: fix functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         browser: [chrome]

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "devDependencies": {
     "chai": "^4.3.6",
-    "chromedriver": "^98.0.1",
+    "chromedriver": ">98.0.1",
     "eslint": "^8.9.0",
     "eslint-config-google": "^0.14.0",
     "geckodriver": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "http-server . -c-1",
     "test": "npm run eslint && npm run stylelint",
     "eslint": "eslint 'src/content/**/*.js'",
-    "mocha": "mocha 'src/content/**/test.js'",
+    "mocha": "mocha --timeout 5000 'src/content/**/test.js'",
     "stylelint": "stylelint 'src/**/*.css'"
   },
   "eslintIgnore": [

--- a/src/content/datachannel/filetransfer/js/test.js
+++ b/src/content/datachannel/filetransfer/js/test.js
@@ -15,7 +15,7 @@ let driver;
 const path = '/src/content/datachannel/filetransfer/index.html';
 const url = `${process.env.BASEURL ? process.env.BASEURL : ('file://' + process.cwd())}${path}`;
 
-describe('datachannel basic', () => {
+describe('datachannel filetransfer', () => {
   before(() => {
     driver = seleniumHelpers.buildDriver();
   });

--- a/src/content/peerconnection/restart-ice/js/test.js
+++ b/src/content/peerconnection/restart-ice/js/test.js
@@ -16,7 +16,7 @@ let driver;
 const path = '/src/content/peerconnection/restart-ice/index.html';
 const url = `${process.env.BASEURL ? process.env.BASEURL : ('file://' + process.cwd())}${path}`;
 
-describe.skip('peerconnection ice restart', () => {
+describe('peerconnection ice restart', () => {
   before(() => {
     driver = seleniumHelpers.buildDriver();
   });
@@ -58,7 +58,6 @@ describe.skip('peerconnection ice restart', () => {
     await driver.wait(() => driver.findElement(webdriver.By.id('restartButton')).isEnabled());
     await driver.findElement(webdriver.By.id('restartButton')).click();
 
-    await driver.wait(() => !driver.findElement(webdriver.By.id('restartButton')).isEnabled());
     await driver.wait(() => driver.findElement(webdriver.By.id('restartButton')).isEnabled());
 
     const secondCandidateIds = await Promise.all([


### PR DESCRIPTION
by listening to the transport selectedcandidatepairchange event.
This sample has been relying on the somewhat buggy but useful behavior
of the "legacy" iceconnectionstatechange firing a "connected" event even
if the previous state was already connected.

This behavior is no longer supported in the spec iceconnectionstatechange
event. Alternatively listen to the selectedcandidatepairchange event and
determine the availability of new candidates based on that