### PR TITLE
test: change interop test to run mocha instead of mocha npm script

### DIFF
--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -1,7 +1,6 @@
 on:
   schedule:
     - cron: "30 5 * * *"
-  push:
 jobs:
   interop:
     runs-on: ubuntu-latest
@@ -19,4 +18,4 @@ jobs:
     - run: BROWSER=${{matrix.browserA}} BVER=${{matrix.bver}} ./node_modules/travis-multirunner/setup.sh
     - run: BROWSER=${{matrix.browserB}} BVER=${{matrix.bver}} ./node_modules/travis-multirunner/setup.sh
     - run: Xvfb :99 &
-    - run: BROWSER_A=${{matrix.browserA}} BROWSER_B=${{matrix.browserB}} BVER=${{matrix.bver}} DISPLAY=:99.0 npm run mocha test/interop/connection.js
+    - run: BROWSER_A=${{matrix.browserA}} BROWSER_B=${{matrix.browserB}} BVER=${{matrix.bver}} DISPLAY=:99.0 node_modules/.bin/mocha test/interop/connection.js


### PR DESCRIPTION
since package.json contains a "mocha" script/task this was running this task with the usual tests done on every PR instead of the actually intended interop tests.

Also removes the on-push trigger
