### PR TITLE
permission: need to call resume()

### DIFF
--- a/src/content/peerconnection/webaudio-input/js/webaudioextended.js
+++ b/src/content/peerconnection/webaudio-input/js/webaudioextended.js
@@ -13,7 +13,17 @@
 function WebAudioExtended() {
   window.AudioContext = window.AudioContext || window.webkitAudioContext;
   /* global AudioContext */
-  this.context = new AudioContext();
+  const self = this;
+  // tricky solution for suspended state
+  // for more information => https://developer.chrome.com/blog/autoplay/#web-audio
+  navigator.mediaDevices.getUserMedia({
+    audio: true,
+    video: false,
+  }).then(() => {
+    self.context = new AudioContext();
+  }).catch((err) => {
+    alert(`ERROR : ${err.message}`);
+  });
   this.soundBuffer = null;
 }
 


### PR DESCRIPTION
**Description**
In this page : https://developer.chrome.com/blog/autoplay/#web-audio
When we read the relevant page, we may need to make changes from the
beginning, so we ask the user what to do before the AudioContext is
called.

**Purpose**
`"The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page."` It was not working because of this error, it has been fixed.