### PR TITLE
Make endtoend-encryption work in Firefox (Feature-detect setCodecPreferences)

### DIFF
--- a/src/content/insertable-streams/endtoend-encryption/js/videopipe.js
+++ b/src/content/insertable-streams/endtoend-encryption/js/videopipe.js
@@ -36,7 +36,7 @@ function VideoPipe(stream, forceSend, forceReceive, handler) {
 
   stream.getTracks().forEach((track) => this.pc1.addTrack(track, stream));
   this.pc2.ontrack = handler;
-  if (preferredVideoCodecMimeType && 'setCodecPreferences' in RTCRtpTransceiver.prototype) {
+  if (preferredVideoCodecMimeType && 'setCodecPreferences' in window.RTCRtpTransceiver.prototype) {
     const {codecs} = RTCRtpSender.getCapabilities('video');
     const selectedCodecIndex = codecs.findIndex(c => c.mimeType === preferredVideoCodecMimeType);
     const selectedCodec = codecs[selectedCodecIndex];

--- a/src/content/insertable-streams/endtoend-encryption/js/videopipe.js
+++ b/src/content/insertable-streams/endtoend-encryption/js/videopipe.js
@@ -36,7 +36,7 @@ function VideoPipe(stream, forceSend, forceReceive, handler) {
 
   stream.getTracks().forEach((track) => this.pc1.addTrack(track, stream));
   this.pc2.ontrack = handler;
-  if (preferredVideoCodecMimeType) {
+  if (preferredVideoCodecMimeType && 'setCodecPreferences' in RTCRtpTransceiver.prototype) {
     const {codecs} = RTCRtpSender.getCapabilities('video');
     const selectedCodecIndex = codecs.findIndex(c => c.mimeType === preferredVideoCodecMimeType);
     const selectedCodec = codecs[selectedCodecIndex];


### PR DESCRIPTION
**Description**
- Feature-detecting setCodecPreferences which is only needed for an optional feature.

**Purpose**
- Make endtoend-encryption work in Firefox 117.