### PR TITLE
test: fix mapVersion call

### DIFF
--- a/test/webdriver.js
+++ b/test/webdriver.js
@@ -48,7 +48,7 @@ function mapVersion(browser, version) {
 }
 
 async function buildDriver(browser = process.env.BROWSER || 'chrome', options = {version: process.env.BVER}) {
-  const version = mapVersion(options.version);
+  const version = mapVersion(browser, options.version);
   const platform = puppeteerBrowsers.detectBrowserPlatform();
 
   const buildId = await download(browser, version || 'stable',


### PR DESCRIPTION
which should result in actual canary/nightly being used for interop tests
