### PR TITLE
fix: Add workaround for Firefox DTMF compatibility

### DIFF
--- a/src/content/peerconnection/dtmf/js/main.js
+++ b/src/content/peerconnection/dtmf/js/main.js
@@ -173,7 +173,9 @@ function dtmfOnToneChange(tone) {
 }
 
 function sendTones(tones) {
-  if (dtmfSender && dtmfSender.canInsertDTMF) {
+  // firefox doesn't implement canInsertDTMF, so assume it's always available
+  // Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1623193
+  if (dtmfSender && (typeof (dtmfSender.canInsertDTMF) === 'undefined' || dtmfSender.canInsertDTMF)) {
     const duration = durationInput.value;
     const gap = gapInput.value;
     console.log('Tones, duration, gap: ', tones, duration, gap);


### PR DESCRIPTION
**Description**

`src/content/peerconnection/dtmf/js/main.js` was incompatible with Firefox due to its reliance on the `canInsertDTMF` function, which is not supported in Firefox. This commit implements a workaround by assuming DTMF insertion is always available when `canInsertDTMF` is not present.


**Purpose**
