### PR TITLE
Fix error message handling in getusermedia/gum.

### DIFF
--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -24,10 +24,9 @@ function handleSuccess(stream) {
 
 function handleError(error) {
   if (error.name === 'OverconstrainedError') {
-    const v = constraints.video;
-    errorMsg(`The resolution ${v.width.exact}x${v.height.exact} px is not supported by your device.`);
+    console.error(`The constraints could not be satisfied by the available devices. Constraints: ${JSON.stringify(constraints)}`);
   } else if (error.name === 'NotAllowedError') {
-    errorMsg('Permissions have not been granted to use your camera and ' +
+    console.error('Permissions have not been granted to use your camera and ' +
       'microphone, you need to allow the page access to your devices in ' +
       'order for the demo to work.');
   }

--- a/src/content/getusermedia/gum/js/main.js
+++ b/src/content/getusermedia/gum/js/main.js
@@ -24,9 +24,9 @@ function handleSuccess(stream) {
 
 function handleError(error) {
   if (error.name === 'OverconstrainedError') {
-    console.error(`The constraints could not be satisfied by the available devices. Constraints: ${JSON.stringify(constraints)}`);
+    errorMsg(`OverconstrainedError: The constraints could not be satisfied by the available devices. Constraints: ${JSON.stringify(constraints)}`);
   } else if (error.name === 'NotAllowedError') {
-    console.error('Permissions have not been granted to use your camera and ' +
+    errorMsg('NotAllowedError: Permissions have not been granted to use your camera and ' +
       'microphone, you need to allow the page access to your devices in ' +
       'order for the demo to work.');
   }


### PR DESCRIPTION
**Description**

Currently, when some errors occur in the getusermedia/gum demo, the error message isn't handled correctly because the constraints object might not have required properties in some cases. This patch fixes the error message handling by using the error object directly and dumping it as a JSON string.


**Purpose**
