### PR TITLE
fix: removed await with createPeerConnection

### DIFF
--- a/src/content/peerconnection/channel/js/main.js
+++ b/src/content/peerconnection/channel/js/main.js
@@ -99,7 +99,7 @@ function createPeerConnection() {
 }
 
 async function makeCall() {
-  await createPeerConnection();
+  createPeerConnection();
 
   const offer = await pc.createOffer();
   signaling.postMessage({type: 'offer', sdp: offer.sdp});
@@ -111,7 +111,7 @@ async function handleOffer(offer) {
     console.error('existing peerconnection');
     return;
   }
-  await createPeerConnection();
+  createPeerConnection();
   await pc.setRemoteDescription(offer);
 
   const answer = await pc.createAnswer();


### PR DESCRIPTION
**Description**
The sample code for using channels includes several instances of the await keyword applied to createPeerConnection, even though the function itself is not asynchronous. As a result, the await calls have no effect and are redundant.

**Purpose**
To enhance the overall quality and readability of the sample code.