### PR TITLE
getdisplaymedia: add displaysurface

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -37,7 +37,7 @@
     <button id="startButton" disabled>Start</button>
     <select id="preference" style="display:none">
       <option value="" selected>Share the default</option>
-      <option value="browser">Share a browser window</option>
+      <option value="browser">Share a browser tab</option>
       <option value="window">Share another window</option>
       <option value="monitor">Share the entire screen</option>
     </select>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -36,7 +36,7 @@
     <video id="gum-local" autoplay playsinline muted></video>
     <button id="startButton" disabled>Start</button>
     <select id="displaySurface" style="display:none">
-      <option value="" selected>Share the default</option>
+      <option value="default" selected>Share the default</option>
       <option value="browser">Share a browser tab</option>
       <option value="window">Share a window</option>
       <option value="monitor">Share the entire screen</option>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -35,12 +35,15 @@
 
     <video id="gum-local" autoplay playsinline muted></video>
     <button id="startButton" disabled>Start</button>
-    <select id="displaySurface" style="display:none">
-      <option value="default" selected>Share the default</option>
-      <option value="browser">Share a browser tab</option>
-      <option value="window">Share a window</option>
-      <option value="monitor">Share the entire screen</option>
-    </select>
+    <fieldset id="options" style="display:none">
+      <legend>Advanced options</legend>
+      <select id="displaySurface">
+        <option value="default" selected>Show default sharing options</option>
+        <option value="browser">Prefer to share a browser tab</option>
+        <option value="window">Prefer to share a window</option>
+        <option value="monitor">Prefer to share the entire screen</option>
+      </select>
+    </fieldset>
     <div id="errorMsg"></div>
 
     <p>Display the screensharing stream from <code>getDisplayMedia()</code> in a video element.</p>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -41,7 +41,7 @@
         <option value="default" selected>Show default sharing options</option>
         <option value="browser">Prefer to share a browser tab</option>
         <option value="window">Prefer to share a window</option>
-        <option value="monitor">Prefer to share the entire screen</option>
+        <option value="monitor">Prefer to share an entire screen</option>
       </select>
     </fieldset>
     <div id="errorMsg"></div>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -35,7 +35,7 @@
 
     <video id="gum-local" autoplay playsinline muted></video>
     <button id="startButton" disabled>Start</button>
-    <select id="preference" style="display:none">
+    <select id="displaySurface" style="display:none">
       <option value="" selected>Share the default</option>
       <option value="browser">Share a browser tab</option>
       <option value="window">Share a window</option>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -35,7 +35,12 @@
 
     <video id="gum-local" autoplay playsinline muted></video>
     <button id="startButton" disabled>Start</button>
-
+    <select id="preference" style="display:none">
+      <option value="" selected>Share the default</option>
+      <option value="browser">Share a browser window</option>
+      <option value="window">Share another window</option>
+      <option value="monitor">Share the entire screen</option>
+    </select>
     <div id="errorMsg"></div>
 
     <p>Display the screensharing stream from <code>getDisplayMedia()</code> in a video element.</p>

--- a/src/content/getusermedia/getdisplaymedia/index.html
+++ b/src/content/getusermedia/getdisplaymedia/index.html
@@ -38,7 +38,7 @@
     <select id="preference" style="display:none">
       <option value="" selected>Share the default</option>
       <option value="browser">Share a browser tab</option>
-      <option value="window">Share another window</option>
+      <option value="window">Share a window</option>
       <option value="monitor">Share the entire screen</option>
     </select>
     <div id="errorMsg"></div>

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const preferredDisplaySurface = document.getElementById('displaySurface');
+const startButton = document.getElementById('startButton');
 
 if (adapter.browserDetails.browser === 'chrome' &&
     adapter.browserDetails.version >= 107) {
@@ -46,12 +47,12 @@ function errorMsg(msg, error) {
   }
 }
 
