### PR TITLE
pin browser tests to ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -13,7 +13,7 @@ jobs:
     - run: npm run stylelint
   test:
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     strategy:
       matrix:


### PR DESCRIPTION
follow-up to #1694 which only replaced the wrong (first) test runner.
Use ubuntu-latest for lint