### PR TITLE
e2ee: fix setCodecPreferences capabilities check

### DIFF
--- a/src/content/insertable-streams/endtoend-encryption/js/main.js
+++ b/src/content/insertable-streams/endtoend-encryption/js/main.js
@@ -47,6 +47,9 @@ let preferredAudioCodecMimeType = 'audio/opus';
 // eslint-disable-next-line prefer-const
 let preferredVideoCodecMimeType = 'video/VP8';
 
+const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
+  'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
+
 let hasEnoughAPIs = !!window.RTCRtpScriptTransform;
 
 if (!hasEnoughAPIs) {
@@ -150,7 +153,7 @@ function setupReceiverTransform(receiver) {
 }
 
 function maybeSetCodecPreferences(trackEvent) {
-  if (!'setCodecPreferences' in window.RTCRtpTransceiver.prototype) return;
+  if (!supportsSetCodecPreferences) return;
   if (trackEvent.track.kind === 'audio' && preferredAudioCodecMimeType ) {
     const {codecs} = RTCRtpReceiver.getCapabilities('audio');
     const selectedCodecIndex = codecs.findIndex(c => c.mimeType === preferredAudioCodecMimeType);


### PR DESCRIPTION
`if (!'setCodecPreferences' in window.RTCRtpTransceiver.prototype) return;`
is missing `()`. Sync with the style used in change-codecs