### PR TITLE
fix(change-codecs): audio receiver set video codec throw error

### DIFF
--- a/src/content/peerconnection/change-codecs/js/main.js
+++ b/src/content/peerconnection/change-codecs/js/main.js
@@ -171,7 +171,7 @@ function onSetSessionDescriptionError(error) {
 
 function gotRemoteStream(e) {
   // Set codec preferences on the receiving side.
-  if (supportsSetCodecPreferences) {
+  if (e.track.kind === 'video' && supportsSetCodecPreferences) {
     const preferredCodec = codecPreferences.options[codecPreferences.selectedIndex];
     if (preferredCodec.value !== '') {
       const [mimeType, sdpFmtpLine] = preferredCodec.value.split(' ');


### PR DESCRIPTION


**Description**
Line 183 e.transceiver.setCodecPreferences(codecs); e.transceiver may be for audio, set video will throw error.
error message: Failed to execute 'setCodecPreferences' on 'RTCRtpTransceiver': Invalid codec preferences: Missing codec from recv codec capabilities.

**Purpose**
fix bug