### PR TITLE
GetDisplayMedia: add Start/Stop switch

### DIFF
--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -8,7 +8,8 @@
 'use strict';
 
 const preferredDisplaySurface = document.getElementById('displaySurface');
-const startButton = document.getElementById('startButton');
+const startStopButton = document.getElementById('startButton');
+const videoElement = document.querySelector('video');
 
 if (adapter.browserDetails.browser === 'chrome' &&
     adapter.browserDetails.version >= 107) {
@@ -21,16 +22,15 @@ if (adapter.browserDetails.browser === 'chrome' &&
 }
 
 function handleSuccess(stream) {
-  startButton.disabled = true;
+  startStopButton.textContent = 'Stop';
   preferredDisplaySurface.disabled = true;
-  const video = document.querySelector('video');
-  video.srcObject = stream;
+  videoElement.srcObject = stream;
 
   // demonstrates how to detect that the user has stopped
   // sharing the screen via the browser UI.
   stream.getVideoTracks()[0].addEventListener('ended', () => {
     errorMsg('The user has ended sharing the screen');
-    startButton.disabled = false;
+    startStopButton.textContent = 'Start';
     preferredDisplaySurface.disabled = false;
   });
 }
@@ -48,18 +48,27 @@ function errorMsg(msg, error) {
 }
 
 
-startButton.addEventListener('click', () => {
-  const options = {audio: true, video: true};
-  const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex].value;
-  if (displaySurface !== 'default') {
-    options.video = {displaySurface};
+startStopButton.addEventListener('click', () => {
+  if (startStopButton.textContent === 'Start') {
+    const options = {audio: true, video: true};
+    const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex].value;
+    if (displaySurface !== 'default') {
+      options.video = {displaySurface};
+    }
+    navigator.mediaDevices.getDisplayMedia(options)
+        .then(handleSuccess, handleError);
   }
-  navigator.mediaDevices.getDisplayMedia(options)
-      .then(handleSuccess, handleError);
+  else {
+    // demonstrates how to stop the stream from JavaScript
+    errorMsg('JavaScript has ended sharing the screen');
+    videoElement.srcObject.getTracks().forEach(track => track.stop());
+    videoElement.srcObject = null;
+    startStopButton.textContent = 'Start';
+  }
 });
 
 if ((navigator.mediaDevices && 'getDisplayMedia' in navigator.mediaDevices)) {
-  startButton.disabled = false;
+  startStopButton.disabled = false;
 } else {
   errorMsg('getDisplayMedia is not supported');
 }

--- a/src/content/getusermedia/getdisplaymedia/js/main.js
+++ b/src/content/getusermedia/getdisplaymedia/js/main.js
@@ -10,6 +10,7 @@
 const preferredDisplaySurface = document.getElementById('displaySurface');
 const startStopButton = document.getElementById('startButton');
 const videoElement = document.querySelector('video');
+let displayMediaStarted = false;
 
 if (adapter.browserDetails.browser === 'chrome' &&
     adapter.browserDetails.version >= 107) {
@@ -22,6 +23,7 @@ if (adapter.browserDetails.browser === 'chrome' &&
 }
 
 function handleSuccess(stream) {
+  displayMediaStarted = true;
   startStopButton.textContent = 'Stop';
   preferredDisplaySurface.disabled = true;
   videoElement.srcObject = stream;
@@ -49,7 +51,7 @@ function errorMsg(msg, error) {
 
 
 startStopButton.addEventListener('click', () => {
-  if (startStopButton.textContent === 'Start') {
+  if (!displayMediaStarted) {
     const options = {audio: true, video: true};
     const displaySurface = preferredDisplaySurface.options[preferredDisplaySurface.selectedIndex].value;
     if (displaySurface !== 'default') {
@@ -64,6 +66,7 @@ startStopButton.addEventListener('click', () => {
     videoElement.srcObject.getTracks().forEach(track => track.stop());
     videoElement.srcObject = null;
     startStopButton.textContent = 'Start';
+    displayMediaStarted = false;
   }
 });
 


### PR DESCRIPTION
**Description**

Add a stop button to the `getdisplaymedia` demo

**Purpose**

* Demonstrate how to stop screen sharing from JavaScript
* Helps to stop screen sharing easily in automated tests

![chrome_PsUcBGULUv](https://github.com/webrtc/samples/assets/63298684/6f85e2a3-529e-4d7d-b484-8c0e4096b0b5)

