### PR TITLE
Refactor: Rename peer connection variables

### DIFF
--- a/src/content/capture/canvas-pc/index.html
+++ b/src/content/capture/canvas-pc/index.html
@@ -50,7 +50,7 @@
     <p>View the browser console to see logging.</p>
 
     <p>Several variables are in global scope, so you can inspect them from the console: <code>canvas</code>,
-        <code>video</code>, <code>localPeerConnection</code>, <code>remotePeerConnection</code> and <code>stream</code>.
+        <code>video</code>, <code>pc1</code>, <code>pc2</code> and <code>stream</code>.
     </p>
 
     <p>For more demos and information about <code>captureStream()</code>, see <a

--- a/src/content/datachannel/basic/index.html
+++ b/src/content/datachannel/basic/index.html
@@ -56,7 +56,7 @@
 
     <p>View the console to see logging.</p>
 
-    <p>The <code>RTCPeerConnection</code> objects <code>localConnection</code> and <code>remoteConnection</code> are in
+    <p>The <code>RTCPeerConnection</code> objects <code>pc1</code> and <code>pc2</code> are in
         global scope, so you can inspect them in the console as well.</p>
 
     <p>For more information about RTCDataChannel, see <a

--- a/src/content/datachannel/basic/js/main.js
+++ b/src/content/datachannel/basic/js/main.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-let localConnection;
-let remoteConnection;
+let pc1;
+let pc2;
 let sendChannel;
 let receiveChannel;
 const dataChannelSend = document.querySelector('textarea#dataChannelSend');
