### PR TITLE
don't use exact property for device ID

### DIFF
--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -236,7 +236,7 @@ function getMedia(constraints) {
 
   clearErrorMessage();
   videoblock.style.display = 'none';
-  constraints.video.deviceId = {exact: videoSelect.value};
+  constraints.video.deviceId = {ideal: videoSelect.value};
   console.log('getUserMedia constraints: ' + JSON.stringify(constraints));
   navigator.mediaDevices.getUserMedia(constraints)
       .then(gotStream)


### PR DESCRIPTION
Use ideal property instead of exact property when calling getUserMedia API. 
**Description**
Since enumerateDevices API does not request device permission, the test page will not receive any device ID if camera permission is not already set nor will it trigger a device permission popup. Since getUserMedia API will be called with empty device ID using 'exact' property, test page will not display any video.


**Purpose**
Allow the test page to get camera video on initial launch or after camera permission for test page has been reset.