### PR TITLE
Migrate WebRTC Network Limiter extension to Manifest V3

### DIFF
--- a/src/content/extensions/multipleroutes/src/manifest.json
+++ b/src/content/extensions/multipleroutes/src/manifest.json
@@ -5,13 +5,13 @@
     "16": "img/icon_16.png",
     "128": "img/icon_128.png"
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "minimum_chrome_version": "42.0.2311.135",
   "name": "__MSG_NETLI_APPNAME__",
   "options_ui": {
-    "chrome_style": true,
+    "open_in_tab": false,
     "page": "options.html"
   },
   "permissions": [ "privacy" ],
-  "version": "0.2.1.3"
+  "version": "0.2.1.4"
 }


### PR DESCRIPTION
Migrate WebRTC Network Limiter extension to Manifest V3 since V2 is deprecated.

Only minor tweaks needed to how the options UI is specified.

Tested locally by loading unpacked in Chrome 115.0.5790.75, choosing each option in turn, and gathering ICE candidates in https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/.