### PR TITLE
Use valid mimetype for HEVC/H.264/AV1 and add `hev1`/`avc3` mimetypes

### DIFF
--- a/src/content/getusermedia/record/js/main.js
+++ b/src/content/getusermedia/record/js/main.js
@@ -87,12 +87,13 @@ function getSupportedMimeTypes() {
     'video/webm;codecs=vp8,opus',
     'video/webm;codecs=h264,opus',
     'video/webm;codecs=av01,opus',
-    'video/x-matroska;codecs=hvc1,opus',
-    'video/mp4;codecs=h264,aac',
+    'video/x-matroska;codecs=hvc1.1.6.L186.B0,opus',
     'video/mp4;codecs=vp9,mp4a.40.2',
-    'video/mp4;codecs=avc1,mp4a.40.2',
-    'video/mp4;codecs=hvc1,mp4a.40.2',
-    'video/mp4;codecs=av01,mp4a.40.2',
+    'video/mp4;codecs=avc1.64003E,mp4a.40.2',
+    'video/mp4;codecs=avc3.64003E,mp4a.40.2',
+    'video/mp4;codecs=hvc1.1.6.L186.B0,mp4a.40.2',
+    'video/mp4;codecs=hev1.1.6.L186.B0,mp4a.40.2',
+    'video/mp4;codecs=av01.1.19M.08,mp4a.40.2',
     'video/mp4',
   ];
   return possibleTypes.filter(mimeType => {


### PR DESCRIPTION
Based on conversation with Chrome Media Team, we should only support valid mimetype for future new codecs like HEVC.

For HEVC/H.264/AV1, it is recommend to use valid mimetype instead of just `hvc1`, `avc1` or `av01`.

There are some limitation for `avc1` / `hvc1` as they only allow "out of band parameter sets", so if capture device can produce dynamic resolution video stream, only `avc3` / `hev1` can satisfy the needs as they supports "in band parameter sets".

Chromium may support `hev1` and `avc3` in the future, so also added these mimetypes for future testing.