### PR TITLE
change-codecs: fix getCapabilities call

### DIFF
--- a/src/content/peerconnection/change-codecs/js/main.js
+++ b/src/content/peerconnection/change-codecs/js/main.js
@@ -69,9 +69,9 @@ async function start() {
     alert(`getUserMedia() error: ${e.name}`);
   }
   if (supportsSetCodecPreferences) {
-    const {codecs} = RTCRtpSender.getCapabilities('video');
+    const {codecs} = RTCRtpReceiver.getCapabilities('video');
     codecs.forEach(codec => {
-      if (['video/red', 'video/ulpfec', 'video/rtx'].includes(codec.mimeType)) {
+      if (['video/red', 'video/ulpfec', 'video/rtx', 'video/flexfec-03'].includes(codec.mimeType)) {
         return;
       }
       const option = document.createElement('option');


### PR DESCRIPTION
which needs to be seeded from receiver capabilities, not sender capabilities

Surprisingly passing undefined worked before M130 where this throws due to IDL validation