### PR TITLE
trickle-ice: support loading config from URL

### DIFF
--- a/src/content/peerconnection/trickle-ice/index.html
+++ b/src/content/peerconnection/trickle-ice/index.html
@@ -69,17 +69,17 @@
 
         <div>
             <label for="url">STUN or TURN URI:</label>
-            <input id="url">
+            <input id="url" spellcheck="false">
         </div>
 
         <div>
             <label for="username">TURN username:</label>
-            <input id="username">
+            <input id="username" spellcheck="false">
         </div>
 
         <div>
             <label for="password">TURN password:</label>
-            <input id="password">
+            <input id="password" spellcheck="false">
         </div>
 
         <div>

--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -55,6 +55,23 @@ function readServersFromLocalStorage() {
   const serversSelect = document.querySelector('select#servers');
   const storedServers = window.localStorage.getItem(allServersKey);
 
+  // Try to load servers from the URL hash
+  // You can easily share a config with someone else by copying your localStorage config and appending it to the URL after a #
+  if (window.location.hash) {
+    try {
+      JSON.parse(decodeURI(window.location.hash.substring(1))).forEach((server, key) => {
+        const o = document.createElement('option');
+        o.value = JSON.stringify(server);
+        o.text = server.urls[0];
+        o.ondblclick = selectServer;
+        serversSelect.add(o);
+      });
+      return;
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   if (storedServers === null || storedServers === '') {
     setDefaultServer(serversSelect);
   } else {


### PR DESCRIPTION
**Description**

I want to help someone else debug on their network. It is hard to explain how to enter the configuration, username, etc. It would be simpler if I could just send a URL, ask them to open it, click the button, and take a screenshot of the result.

Putting the config in the hash prevents the browser from sending it to the server.

The URL for the default config would look like this: https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/#[{%22urls%22:[%22stun:stun.l.google.com:19302%22]}]

**Purpose**

Make it easier to send a config to someone else, for helping them test their network.
