### PR TITLE
restore github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,11 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
 # Please read first!
 Please use [discuss-webrtc](https://groups.google.com/forum/#!forum/discuss-webrtc) for general technical discussions and questions.
 If you have found an issue/bug with the native `libwebrtc` SDK or a browser's behaviour around WebRTC please create an issue in the relevant bug tracker. You can find more information on how to submit a bug and do so in the right place [here](https://webrtc.googlesource.com/src/+/refs/heads/main/docs/bug-reporting.md)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Please use the discuss-webrtc mailing list for general questions
+    url: https://groups.google.com/g/discuss-webrtc


### PR DESCRIPTION
(mostly so we can say "we told you to only file issues about the samples here")

**Description**
https://github.com/webrtc/samples/issues/new currently shows a blank template. Some change by github at some point in time... this worked nicely for https://github.com/webrtcHacks/adapter/issues/new

**Purpose**
