### PR TITLE
trickle-ice: trim information about candidates

### DIFF
--- a/src/content/peerconnection/trickle-ice/css/main.css
+++ b/src/content/peerconnection/trickle-ice/css/main.css
@@ -69,7 +69,3 @@ th:nth-child(6),td:nth-child(6) {
 #error-note {
   display: none;
 }
-
-div#container {
-  max-width: 90em;
-}

--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -118,18 +118,14 @@
             <thead id="candidatesHead">
             <tr>
                 <th>Time</th>
-                <th>Component</th>
                 <th>Type</th>
                 <th>Foundation</th>
                 <th>Protocol</th>
                 <th>Address</th>
                 <th>Port</th>
                 <th>Priority</th>
-                <th>relayProtocol (if present)</th>
-                <th>Mid</th>
-                <th>MLine Index</th>
-                <th>Username Fragment</th>
                 <th>URL (if present)</th>
+                <th>relayProtocol (if present)</th>
             </tr>
             </thead>
             <tbody id="candidatesBody"></tbody>

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -182,12 +182,9 @@ function formatPriority(priority) {
   ].join(' | ');
 }
 
-function appendCell(row, val, span) {
+function appendCell(row, val) {
   const cell = document.createElement('td');
   cell.textContent = val;
-  if (span) {
-    cell.setAttribute('colspan', span);
-  }
   row.appendChild(cell);
 }
 
@@ -232,11 +229,11 @@ function getFinalResult() {
 async function iceCallback(event) {
   const elapsed = ((window.performance.now() - begin) / 1000).toFixed(3);
   const row = document.createElement('tr');
-  appendCell(row, elapsed);
   if (event.candidate) {
     if (event.candidate.candidate === '') {
       return;
     }
+    appendCell(row, elapsed);
     const {candidate} = event;
     let url;
     // Until url is available from the candidate, to to polyfill.
@@ -251,18 +248,14 @@ async function iceCallback(event) {
       });
     }
 
-    appendCell(row, candidate.component);
     appendCell(row, candidate.type);
     appendCell(row, candidate.foundation);
     appendCell(row, candidate.protocol);
     appendCell(row, candidate.address);
     appendCell(row, candidate.port);
     appendCell(row, formatPriority(candidate.priority));
-    appendCell(row, candidate.relayProtocol || '');
-    appendCell(row, candidate.sdpMid);
-    appendCell(row, candidate.sdpMLineIndex);
-    appendCell(row, candidate.usernameFragment);
     appendCell(row, candidate.url || url || '');
+    appendCell(row, candidate.relayProtocol || '');
     candidates.push(candidate);
   }
   candidateTBody.appendChild(row);
@@ -275,7 +268,7 @@ function gatheringStateChange() {
   const elapsed = ((window.performance.now() - begin) / 1000).toFixed(3);
   const row = document.createElement('tr');
   appendCell(row, elapsed);
-  appendCell(row, getFinalResult(), 7);
+  appendCell(row, getFinalResult());
   pc.close();
   pc = null;
   if (stream) {


### PR DESCRIPTION
since some of the current information is not relevant for this use-case and revert the width of the table which was enlarged in #1561 since this is no longer necessary.