@@ -33,27 +33,27 @@ function disableSendButton() {
 function createConnection() {
   dataChannelSend.placeholder = '';
   const servers = null;
-  window.localConnection = localConnection = new RTCPeerConnection(servers);
-  console.log('Created local peer connection object localConnection');
+  pc1 = new RTCPeerConnection(servers);
+  console.log('Created local peer connection object pc1');
 
-  sendChannel = localConnection.createDataChannel('sendDataChannel');
+  sendChannel = pc1.createDataChannel('sendDataChannel');
   console.log('Created send data channel');
 
-  localConnection.onicecandidate = e => {
-    onIceCandidate(localConnection, e);
+  pc1.onicecandidate = e => {
+    onIceCandidate(pc1, e);
   };
   sendChannel.onopen = onSendChannelStateChange;
   sendChannel.onclose = onSendChannelStateChange;
 
-  window.remoteConnection = remoteConnection = new RTCPeerConnection(servers);
-  console.log('Created remote peer connection object remoteConnection');
+  pc2 = new RTCPeerConnection(servers);
+  console.log('Created remote peer connection object pc2');
 
-  remoteConnection.onicecandidate = e => {
-    onIceCandidate(remoteConnection, e);
+  pc2.onicecandidate = e => {
+    onIceCandidate(pc2, e);
   };
-  remoteConnection.ondatachannel = receiveChannelCallback;
+  pc2.ondatachannel = receiveChannelCallback;
 
-  localConnection.createOffer().then(
+  pc1.createOffer().then(
       gotDescription1,
       onCreateSessionDescriptionError
   );
@@ -77,10 +77,10 @@ function closeDataChannels() {
   console.log('Closed data channel with label: ' + sendChannel.label);
   receiveChannel.close();
   console.log('Closed data channel with label: ' + receiveChannel.label);
-  localConnection.close();
-  remoteConnection.close();
-  localConnection = null;
-  remoteConnection = null;
+  pc1.close();
+  pc2.close();
+  pc1 = null;
+  pc2 = null;
   console.log('Closed peer connections');
   startButton.disabled = false;
   sendButton.disabled = true;
@@ -93,27 +93,27 @@ function closeDataChannels() {
 }
 
 function gotDescription1(desc) {
-  localConnection.setLocalDescription(desc);
-  console.log(`Offer from localConnection\n${desc.sdp}`);
-  remoteConnection.setRemoteDescription(desc);
-  remoteConnection.createAnswer().then(
+  pc1.setLocalDescription(desc);
+  console.log(`Offer from pc1\n${desc.sdp}`);
+  pc2.setRemoteDescription(desc);
+  pc2.createAnswer().then(
       gotDescription2,
       onCreateSessionDescriptionError
   );
 }
 
 function gotDescription2(desc) {
-  remoteConnection.setLocalDescription(desc);
-  console.log(`Answer from remoteConnection\n${desc.sdp}`);
-  localConnection.setRemoteDescription(desc);
+  pc2.setLocalDescription(desc);
+  console.log(`Answer from pc2\n${desc.sdp}`);
+  pc1.setRemoteDescription(desc);
 }
 
 function getOtherPc(pc) {
-  return (pc === localConnection) ? remoteConnection : localConnection;
+  return (pc === pc1) ? pc2 : pc1;
 }
 
 function getName(pc) {
-  return (pc === localConnection) ? 'localPeerConnection' : 'remotePeerConnection';
+  return (pc === pc1) ? 'pc1' : 'pc2';
 }
 
 function onIceCandidate(pc, event) {

--- a/src/content/datachannel/basic/js/test.js
+++ b/src/content/datachannel/basic/js/test.js
@@ -30,10 +30,10 @@ describe('datachannel basic', () => {
 
     await Promise.all([
       driver.wait(() => driver.executeScript(() => {
-        return localConnection && localConnection.connectionState === 'connected'; // eslint-disable-line no-undef
+        return pc1 && pc1.connectionState === 'connected'; // eslint-disable-line no-undef
       })),
       await driver.wait(() => driver.executeScript(() => {
-        return remoteConnection && remoteConnection.connectionState === 'connected'; // eslint-disable-line no-undef
+        return pc2 && pc2.connectionState === 'connected'; // eslint-disable-line no-undef
       })),
     ]);
     await driver.wait(() => driver.findElement(webdriver.By.id('sendButton')).isEnabled());

--- a/src/content/datachannel/datatransfer/index.html
+++ b/src/content/datachannel/datatransfer/index.html
@@ -77,7 +77,7 @@
     <section>
         <p>View the console to see logging.</p>
 
-        <p>The <code>RTCPeerConnection</code> objects <code>localConnection</code> and <code>remoteConnection</code> are
+        <p>The <code>RTCPeerConnection</code> objects <code>pc1</code> and <code>pc2</code> are
             in global scope, so you can inspect them in the console as well.</p>
 
         <p>For more information about RTCDataChannel, see <a

--- a/src/content/datachannel/datatransfer/js/main.js
+++ b/src/content/datachannel/datatransfer/js/main.js
@@ -9,8 +9,8 @@
 'use strict';
 const MAX_CHUNK_SIZE = 262144;
 
-let localConnection;
-let remoteConnection;
+let pc1;
+let pc2;
 let sendChannel;
 let receiveChannel;
 let chunkSize;
@@ -61,28 +61,28 @@ async function createConnection() {
   const number = Number.parseInt(megsToSend.value);
   bytesToSend = number * 1024 * 1024;
 
-  localConnection = new RTCPeerConnection(servers);
+  pc1 = new RTCPeerConnection(servers);
 
   // Let's make a data channel!
   const dataChannelParams = {ordered: false};
   if (orderedCheckbox.checked) {
     dataChannelParams.ordered = true;
   }
-  sendChannel = localConnection.createDataChannel('sendDataChannel', dataChannelParams);
+  sendChannel = pc1.createDataChannel('sendDataChannel', dataChannelParams);
   sendChannel.addEventListener('open', onSendChannelOpen);
   sendChannel.addEventListener('close', onSendChannelClosed);
   console.log('Created send data channel: ', sendChannel);
 
-  console.log('Created local peer connection object localConnection: ', localConnection);
+  console.log('Created local peer connection object pc1: ', pc1);
 
-  localConnection.addEventListener('icecandidate', e => onIceCandidate(localConnection, e));
+  pc1.addEventListener('icecandidate', e => onIceCandidate(pc1, e));
 
-  remoteConnection = new RTCPeerConnection(servers);
-  remoteConnection.addEventListener('icecandidate', e => onIceCandidate(remoteConnection, e));
-  remoteConnection.addEventListener('datachannel', receiveChannelCallback);
+  pc2 = new RTCPeerConnection(servers);
+  pc2.addEventListener('icecandidate', e => onIceCandidate(pc2, e));
+  pc2.addEventListener('datachannel', receiveChannelCallback);
 
   try {
-    const localOffer = await localConnection.createOffer();
+    const localOffer = await pc1.createOffer();
     await handleLocalDescription(localOffer);
   } catch (e) {
     console.error('Failed to create session description: ', e);
@@ -143,18 +143,18 @@ function startSendingData() {
 }
 
 function maybeReset() {
-  if (localConnection === null && remoteConnection === null) {
+  if (pc1 === null && pc2 === null) {
     sendButton.disabled = false;
     megsToSend.disabled = false;
   }
 }
 
 async function handleLocalDescription(desc) {
-  localConnection.setLocalDescription(desc);
-  console.log('Offer from localConnection:\n', desc.sdp);
-  remoteConnection.setRemoteDescription(desc);
+  pc1.setLocalDescription(desc);
+  console.log('Offer from pc1:\n', desc.sdp);
+  pc2.setRemoteDescription(desc);
   try {
-    const remoteAnswer = await remoteConnection.createAnswer();
+    const remoteAnswer = await pc2.createAnswer();
     handleRemoteAnswer(remoteAnswer);
   } catch (e) {
     console.error('Error when creating remote answer: ', e);
@@ -162,13 +162,13 @@ async function handleLocalDescription(desc) {
 }
 
 function handleRemoteAnswer(desc) {
-  remoteConnection.setLocalDescription(desc);
-  console.log('Answer from remoteConnection:\n', desc.sdp);
-  localConnection.setRemoteDescription(desc);
+  pc2.setLocalDescription(desc);
+  console.log('Answer from pc2:\n', desc.sdp);
+  pc1.setRemoteDescription(desc);
 }
 
 function getOtherPc(pc) {
-  return (pc === localConnection) ? remoteConnection : localConnection;
+  return (pc === pc1) ? pc2 : pc1;
 }
 
 async function onIceCandidate(pc, event) {
@@ -209,7 +209,7 @@ function onReceiveMessageCallback(event) {
 function onSendChannelOpen() {
   console.log('Send channel is open');
 
-  chunkSize = Math.min(localConnection.sctp.maxMessageSize, MAX_CHUNK_SIZE);
+  chunkSize = Math.min(pc1.sctp.maxMessageSize, MAX_CHUNK_SIZE);
   console.log('Determined chunk size: ', chunkSize);
   dataString = new Array(chunkSize).fill('X').join('');
   lowWaterMark = chunkSize; // A single chunk
@@ -227,8 +227,8 @@ function onSendChannelOpen() {
 
 function onSendChannelClosed() {
   console.log('Send channel is closed');
-  localConnection.close();
-  localConnection = null;
+  pc1.close();
+  pc1 = null;
   console.log('Closed local peer connection');
   maybeReset();
   console.log('Average time spent in send() (ms): ' +
@@ -241,8 +241,8 @@ function onSendChannelClosed() {
 
 function onReceiveChannelClosed() {
   console.log('Receive channel is closed');
-  remoteConnection.close();
-  remoteConnection = null;
+  pc2.close();
+  pc2 = null;
   console.log('Closed remote peer connection');
   maybeReset();
 }

--- a/src/content/datachannel/datatransfer/js/test.js
+++ b/src/content/datachannel/datatransfer/js/test.js
@@ -38,16 +38,16 @@ describe('datachannel datatransfer', () => {
 
     await Promise.all([
       driver.wait(() => driver.executeScript(() => {
-        return localConnection && localConnection.connectionState === 'connected'; // eslint-disable-line no-undef
+        return pc1 && pc1.connectionState === 'connected'; // eslint-disable-line no-undef
       })),
       await driver.wait(() => driver.executeScript(() => {
-        return remoteConnection && remoteConnection.connectionState === 'connected'; // eslint-disable-line no-undef
+        return pc2 && pc2.connectionState === 'connected'; // eslint-disable-line no-undef
       })),
     ]);
 
     // the remote connection gets closed when it is done.
     await driver.wait(() => driver.executeScript(() => {
-      return remoteConnection === null; // eslint-disable-line no-undef
+      return pc2 === null; // eslint-disable-line no-undef
     }));
 
     const transferred = await driver.findElement(webdriver.By.id('receiveProgress')).getAttribute('value');

--- a/src/content/datachannel/filetransfer/index.html
+++ b/src/content/datachannel/filetransfer/index.html
@@ -76,7 +76,7 @@
     <section>
       <p>View the console to see logging.</p>
 
-      <p>The <code>RTCPeerConnection</code> objects <code>localConnection</code> and <code>remoteConnection</code> are in global scope, so you can inspect them in the console as well.</p>
+      <p>The <code>RTCPeerConnection</code> objects <code>pc1</code> and <code>pc2</code> are in global scope, so you can inspect them in the console as well.</p>
 
       <p>For more information about RTCDataChannel, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/#toc-rtcdatachannel" title="RTCDataChannel section of HTML5 Rocks article about WebRTC">Getting Started With WebRTC</a>.</p>
     </section>

--- a/src/content/datachannel/filetransfer/js/main.js
+++ b/src/content/datachannel/filetransfer/js/main.js
@@ -8,8 +8,8 @@
  */
 'use strict';
 
-let localConnection;
-let remoteConnection;
+let pc1;
+let pc2;
 let sendChannel;
 let receiveChannel;
 let fileReader;
@@ -52,10 +52,10 @@ async function handleFileInputChange() {
 async function createConnection() {
   abortButton.disabled = false;
   sendFileButton.disabled = true;
-  localConnection = new RTCPeerConnection();
-  console.log('Created local peer connection object localConnection');
+  pc1 = new RTCPeerConnection();
+  console.log('Created local peer connection object pc1');
 
-  sendChannel = localConnection.createDataChannel('sendDataChannel');
+  sendChannel = pc1.createDataChannel('sendDataChannel');
   sendChannel.binaryType = 'arraybuffer';
   console.log('Created send data channel');
 
@@ -63,22 +63,22 @@ async function createConnection() {
   sendChannel.addEventListener('close', onSendChannelStateChange);
   sendChannel.addEventListener('error', onError);
 
-  localConnection.addEventListener('icecandidate', async event => {
+  pc1.addEventListener('icecandidate', async event => {
     console.log('Local ICE candidate: ', event.candidate);
-    await remoteConnection.addIceCandidate(event.candidate);
+    await pc2.addIceCandidate(event.candidate);
   });
 
-  remoteConnection = new RTCPeerConnection();
-  console.log('Created remote peer connection object remoteConnection');
+  pc2 = new RTCPeerConnection();
+  console.log('Created remote peer connection object pc2');
 
-  remoteConnection.addEventListener('icecandidate', async event => {
+  pc2.addEventListener('icecandidate', async event => {
     console.log('Remote ICE candidate: ', event.candidate);
-    await localConnection.addIceCandidate(event.candidate);
+    await pc1.addIceCandidate(event.candidate);
   });
-  remoteConnection.addEventListener('datachannel', receiveChannelCallback);
+  pc2.addEventListener('datachannel', receiveChannelCallback);
 
   try {
-    const offer = await localConnection.createOffer();
+    const offer = await pc1.createOffer();
     await gotLocalDescription(offer);
   } catch (e) {
     console.log('Failed to create session description: ', e);
@@ -134,10 +134,10 @@ function closeDataChannels() {
     console.log(`Closed data channel with label: ${receiveChannel.label}`);
     receiveChannel = null;
   }
-  localConnection.close();
-  remoteConnection.close();
-  localConnection = null;
-  remoteConnection = null;
+  pc1.close();
+  pc2.close();
+  pc1 = null;
+  pc2 = null;
   console.log('Closed peer connections');
 
   // re-enable the file select
@@ -147,11 +147,11 @@ function closeDataChannels() {
 }
 
 async function gotLocalDescription(desc) {
-  await localConnection.setLocalDescription(desc);
-  console.log(`Offer from localConnection\n ${desc.sdp}`);
-  await remoteConnection.setRemoteDescription(desc);
+  await pc1.setLocalDescription(desc);
+  console.log(`Offer from pc1\n ${desc.sdp}`);
+  await pc2.setRemoteDescription(desc);
   try {
-    const answer = await remoteConnection.createAnswer();
+    const answer = await pc2.createAnswer();
     await gotRemoteDescription(answer);
   } catch (e) {
     console.log('Failed to create session description: ', e);
@@ -159,9 +159,9 @@ async function gotLocalDescription(desc) {
 }
 
 async function gotRemoteDescription(desc) {
-  await remoteConnection.setLocalDescription(desc);
-  console.log(`Answer from remoteConnection\n ${desc.sdp}`);
-  await localConnection.setRemoteDescription(desc);
+  await pc2.setLocalDescription(desc);
+  console.log(`Answer from pc2\n ${desc.sdp}`);
+  await pc1.setRemoteDescription(desc);
 }
 
 function receiveChannelCallback(event) {
@@ -248,8 +248,8 @@ async function onReceiveChannelStateChange() {
 
 // display bitrate statistics.
 async function displayStats() {
-  if (remoteConnection && remoteConnection.iceConnectionState === 'connected') {
-    const stats = await remoteConnection.getStats();
+  if (pc2 && pc2.iceConnectionState === 'connected') {
+    const stats = await pc2.getStats();
     let activeCandidatePair;
     stats.forEach(report => {
       if (report.type === 'transport') {

--- a/src/content/datachannel/filetransfer/js/test.js
+++ b/src/content/datachannel/filetransfer/js/test.js
@@ -35,7 +35,7 @@ describe('datachannel filetransfer', () => {
 
     // the remote connection gets closed when it is done.
     await driver.wait(() => driver.executeScript(() => {
-      return remoteConnection === null; // eslint-disable-line no-undef
+      return pc2 === null; // eslint-disable-line no-undef
     }));
     await driver.wait(() => driver.findElement(webdriver.By.id('download')).isEnabled());
   });

--- a/src/content/datachannel/messaging/main.js
+++ b/src/content/datachannel/messaging/main.js
@@ -19,26 +19,26 @@ class MessagingSample extends LitElement {
   }
 
   disconnect() {
-    this._localConnection.close();
-    this._remoteConnection.close();
+    this._pc1.close();
+    this._pc2.close();
   }
 
   async connect() {
     console.log('connect!');
     try {
       const dataChannelParams = {ordered: true};
-      window.localConnection = this._localConnection = new RTCPeerConnection();
-      this._localConnection.addEventListener('icecandidate', async e => {
+      this._pc1 = new RTCPeerConnection();
+      this._pc1.addEventListener('icecandidate', async e => {
         console.log('local connection ICE candidate: ', e.candidate);
-        await this._remoteConnection.addIceCandidate(e.candidate);
+        await this._pc2.addIceCandidate(e.candidate);
       });
-      window.remoteConnection = this._remoteConnection = new RTCPeerConnection();
-      this._remoteConnection.addEventListener('icecandidate', async e => {
+      this._pc2 = new RTCPeerConnection();
+      this._pc2.addEventListener('icecandidate', async e => {
         console.log('remote connection ICE candidate: ', e.candidate);
-        await this._localConnection.addIceCandidate(e.candidate);
+        await this._pc1.addIceCandidate(e.candidate);
       });
 
-      window.localChannel = this._localChannel = this._localConnection
+      window.localChannel = this._localChannel = this._pc1
           .createDataChannel('messaging-channel', dataChannelParams);
       this._localChannel.binaryType = 'arraybuffer';
       this._localChannel.addEventListener('open', () => {
@@ -51,21 +51,21 @@ class MessagingSample extends LitElement {
       });
       this._localChannel.addEventListener('message', this._onLocalMessageReceived.bind(this));
 
-      this._remoteConnection.addEventListener('datachannel', this._onRemoteDataChannel.bind(this));
+      this._pc2.addEventListener('datachannel', this._onRemoteDataChannel.bind(this));
 
       const initLocalOffer = async () => {
-        const localOffer = await this._localConnection.createOffer();
+        const localOffer = await this._pc1.createOffer();
         console.log(`Got local offer ${JSON.stringify(localOffer)}`);
-        const localDesc = this._localConnection.setLocalDescription(localOffer);
-        const remoteDesc = this._remoteConnection.setRemoteDescription(localOffer);
+        const localDesc = this._pc1.setLocalDescription(localOffer);
+        const remoteDesc = this._pc2.setRemoteDescription(localOffer);
         return Promise.all([localDesc, remoteDesc]);
       };
 
       const initRemoteAnswer = async () => {
-        const remoteAnswer = await this._remoteConnection.createAnswer();
+        const remoteAnswer = await this._pc2.createAnswer();
         console.log(`Got remote answer ${JSON.stringify(remoteAnswer)}`);
-        const localDesc = this._remoteConnection.setLocalDescription(remoteAnswer);
-        const remoteDesc = this._localConnection.setRemoteDescription(remoteAnswer);
+        const localDesc = this._pc2.setLocalDescription(remoteAnswer);
+        const remoteDesc = this._pc1.setRemoteDescription(remoteAnswer);
         return Promise.all([localDesc, remoteDesc]);
       };
 

--- a/src/content/peerconnection/constraints/index.html
+++ b/src/content/peerconnection/constraints/index.html
@@ -39,8 +39,8 @@
     <section id="blurb">
         <p>This demo shows ways to use constraints and statistics in WebRTC applications.</p>
         <p>Set camera constraints, and click <strong>Get media</strong> to (re)open the camera with these included.
-            Click <strong>Connect</strong> to create a (local) peer connection. The RTCPeerConnection objects <code>localPeerConnection</code>
-            and <code>remotePeerConnection</code> can be inspected from the console.</p>
+            Click <strong>Connect</strong> to create a (local) peer connection. The RTCPeerConnection objects <code>pc1</code>
+            and <code>pc2</code> can be inspected from the console.</p>
         <p>Setting a value to zero will remove that constraint. </p>
         <p>The lefthand video shows the output of <code>getUserMedia()</code>; on the right is the video after being
             passed through the peer connection. The transmission bitrate is displayed below the righthand video.</p>

--- a/src/content/peerconnection/constraints/js/main.js
+++ b/src/content/peerconnection/constraints/js/main.js
@@ -40,8 +40,8 @@ const remoteVideoStatsDiv = document.querySelector('div#remoteVideo div');
 
 const updateStats = document.querySelector('input#updateStats');
 
-let localPeerConnection;
-let remotePeerConnection;
+let pc1;
+let pc2;
 let localStream;
 let bytesPrev;
 let timestampPrev;
@@ -54,22 +54,22 @@ function main() {
 
 function hangup() {
   console.log('Ending call');
-  localPeerConnection.close();
-  remotePeerConnection.close();
+  pc1.close();
+  pc2.close();
 
   // query stats one last time.
   Promise
       .all([
-        remotePeerConnection
+        pc2
             .getStats()
             .then(showRemoteStats, err => console.log(err)),
-        localPeerConnection
+        pc1
             .getStats()
             .then(showLocalStats, err => console.log(err))
       ])
       .then(() => {
-        localPeerConnection = null;
-        remotePeerConnection = null;
+        pc1 = null;
+        pc2 = null;
       });
 
   localStream.getTracks().forEach(track => track.stop());
@@ -149,40 +149,40 @@ function createPeerConnection() {
 
   bytesPrev = 0;
   timestampPrev = 0;
-  localPeerConnection = new RTCPeerConnection(null);
-  remotePeerConnection = new RTCPeerConnection(null);
-  localStream.getTracks().forEach(track => localPeerConnection.addTrack(track, localStream));
-  console.log('localPeerConnection creating offer');
-  localPeerConnection.onnegotiationneeded = () => console.log('Negotiation needed - localPeerConnection');
-  remotePeerConnection.onnegotiationneeded = () => console.log('Negotiation needed - remotePeerConnection');
-  localPeerConnection.onicecandidate = e => {
-    console.log('Candidate localPeerConnection');
-    remotePeerConnection
+  pc1 = new RTCPeerConnection(null);
+  pc2 = new RTCPeerConnection(null);
+  localStream.getTracks().forEach(track => pc1.addTrack(track, localStream));
+  console.log('pc1 creating offer');
+  pc1.onnegotiationneeded = () => console.log('Negotiation needed - pc1');
+  pc2.onnegotiationneeded = () => console.log('Negotiation needed - pc2');
+  pc1.onicecandidate = e => {
+    console.log('Candidate pc1');
+    pc2
         .addIceCandidate(e.candidate)
         .then(onAddIceCandidateSuccess, onAddIceCandidateError);
   };
-  remotePeerConnection.onicecandidate = e => {
-    console.log('Candidate remotePeerConnection');
-    localPeerConnection
+  pc2.onicecandidate = e => {
+    console.log('Candidate pc2');
+    pc1
         .addIceCandidate(e.candidate)
         .then(onAddIceCandidateSuccess, onAddIceCandidateError);
   };
-  remotePeerConnection.ontrack = e => {
+  pc2.ontrack = e => {
     if (remoteVideo.srcObject !== e.streams[0]) {
-      console.log('remotePeerConnection got stream');
+      console.log('pc2 got stream');
       remoteVideo.srcObject = e.streams[0];
     }
   };
-  localPeerConnection.createOffer().then(
+  pc1.createOffer().then(
       desc => {
-        console.log('localPeerConnection offering');
-        localPeerConnection.setLocalDescription(desc);
-        remotePeerConnection.setRemoteDescription(desc);
-        remotePeerConnection.createAnswer().then(
+        console.log('pc1 offering');
+        pc1.setLocalDescription(desc);
+        pc2.setRemoteDescription(desc);
+        pc2.createAnswer().then(
             desc2 => {
-              console.log('remotePeerConnection answering');
-              remotePeerConnection.setLocalDescription(desc2);
-              localPeerConnection.setRemoteDescription(desc2);
+              console.log('pc2 answering');
+              pc2.setLocalDescription(desc2);
+              pc1.setRemoteDescription(desc2);
             },
             err => console.log(err)
         );
@@ -265,11 +265,11 @@ setInterval(() => {
   if (!updateStats.checked) {
     return;
   }
-  if (localPeerConnection && remotePeerConnection) {
-    remotePeerConnection
+  if (pc1 && pc2) {
+    pc2
         .getStats()
         .then(showRemoteStats, err => console.log(err));
-    localPeerConnection
+    pc1
         .getStats()
         .then(showLocalStats, err => console.log(err));
   } else {

--- a/src/content/peerconnection/munge-sdp/index.html
+++ b/src/content/peerconnection/munge-sdp/index.html
@@ -69,7 +69,7 @@
 
     <p>View the console to see logging.</p>
 
-    <p>The <code>RTCPeerConnection</code> objects <code>localPeerConnection</code> and <code>remotePeerConnection</code>
+    <p>The <code>RTCPeerConnection</code> objects <code>pc1</code> and <code>pc2</code>
         are in global scope, so you can inspect them in the console as well.</p>
 
     <p>For more information about RTCPeerConnection, see <a

--- a/src/content/peerconnection/munge-sdp/js/main.js
+++ b/src/content/peerconnection/munge-sdp/js/main.js
@@ -31,8 +31,8 @@ const answerSdpTextarea = document.querySelector('div#remote textarea');
 const localVideo = document.querySelector('div#local video');
 const remoteVideo = document.querySelector('div#remote video');
 
-let localPeerConnection;
-let remotePeerConnection;
+let pc1;
+let pc2;
 let localStream;
 let sendChannel;
 let receiveChannel;
@@ -82,22 +82,22 @@ function createPeerConnection() {
     console.log(`Using audio device: ${audioTracks[0].label}`);
   }
 
-  localPeerConnection = new RTCPeerConnection();
-  console.log('Created local peer connection object localPeerConnection');
-  localPeerConnection.onicecandidate = e => onIceCandidate(localPeerConnection, e);
-  sendChannel = localPeerConnection.createDataChannel('sendDataChannel', dataChannelOptions);
+  pc1 = new RTCPeerConnection();
+  console.log('Created local peer connection object pc1');
+  pc1.onicecandidate = e => onIceCandidate(pc1, e);
+  sendChannel = pc1.createDataChannel('sendDataChannel', dataChannelOptions);
   sendChannel.onopen = onSendChannelStateChange;
   sendChannel.onclose = onSendChannelStateChange;
   sendChannel.onerror = onSendChannelStateChange;
 
-  remotePeerConnection = new RTCPeerConnection();
-  console.log('Created remote peer connection object remotePeerConnection');
-  remotePeerConnection.onicecandidate = e => onIceCandidate(remotePeerConnection, e);
-  remotePeerConnection.ontrack = gotRemoteStream;
-  remotePeerConnection.ondatachannel = receiveChannelCallback;
+  pc2 = new RTCPeerConnection();
+  console.log('Created remote peer connection object pc2');
+  pc2.onicecandidate = e => onIceCandidate(pc2, e);
+  pc2.ontrack = gotRemoteStream;
+  pc2.ondatachannel = receiveChannelCallback;
 
   localStream.getTracks()
-      .forEach(track => localPeerConnection.addTrack(track, localStream));
+      .forEach(track => pc1.addTrack(track, localStream));
   console.log('Adding Local Stream to peer connection');
 }
 
@@ -112,7 +112,7 @@ function onSetSessionDescriptionError(error) {
 
 async function createOffer() {
   try {
-    const offer = await localPeerConnection.createOffer(offerOptions);
+    const offer = await pc1.createOffer(offerOptions);
     gotDescription1(offer);
   } catch (e) {
     onCreateSessionDescriptionError(e);
@@ -135,11 +135,10 @@ async function setOffer() {
     type: 'offer',
     sdp: sdp
   };
-  console.log(`Modified Offer from localPeerConnection\n${sdp}`);
+  console.log(`Modified Offer from pc1\n${sdp}`);
 
   try {
-    // eslint-disable-next-line no-unused-vars
-    const ignore = await localPeerConnection.setLocalDescription(offer);
+    await pc1.setLocalDescription(offer);
     onSetSessionDescriptionSuccess();
     setOfferButton.disabled = true;
   } catch (e) {
@@ -148,8 +147,7 @@ async function setOffer() {
   }
 
   try {
-    // eslint-disable-next-line no-unused-vars
-    const ignore = await remotePeerConnection.setRemoteDescription(offer);
+    await pc2.setRemoteDescription(offer);
     onSetSessionDescriptionSuccess();
     createAnswerButton.disabled = false;
   } catch (e) {
@@ -170,7 +168,7 @@ async function createAnswer() {
   // to pass in the right constraints in order for it to
   // accept the incoming offer of audio and video.
   try {
-    const answer = await remotePeerConnection.createAnswer();
+    const answer = await pc2.createAnswer();
     gotDescription2(answer);
   } catch (e) {
     onCreateSessionDescriptionError(e);
@@ -193,7 +191,7 @@ async function setAnswer() {
 
   try {
     // eslint-disable-next-line no-unused-vars
-    const ignore = await remotePeerConnection.setLocalDescription(answer);
+    const ignore = await pc2.setLocalDescription(answer);
     onSetSessionDescriptionSuccess();
     setAnswerButton.disabled = true;
   } catch (e) {
@@ -201,10 +199,10 @@ async function setAnswer() {
     return;
   }
 
-  console.log(`Modified Answer from remotePeerConnection\n${sdp}`);
+  console.log(`Modified Answer from pc2\n${sdp}`);
   try {
     // eslint-disable-next-line no-unused-vars
-    const ignore = await localPeerConnection.setRemoteDescription(answer);
+    const ignore = await pc1.setRemoteDescription(answer);
     onSetSessionDescriptionSuccess();
   } catch (e) {
     onSetSessionDescriptionError(e);
@@ -237,10 +235,10 @@ function hangup() {
   if (receiveChannel) {
     receiveChannel.close();
   }
-  localPeerConnection.close();
-  remotePeerConnection.close();
-  localPeerConnection = null;
-  remotePeerConnection = null;
+  pc1.close();
+  pc2.close();
+  pc1 = null;
+  pc2 = null;
   offerSdpTextarea.disabled = true;
   answerSdpTextarea.disabled = true;
   getMediaButton.disabled = false;
@@ -260,11 +258,11 @@ function gotRemoteStream(e) {
 }
 
 function getOtherPc(pc) {
-  return (pc === localPeerConnection) ? remotePeerConnection : localPeerConnection;
+  return (pc === pc1) ? pc2 : pc1;
 }
 
 function getName(pc) {
-  return (pc === localPeerConnection) ? 'localPeerConnection' : 'remotePeerConnection';
+  return (pc === pc1) ? 'pc1' : 'pc2';
 }
 
 async function onIceCandidate(pc, event) {

--- a/src/content/peerconnection/munge-sdp/js/test.js
+++ b/src/content/peerconnection/munge-sdp/js/test.js
@@ -50,10 +50,10 @@ describe('peerconnection sdp munging', () => {
 
     await Promise.all([
       await driver.wait(() => driver.executeScript(() => {
-        return localPeerConnection && localPeerConnection.connectionState === 'connected'; // eslint-disable-line no-undef
+        return pc1 && pc1.connectionState === 'connected'; // eslint-disable-line no-undef
       })),
       await driver.wait(() => driver.executeScript(() => {
-        return remotePeerConnection && remotePeerConnection.connectionState === 'connected'; // eslint-disable-line no-undef
+        return pc2 && pc2.connectionState === 'connected'; // eslint-disable-line no-undef
       })),
     ]);
   });

--- a/src/content/peerconnection/restart-ice/index.html
+++ b/src/content/peerconnection/restart-ice/index.html
@@ -57,7 +57,7 @@
     </div>
 
     <p>View the console to see logging. The <code>MediaStream</code> object <code>localStream</code>, and the <code>RTCPeerConnection</code>
-        objects <code>localPeerConnection</code> and <code>remotePeerConnection</code> are in global scope, so you can
+        objects <code>pc1</code> and <code>pc2</code> are in global scope, so you can
         inspect them in the console as well.</p>
 
     <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/"

--- a/src/content/peerconnection/webaudio-output/index.html
+++ b/src/content/peerconnection/webaudio-output/index.html
@@ -48,7 +48,7 @@
     </div>
 
     <p>View the console to see logging. The <code>MediaStream</code> object <code>localStream</code>, and the <code>RTCPeerConnection</code>
-        objects <code>localPeerConnection</code> and <code>remotePeerConnection</code> are in global scope, so you can
+        objects <code>pc1</code> and <code>pc2</code> are in global scope, so you can
         inspect them in the console as well.</p>
 
     <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/"


### PR DESCRIPTION
Rename 'localPeerConnection' to 'pc1' and 'remotePeerConnection' to 'pc2' across the codebase. Additionally, rename 'localConnection' to 'pc1' and 'remoteConnection' to 'pc2', and remove explicit 'window.localConnection' and 'window.remoteConnection' assignments.

Prompt for gemini:
```
rename all instances of "localPeerConnection" found using `git grep localPeerConnection`
to `pc1` and all instances of `remotePeerConnection`  to `pc2`
```
(and then repeated for "localConnection")