### PR TITLE
Make the gDM example request audio

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -40,7 +40,7 @@ function errorMsg(msg, error) {
 
 const startButton = document.getElementById('startButton');
 startButton.addEventListener('click', () => {
-  navigator.mediaDevices.getDisplayMedia({video: true})
+  navigator.mediaDevices.getDisplayMedia({video: true, audio: true})
       .then(handleSuccess, handleError);
 });
 


### PR DESCRIPTION
As a Chromium committer, I use this page often to trigger gDM. I know many others who do the same. And we often need audio, which then requires us to use the DevTools console. Or worse, we interact with someone trying to reproduce an issue, and they report that "audio has now also stopped working" after interacting with this page.
