### PR TITLE
e2ee: prefer metadata rtpTimestamp over encodedFrame.timestamp

### DIFF
--- a/src/content/insertable-streams/endtoend-encryption/js/worker.js
+++ b/src/content/insertable-streams/endtoend-encryption/js/worker.js
@@ -44,7 +44,7 @@ function dump(encodedFrame, direction, max = 16) {
   console.log(performance.now().toFixed(2), direction, bytes.trim(),
       'len=' + encodedFrame.data.byteLength,
       'type=' + (encodedFrame.type || 'audio'),
-      'ts=' + encodedFrame.timestamp,
+      'ts=' + (metadata.rtpTimestamp || encodedFrame.timestamp),
       'ssrc=' + metadata.synchronizationSource,
       'pt=' + (metadata.payloadType || '(unknown)'),
       'mimeType=' + (metadata.mimeType || '(unknown)'),


### PR DESCRIPTION
which launched in
https://issues.chromium.org/issues/372512094