### PR TITLE
test: fix interop test

### DIFF
--- a/test/download-browsers.js
+++ b/test/download-browsers.js
@@ -1,9 +1,9 @@
 const {buildDriver} = require('./webdriver');
 // Download the browser(s).
 async function download() {
-  if (process.env.browserA && process.env.browserB) {
-    (await buildDriver(process.env.browserA)).quit();
-    (await buildDriver(process.env.browserB)).quit();
+  if (process.env.BROWSER_A && process.env.BROWSER_B) {
+    (await buildDriver(process.env.BROWSER_A)).quit();
+    (await buildDriver(process.env.BROWSER_B)).quit();
   } else {
     (await buildDriver()).quit();
   }


### PR DESCRIPTION
which was setting the wrong shell environment variables

(they are `browserA` et al in the [matrix definition](https://github.com/webrtc/samples/blob/gh-pages/.github/workflows/interop-tests.yml#L12))