### PR TITLE
trickle-ice: disallow empty input

### DIFF
--- a/src/content/peerconnection/trickle-ice/js/main.js
+++ b/src/content/peerconnection/trickle-ice/js/main.js
@@ -77,6 +77,11 @@ function selectServer(event) {
 }
 
 function addServer() {
+  if (urlInput.value === '' && usernameInput.value === '' && passwordInput.value === '') {
+    // Ignore since this leads to invisible items being added to the list.
+    console.warn('Not adding empty ICE server input');
+    return;
+  }
   // Store the ICE server as a stringified JSON object in option.value.
   const option = document.createElement('option');
   const iceServer = {


### PR DESCRIPTION
since it adds invisible servers to the list which is confusing.

Fixes #1647