-const startButton = document.getElementById('startButton');
+
 startButton.addEventListener('click', () => {
-  let options = {audio: true, video: true};
+  const options = {audio: true, video: true};
   const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex].value;
   if (displaySurface !== 'default') {
-    options.video = { displaySurface };
+    options.video = {displaySurface};
   }
   navigator.mediaDevices.getDisplayMedia(options)
       .then(handleSuccess, handleError);

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -7,9 +7,14 @@
  */
 'use strict';
 
-// Polyfill in Firefox.
-// See https://blog.mozilla.org/webrtc/getdisplaymedia-now-available-in-adapter-js/
-if (adapter.browserDetails.browser == 'firefox') {
+const sharingPreference = document.getElementById('preference');
+
+if (adapter.browserDetails.browser === 'chrome' && adapter.browserDetails.version >= 107) {
+  // See https://developer.chrome.com/docs/web-platform/screen-sharing-controls/
+  sharingPreference.style.display = 'block';
+} else if (adapter.browserDetails.browser === 'firefox') {
+  // Polyfill in Firefox.
+  // See https://blog.mozilla.org/webrtc/getdisplaymedia-now-available-in-adapter-js/
   adapter.browserShim.shimGetDisplayMedia(window, 'screen');
 }
 
@@ -23,6 +28,7 @@ function handleSuccess(stream) {
   stream.getVideoTracks()[0].addEventListener('ended', () => {
     errorMsg('The user has ended sharing the screen');
     startButton.disabled = false;
+    sharingPreference.disabled = false;
   });
 }
 
@@ -40,7 +46,13 @@ function errorMsg(msg, error) {
 
 const startButton = document.getElementById('startButton');
 startButton.addEventListener('click', () => {
-  navigator.mediaDevices.getDisplayMedia({video: true, audio: true})
+  const options = {audio: true, video: {}};
+  const displaySurface = sharingPreference.options[sharingPreference.selectedIndex];
+  if (displaySurface.value !== '') {
+    options.video.displaySurface = displaySurface.value;
+  }
+  sharingPreference.disabled = true;
+  navigator.mediaDevices.getDisplayMedia(options)
       .then(handleSuccess, handleError);
 });
 

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -48,7 +48,7 @@ function errorMsg(msg, error) {
 
 const startButton = document.getElementById('startButton');
 startButton.addEventListener('click', () => {
-  const options = {audio: true, video: {}};
+  let options = {audio: true, video: true};
   const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex].value;
   if (displaySurface !== 'default') {
     options.video = { displaySurface };

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -49,9 +49,9 @@ function errorMsg(msg, error) {
 const startButton = document.getElementById('startButton');
 startButton.addEventListener('click', () => {
   const options = {audio: true, video: {}};
-  const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex];
-  if (displaySurface.value !== 'default') {
-    options.video.displaySurface = displaySurface.value;
+  const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex].value;
+  if (displaySurface !== 'default') {
+    options.video = { displaySurface };
   }
   navigator.mediaDevices.getDisplayMedia(options)
       .then(handleSuccess, handleError);

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -7,11 +7,11 @@
  */
 'use strict';
 
-const sharingPreference = document.getElementById('preference');
+const preferredDisplaySurface = document.getElementById('displaySurface');
 
 if (adapter.browserDetails.browser === 'chrome' && adapter.browserDetails.version >= 107) {
   // See https://developer.chrome.com/docs/web-platform/screen-sharing-controls/
-  sharingPreference.style.display = 'block';
+  preferredDisplaySurface.style.display = 'block';
 } else if (adapter.browserDetails.browser === 'firefox') {
   // Polyfill in Firefox.
   // See https://blog.mozilla.org/webrtc/getdisplaymedia-now-available-in-adapter-js/
@@ -20,6 +20,7 @@ if (adapter.browserDetails.browser === 'chrome' && adapter.browserDetails.versio
 
 function handleSuccess(stream) {
   startButton.disabled = true;
+  preferredDisplaySurface.disabled = true;
   const video = document.querySelector('video');
   video.srcObject = stream;
 
@@ -28,7 +29,7 @@ function handleSuccess(stream) {
   stream.getVideoTracks()[0].addEventListener('ended', () => {
     errorMsg('The user has ended sharing the screen');
     startButton.disabled = false;
-    sharingPreference.disabled = false;
+    preferredDisplaySurface.disabled = false;
   });
 }
 
@@ -47,11 +48,10 @@ function errorMsg(msg, error) {
 const startButton = document.getElementById('startButton');
 startButton.addEventListener('click', () => {
   const options = {audio: true, video: {}};
-  const displaySurface = sharingPreference.options[sharingPreference.selectedIndex];
+  const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex];
   if (displaySurface.value !== '') {
     options.video.displaySurface = displaySurface.value;
   }
-  sharingPreference.disabled = true;
   navigator.mediaDevices.getDisplayMedia(options)
       .then(handleSuccess, handleError);
 });

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -49,7 +49,7 @@ const startButton = document.getElementById('startButton');
 startButton.addEventListener('click', () => {
   const options = {audio: true, video: {}};
   const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex];
-  if (displaySurface.value !== '') {
+  if (displaySurface.value !== 'default') {
     options.video.displaySurface = displaySurface.value;
   }
   navigator.mediaDevices.getDisplayMedia(options)

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -9,9 +9,10 @@
 
 const preferredDisplaySurface = document.getElementById('displaySurface');
 
-if (adapter.browserDetails.browser === 'chrome' && adapter.browserDetails.version >= 107) {
+if (adapter.browserDetails.browser === 'chrome' &&
+    adapter.browserDetails.version >= 107) {
   // See https://developer.chrome.com/docs/web-platform/screen-sharing-controls/
-  preferredDisplaySurface.style.display = 'block';
+  document.getElementById('options').style.display = 'block';
 } else if (adapter.browserDetails.browser === 'firefox') {
   // Polyfill in Firefox.
   // See https://blog.mozilla.org/webrtc/getdisplaymedia-now-available-in-adapter-js/

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -236,6 +236,14 @@ ul {
   margin: 0 0 0.5em 0;
 }
 
+fieldset {
+  margin: 0 0 1em 0;
+}
+
+fieldset > select {
+  margin-top: 1em;
+}
+
 @media screen and (max-width: 650px) {
   .highlight {
     font-size: 1em;
@@ -263,5 +271,3 @@ ul {
     font-size: 20px;
   }
 }
-
-


### PR DESCRIPTION
described in https://developer.chrome.com/docs/web-platform/screen-sharing-controls/

@eladalon1983 it seems https://developer.chrome.com/docs/web-platform/screen-sharing-controls/#displaySurface has displaySurface at the wrong level, no?