### PR TITLE
Add ondevicechange event support to demo

### DIFF
--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -48,7 +48,9 @@ function gotDevices(deviceInfos) {
   });
 }
 
-navigator.mediaDevices.enumerateDevices().then(gotDevices).catch(handleError);
+function getDevices() {
+  navigator.mediaDevices.enumerateDevices().then(gotDevices).catch(handleError);
+}
 
 // Attach audio output device to video element using device/sink ID.
 function attachSinkId(element, sinkId) {
@@ -79,8 +81,7 @@ function changeAudioDestination() {
 function gotStream(stream) {
   window.stream = stream; // make stream available to console
   videoElement.srcObject = stream;
-  // Refresh button list in case labels have become available
-  return navigator.mediaDevices.enumerateDevices();
+  getDevices();
 }
 
 function handleError(error) {
@@ -99,12 +100,12 @@ function start() {
     audio: {deviceId: audioSource ? {exact: audioSource} : undefined},
     video: {deviceId: videoSource ? {exact: videoSource} : undefined}
   };
-  navigator.mediaDevices.getUserMedia(constraints).then(gotStream).then(gotDevices).catch(handleError);
+  navigator.mediaDevices.getUserMedia(constraints).then(gotStream);
 }
 
 audioInputSelect.onchange = start;
 audioOutputSelect.onchange = changeAudioDestination;
-
 videoSelect.onchange = start;
+navigator.mediaDevices.ondevicechange = getDevices;
 
 start();

--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -22,7 +22,6 @@ let hasPermission = false;
 audioOutputSelect.disabled = !('sinkId' in HTMLMediaElement.prototype);
 
 function getDevices() {
-  console.log('getDevices');
   navigator.mediaDevices.enumerateDevices().then(gotDevices).catch(handleError);
 }
 
@@ -40,7 +39,6 @@ function gotDevices(deviceInfos) {
   });
   for (let i = 0; i !== deviceInfos.length; ++i) {
     const deviceInfo = deviceInfos[i];
-    console.log(deviceInfo);
     if (deviceInfo.deviceId == '') {
       continue;
     }
@@ -107,7 +105,6 @@ function gotStream(stream) {
   if (stream.getAudioTracks()[0]) {
     openMic = stream.getAudioTracks()[0].getSettings().deviceId;
   }
-  console.log('openCamera', openCamera, 'openMic', openMic);
   // Refresh list in case labels have become available
   return getDevices();
 }
@@ -119,8 +116,6 @@ function handleError(error) {
 function start() {
   const audioSource = audioInputSelect.value || undefined;
   const videoSource = videoSelect.value || undefined;
-  console.log('audio', audioSource, 'video', videoSource);
-  console.log('openMic', openMic, 'openCamera', openCamera);
   // Don't open the same devices again.
   if (hasPermission && openMic == audioSource && openCamera == videoSource) {
     return;

--- a/src/content/devices/input-output/js/main.js
+++ b/src/content/devices/input-output/js/main.js
@@ -64,11 +64,6 @@ function gotDevices(deviceInfos) {
   start();
 }
 
-function getDevices() {
-  console.log('getDevices');
-  navigator.mediaDevices.enumerateDevices().then(gotDevices).catch(handleError);
-}
-
 // Attach audio output device to video element using device/sink ID.
 function attachSinkId(element, sinkId) {
   if (typeof element.sinkId !== 'undefined') {


### PR DESCRIPTION
Demo does not use `devicechange` event to keep device selectors in sync with hotplug.  This fixes the demo to do that.

It also fixes some other issues:
- The demo now works if only a camera or mic is available (but not both)
- The demo waits for enumeration to complete before calling gUM.  Previously, this would result in a failed request.

`console.log` will be removed before merging.




