### PR TITLE
pin selenium-webdriver to 4.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "geckodriver": "^3.0.1",
     "http-server": "^14.1.0",
     "mocha": "^9.2.1",
-    "selenium-webdriver": "^4.1.1",
+    "selenium-webdriver": "4.10.0",
     "stylelint": "^14.5.3",
     "stylelint-config-recommended": "^7.0.0",
     "travis-multirunner": "^5.0.1"


### PR DESCRIPTION
which avoids issues in the integration of travis-multirunner since the custom Chrome path is no longer found when being used with selenium manager

See #1614