### PR TITLE
fix: add async for createPeerConnection when use await call it

### DIFF
--- a/src/content/peerconnection/channel/js/main.js
+++ b/src/content/peerconnection/channel/js/main.js
@@ -80,7 +80,7 @@ async function hangup() {
   hangupButton.disabled = true;
 };
 
-function createPeerConnection() {
+async function createPeerConnection() {
   pc = new RTCPeerConnection();
   pc.onicecandidate = e => {
     const message = {


### PR DESCRIPTION
**Description**
When use VSCode edit main.js, if we call ```await createPeerConnection();```

there is a warning of: `'await' has no effect on the type of this expression.ts(80007`
**Purpose**
resolve warning