### PR TITLE
Update video-crop demo note

### DIFF
--- a/src/content/insertable-streams/video-crop/index.html
+++ b/src/content/insertable-streams/video-crop/index.html
@@ -49,9 +49,7 @@
 
     <p>
         <b>Note</b>: This sample is using an experimental API that has not yet been standardized. As
-        of 2021-07-16, this API is available in Chrome M91 if the experimental code is enabled on
-        the command line with
-        <code>--enable-blink-features=MediaStreamInsertableStreams</code>.
+        of 2022-11-21, this API is available in the latest version of Chrome based browsers.
     </p>
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/insertable-streams/video-crop"
        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>


### PR DESCRIPTION
Not requiring an experimental flag anymore

https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackProcessor#browser_compatibility