### PR TITLE
Fix: close @click attribute properly in messaging button (#1641)

### DIFF
--- a/src/content/datachannel/messaging/main.js
+++ b/src/content/datachannel/messaging/main.js
@@ -120,7 +120,7 @@ class MessagingSample extends LitElement {
       <label for="localOutgoing">Local outgoing message:</label>
       <textarea class="message" id="localOutgoing" 
                 placeholder="Local outgoing message goes here."></textarea>
-      <button ?disabled="${!this.connected}" @click="${e => this._sendMessage('#localOutgoing', this._localChannel)} 
+      <button ?disabled="${!this.connected}" @click="${e => this._sendMessage('#localOutgoing', this._localChannel)}"
       id="sendLocal">Send message from local</button>
   </div>
   <div class="messageBox">


### PR DESCRIPTION
**Description**
Fixed issue #1641.

**Purpose**
I wanted to try contributing to open source, so I started with something relatively easy.