### PR TITLE
Update volume example to use web audio API

### DIFF
--- a/src/content/getusermedia/volume/index.html
+++ b/src/content/getusermedia/volume/index.html
@@ -65,7 +65,7 @@
         about a second.</p>
     <p>Note that you will not hear your own voice; use the <a href="../audio">local audio rendering demo</a> for that.
     </p>
-    <p>The <code>audioContext</code>, <code>stream</code> and <code>soundMeter</code> variables are in global scope, so
+    <p>The <code>audioContext</code> and <code>stream</code> variables are in global scope, so
         you can inspect them from the console.</p>
 
     <a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/getusermedia/volume"
@@ -75,7 +75,6 @@
 
 
 <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
-<script src="js/soundmeter.js"></script>
 <script src="js/main.js" async></script>
 
 <script src="../../../js/lib/ga.js"></script>

--- a/src/content/getusermedia/volume/js/soundmeter.js
+++ b/src/content/getusermedia/volume/js/soundmeter.js
@@ -1,62 +1,57 @@
 /*
- *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2023 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
 
-'use strict';
-
 // Meter class that generates a number correlated to audio volume.
 // The meter class itself displays nothing, but it makes the
 // instantaneous and time-decaying volumes available for inspection.
 // It also reports on the fraction of samples that were at or near
 // the top of the measurement range.
-function SoundMeter(context) {
-  this.context = context;
-  this.instant = 0.0;
-  this.slow = 0.0;
-  this.clip = 0.0;
-  this.script = context.createScriptProcessor(2048, 1, 1);
-  const that = this;
-  this.script.onaudioprocess = function(event) {
-    const input = event.inputBuffer.getChannelData(0);
-    let i;
-    let sum = 0.0;
-    let clipcount = 0;
-    for (i = 0; i < input.length; ++i) {
-      sum += input[i] * input[i];
-      if (Math.abs(input[i]) > 0.99) {
-        clipcount += 1;
+class SoundMeter extends AudioWorkletProcessor {
+  _instant
+  _slow
+  _clip
+  _updateIntervalInMS
+  _nextUpdateFrame
+
+  constructor() {
+    super();
+
+    this._instant=0.0;
+    this._slow=0.0;
+    this._clip=0.0;
+    this._updateIntervalInMS = 50;
+    this._nextUpdateFrame = this._updateIntervalInMS;
+  }
+
+  process(inputs, outputs, parameters) {
+    const input = inputs[0];
+    if (input.length > 0) {
+      const samples = input[0];
+      let sum = 0.0;
+      let clipcount = 0;
+      for (let i = 0; i < samples.length; ++i) {
+	sum += samples[i] * samples[i];
+	if (Math.abs(samples[i]) > 0.99) {
+	  clipcount += 1;
+	}
+      }
+      this._instant = Math.sqrt(sum / samples.length);
+      this._slow = 0.95 * this._slow + 0.05 * this._instant;
+      this._clip = clipcount / samples.length;
+
+      this._nextUpdateFrame -= samples.length;
+      if (this._nextUpdateFrame < 0) {
+	this._nextUpdateFrame += this._updateIntervalInMS / 1000 * sampleRate;
+	this.port.postMessage({instant: this._instant, slow: this._slow, clip: this._clip});
       }
     }
-    that.instant = Math.sqrt(sum / input.length);
-    that.slow = 0.95 * that.slow + 0.05 * that.instant;
-    that.clip = clipcount / input.length;
-  };
+    return true;
+  }
 }
 
-SoundMeter.prototype.connectToSource = function(stream, callback) {
-  console.log('SoundMeter connecting');
-  try {
-    this.mic = this.context.createMediaStreamSource(stream);
-    this.mic.connect(this.script);
-    // necessary to make sample run, but should not be.
-    this.script.connect(this.context.destination);
-    if (typeof callback !== 'undefined') {
-      callback(null);
-    }
-  } catch (e) {
-    console.error(e);
-    if (typeof callback !== 'undefined') {
-      callback(e);
-    }
-  }
-};
-
-SoundMeter.prototype.stop = function() {
-  console.log('SoundMeter stopping');
-  this.mic.disconnect();
-  this.script.disconnect();
-};
+registerProcessor("soundmeter", SoundMeter);


### PR DESCRIPTION
**Description**

Update volume example to use web audio API. Closes #1509 

NOTE: soundmeter.js is no longer loaded via index.html but instead via Javascript using [Worklet `addModule()`](https://developer.mozilla.org/en-US/docs/Web/API/Worklet/addModule) .  As such, [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) comes into effect and files must be served from a HTTP file server (not referenced with `file:///`)

Credit to this Stackoverflow post which was used as a reference: https://stackoverflow.com/a/62732195/202311