### PR TITLE
event.path is no longer available

### DIFF
--- a/src/content/devices/multi/js/main.js
+++ b/src/content/devices/multi/js/main.js
@@ -72,7 +72,7 @@ function changeAudioDestination(event) {
   const deviceId = event.target.value;
   const outputSelector = event.target;
   // FIXME: Make the media element lookup dynamic.
-  const element = event.path[2].childNodes[1];
+  const element = event.composedPath()[2].childNodes[1];
   attachSinkId(element, deviceId, outputSelector);
 }
 


### PR DESCRIPTION
**Description**
event.path is no longer available.

i know there's already a PR #1601, but the author hasn't responded w/ CLA check - and I'd like to use this sample every now and then.

**Purpose**
fix the error "Uncaught TypeError: Cannot read properties of undefined (reading '2')"