### PR TITLE
feat: support configurable multiple receivers and add preview publish workflow

### DIFF
--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -20,25 +20,25 @@ jobs:
         run: |
           set -eux
           TARGET_BRANCH="copilot-preview-${GITHUB_REF_NAME//\//-}"
-          PREVIEW_DIR="/tmp/preview-branch"
+          PREVIEW_WORKTREE="/tmp/preview-${TARGET_BRANCH}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin "${TARGET_BRANCH}" || true
-          rm -rf "${PREVIEW_DIR}"
+          rm -rf "${PREVIEW_WORKTREE}"
           if git show-ref --verify --quiet "refs/remotes/origin/${TARGET_BRANCH}"; then
-            git worktree add "${PREVIEW_DIR}" "origin/${TARGET_BRANCH}"
+            git worktree add "${PREVIEW_WORKTREE}" "origin/${TARGET_BRANCH}"
           else
-            git worktree add -b "${TARGET_BRANCH}" "${PREVIEW_DIR}"
+            git worktree add -b "${TARGET_BRANCH}" "${PREVIEW_WORKTREE}"
           fi
 
           rsync -a --delete \
             --exclude='.git' \
             --exclude='.github/workflows' \
-            ./ "${PREVIEW_DIR}/"
-          touch "${PREVIEW_DIR}/.nojekyll"
+            ./ "${PREVIEW_WORKTREE}/"
+          touch "${PREVIEW_WORKTREE}/.nojekyll"
 
-          cd "${PREVIEW_DIR}"
+          cd "${PREVIEW_WORKTREE}"
           git add -A
           if [ -n "$(git status --porcelain)" ]; then
             git commit -m "Deploy ${GITHUB_SHA}"

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -3,7 +3,7 @@ name: publish-working-branch
 on:
   push:
     branches:
-      - copilot/extend-webrtc-sample-for-multiple-videos
+      - copilot/**
   workflow_dispatch:
 
 permissions:
@@ -19,25 +19,26 @@ jobs:
       - name: Deploy preview branch snapshot
         run: |
           set -eux
-          TARGET_BRANCH="copilot-preview"
+          TARGET_BRANCH="copilot-preview-${GITHUB_REF_NAME//\//-}"
+          PREVIEW_DIR="/tmp/preview-branch"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin "${TARGET_BRANCH}" || true
-          rm -rf /tmp/gh-pages
+          rm -rf "${PREVIEW_DIR}"
           if git show-ref --verify --quiet "refs/remotes/origin/${TARGET_BRANCH}"; then
-            git worktree add /tmp/gh-pages "origin/${TARGET_BRANCH}"
+            git worktree add "${PREVIEW_DIR}" "origin/${TARGET_BRANCH}"
           else
-            git worktree add -b "${TARGET_BRANCH}" /tmp/gh-pages
+            git worktree add -b "${TARGET_BRANCH}" "${PREVIEW_DIR}"
           fi
 
           rsync -a --delete \
             --exclude='.git' \
             --exclude='.github/workflows' \
-            ./ /tmp/gh-pages/
-          touch /tmp/gh-pages/.nojekyll
+            ./ "${PREVIEW_DIR}/"
+          touch "${PREVIEW_DIR}/.nojekyll"
 
-          cd /tmp/gh-pages
+          cd "${PREVIEW_DIR}"
           git add -A
           if [ -n "$(git status --porcelain)" ]; then
             git commit -m "Deploy ${GITHUB_SHA}"

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -19,21 +19,18 @@ jobs:
       - name: Deploy preview branch snapshot
         run: |
           set -eux
-          SANITIZED_REF_NAME="$(printf '%s' "${GITHUB_REF_NAME}" | tr '/ ~^:?*[]\\' '-' | tr -cd '[:alnum:]._-')"
+          SANITIZED_REF_NAME="$(printf '%s' "${GITHUB_REF_NAME}" | sed -E 's#[^A-Za-z0-9._-]#-#g')"
           TARGET_BRANCH="copilot-preview-${SANITIZED_REF_NAME:-unknown-ref}"
           PREVIEW_WORKTREE="/tmp/preview-${TARGET_BRANCH}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
-            git fetch origin "${TARGET_BRANCH}"
-          else
-            echo "Preview branch ${TARGET_BRANCH} does not exist yet; creating it."
-          fi
+          git fetch origin
           rm -rf "${PREVIEW_WORKTREE}"
           if git show-ref --verify --quiet "refs/remotes/origin/${TARGET_BRANCH}"; then
             git worktree add "${PREVIEW_WORKTREE}" "origin/${TARGET_BRANCH}"
           else
+            echo "Preview branch ${TARGET_BRANCH} does not exist yet; creating it."
             git worktree add -b "${TARGET_BRANCH}" "${PREVIEW_WORKTREE}"
           fi
 

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Deploy to gh-pages
+      - name: Deploy preview branch snapshot
         run: |
           set -eux
           TARGET_BRANCH="copilot-preview"

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -19,12 +19,17 @@ jobs:
       - name: Deploy preview branch snapshot
         run: |
           set -eux
-          TARGET_BRANCH="copilot-preview-${GITHUB_REF_NAME//\//-}"
+          SANITIZED_REF_NAME="$(printf '%s' "${GITHUB_REF_NAME}" | tr '/ ~^:?*[]\\' '-' | tr -cd '[:alnum:]._-')"
+          TARGET_BRANCH="copilot-preview-${SANITIZED_REF_NAME:-unknown-ref}"
           PREVIEW_WORKTREE="/tmp/preview-${TARGET_BRANCH}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin "${TARGET_BRANCH}" || true
+          if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "${TARGET_BRANCH}"
+          else
+            echo "Preview branch ${TARGET_BRANCH} does not exist yet; creating it."
+          fi
           rm -rf "${PREVIEW_WORKTREE}"
           if git show-ref --verify --quiet "refs/remotes/origin/${TARGET_BRANCH}"; then
             git worktree add "${PREVIEW_WORKTREE}" "origin/${TARGET_BRANCH}"

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -19,12 +19,17 @@ jobs:
       - name: Deploy to gh-pages
         run: |
           set -eux
+          TARGET_BRANCH="copilot-preview"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin gh-pages
+          git fetch origin "${TARGET_BRANCH}" || true
           rm -rf /tmp/gh-pages
-          git worktree add /tmp/gh-pages origin/gh-pages
+          if git show-ref --verify --quiet "refs/remotes/origin/${TARGET_BRANCH}"; then
+            git worktree add /tmp/gh-pages "origin/${TARGET_BRANCH}"
+          else
+            git worktree add -b "${TARGET_BRANCH}" /tmp/gh-pages
+          fi
 
           rsync -a --delete \
             --exclude='.git' \
@@ -36,7 +41,7 @@ jobs:
           git add -A
           if [ -n "$(git status --porcelain)" ]; then
             git commit -m "Deploy ${GITHUB_SHA}"
-            git push origin HEAD:gh-pages
+            git push origin "HEAD:${TARGET_BRANCH}"
           else
             echo "No changes to deploy."
           fi

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -40,7 +40,7 @@ jobs:
 
           cd "${PREVIEW_WORKTREE}"
           git add -A
-          if [ -n "$(git status --porcelain)" ]; then
+          if ! git diff --cached --quiet; then
             git commit -m "Deploy ${GITHUB_SHA}"
             git push origin "HEAD:${TARGET_BRANCH}"
           else

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -1,0 +1,23 @@
+name: publish-working-branch
+
+on:
+  push:
+    branches:
+      - copilot/extend-webrtc-sample-for-multiple-videos
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: .
+          clean: true
+          single-commit: true

--- a/.github/workflows/publish-working-branch.yml
+++ b/.github/workflows/publish-working-branch.yml
@@ -14,10 +14,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          branch: gh-pages
-          folder: .
-          clean: true
-          single-commit: true
+          fetch-depth: 0
+      - name: Deploy to gh-pages
+        run: |
+          set -eux
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin gh-pages
+          rm -rf /tmp/gh-pages
+          git worktree add /tmp/gh-pages origin/gh-pages
+
+          rsync -a --delete \
+            --exclude='.git' \
+            --exclude='.github/workflows' \
+            ./ /tmp/gh-pages/
+          touch /tmp/gh-pages/.nojekyll
+
+          cd /tmp/gh-pages
+          git add -A
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Deploy ${GITHUB_SHA}"
+            git push origin HEAD:gh-pages
+          else
+            echo "No changes to deploy."
+          fi

--- a/src/content/peerconnection/multiple/css/main.css
+++ b/src/content/peerconnection/multiple/css/main.css
@@ -25,6 +25,23 @@ video#video1 {
   margin: 0 20px 20px 0;
 }
 
+div#remoteVideos {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+div#remoteVideos video {
+  margin: 0 20px 20px 0;
+}
+
+input#videoCountInput {
+  width: 72px;
+}
+
+div#status {
+  margin: 8px 0 0;
+}
+
 @media screen and (max-width: 400px) {
   button {
     margin: 0 11px 10px 0;

--- a/src/content/peerconnection/multiple/index.html
+++ b/src/content/peerconnection/multiple/index.html
@@ -37,14 +37,20 @@
     </h1>
 
     <video id="video1" playsinline autoplay muted></video>
-    <video id="video2" playsinline autoplay></video>
-    <video id="video3" playsinline autoplay></video>
+    <div id="remoteVideos"></div>
+
+    <section>
+        <label for="videoCountInput">Number of receive videos:</label>
+        <input id="videoCountInput" type="number" min="1" max="16" value="2">
+    </section>
 
     <div>
         <button id="startButton">Start</button>
         <button id="callButton">Call</button>
         <button id="hangupButton">Hang Up</button>
     </div>
+
+    <div id="status"></div>
 
     <p>View the console to see logging and to inspect the <code>MediaStream</code> object <code>localStream</code>.</p>
 

--- a/src/content/peerconnection/multiple/index.html
+++ b/src/content/peerconnection/multiple/index.html
@@ -43,6 +43,10 @@
         <label for="videoCountInput">Number of receive videos:</label>
         <input id="videoCountInput" type="number" min="1" max="16" value="2">
     </section>
+    <section>
+        <label for="videoCodecSelect">Video codec:</label>
+        <select id="videoCodecSelect"></select>
+    </section>
 
     <div>
         <button id="startButton">Start</button>

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -97,18 +97,18 @@ async function call() {
   updateStatus();
 }
 
-async function negotiate(localPc, remotePc, index) {
+async function negotiate(localPc, remotePc, displayIndex) {
   localPc.onicecandidate = e => {
     if (e.candidate) {
       remotePc.addIceCandidate(e.candidate).catch(err => {
-        console.warn(`pc${index}: remote addIceCandidate failed`, err);
+        console.warn(`pc${displayIndex}: remote addIceCandidate failed`, err);
       });
     }
   };
   remotePc.onicecandidate = e => {
     if (e.candidate) {
       localPc.addIceCandidate(e.candidate).catch(err => {
-        console.warn(`pc${index}: local addIceCandidate failed`, err);
+        console.warn(`pc${displayIndex}: local addIceCandidate failed`, err);
       });
     }
   };
@@ -117,7 +117,7 @@ async function negotiate(localPc, remotePc, index) {
   await remotePc.setRemoteDescription(localPc.localDescription);
   await remotePc.setLocalDescription();
   await localPc.setRemoteDescription(remotePc.localDescription);
-  console.log(`pc${index}: negotiation completed`);
+  console.log(`pc${displayIndex}: negotiation completed`);
 }
 
 function hangup() {

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -101,14 +101,14 @@ async function negotiate(localPc, remotePc, displayIndex) {
   localPc.onicecandidate = e => {
     if (e.candidate) {
       remotePc.addIceCandidate(e.candidate).catch(err => {
-        console.warn(`pc${displayIndex}: remote addIceCandidate failed`, err);
+        console.warn(`pc${displayIndex}: remotePc.addIceCandidate failed`, err);
       });
     }
   };
   remotePc.onicecandidate = e => {
     if (e.candidate) {
       localPc.addIceCandidate(e.candidate).catch(err => {
-        console.warn(`pc${displayIndex}: local addIceCandidate failed`, err);
+        console.warn(`pc${displayIndex}: localPc.addIceCandidate failed`, err);
       });
     }
   };

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -11,6 +11,9 @@
 const startButton = document.getElementById('startButton');
 const callButton = document.getElementById('callButton');
 const hangupButton = document.getElementById('hangupButton');
+const videoCountInput = document.getElementById('videoCountInput');
+const remoteVideosDiv = document.getElementById('remoteVideos');
+const statusDiv = document.getElementById('status');
 callButton.disabled = true;
 hangupButton.disabled = true;
 startButton.onclick = start;
@@ -18,17 +21,14 @@ callButton.onclick = call;
 hangupButton.onclick = hangup;
 
 const video1 = document.querySelector('video#video1');
-const video2 = document.querySelector('video#video2');
-const video3 = document.querySelector('video#video3');
 
 // eslint-disable-next-line prefer-const
 let preferredVideoCodecMimeType = 'video/VP8';
 
 let localStream;
-let pc1Local;
-let pc1Remote;
-let pc2Local;
-let pc2Remote;
+let peerPairs = [];
+let remoteVideos = [];
+let connectionStates = [];
 
 const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
   'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
@@ -58,7 +58,9 @@ async function start() {
 async function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
-  console.log('Starting calls');
+  videoCountInput.disabled = true;
+  const receiveVideoCount = getRequestedVideoCount();
+  console.log(`Starting ${receiveVideoCount} call(s)`);
   const audioTracks = localStream.getAudioTracks();
   const videoTracks = localStream.getVideoTracks();
   if (audioTracks.length > 0) {
@@ -67,51 +69,110 @@ async function call() {
   if (videoTracks.length > 0) {
     console.log(`Using video device: ${videoTracks[0].label}`);
   }
-  // Create an RTCPeerConnection via the polyfill.
-  pc1Local = new RTCPeerConnection();
-  pc1Remote = new RTCPeerConnection();
-  pc1Remote.ontrack = e => gotRemoteStream(e, video2);
-  console.log('pc1: created local and remote peer connection objects');
-
-  pc2Local = new RTCPeerConnection();
-  pc2Remote = new RTCPeerConnection();
-  pc2Remote.ontrack = e => gotRemoteStream(e, video3);
-  console.log('pc2: created local and remote peer connection objects');
-  localStream.getTracks().forEach(track => {
-    pc1Local.addTrack(track, localStream);
-    pc2Local.addTrack(track, localStream);
-  });
-  await Promise.all([
-    negotiate(pc1Local, pc1Remote),
-    negotiate(pc2Local, pc2Remote),
-  ]);
+  resetRemoteVideos(receiveVideoCount);
+  peerPairs = [];
+  connectionStates = new Array(receiveVideoCount).fill('new');
+  updateStatus();
+  const negotiationPromises = [];
+  for (let i = 0; i < receiveVideoCount; i++) {
+    const index = i + 1;
+    const localPc = new RTCPeerConnection();
+    const remotePc = new RTCPeerConnection();
+    remotePc.ontrack = e => gotRemoteStream(e, remoteVideos[i], index);
+    remotePc.onconnectionstatechange = () => {
+      setConnectionState(i, remotePc.connectionState);
+    };
+    localStream.getTracks().forEach(track => {
+      localPc.addTrack(track, localStream);
+    });
+    console.log(`pc${index}: created local and remote peer connection objects`);
+    peerPairs.push({localPc, remotePc});
+    negotiationPromises.push(negotiate(localPc, remotePc, index));
+  }
+  const results = await Promise.allSettled(negotiationPromises);
+  const failedCount = results.filter(result => result.status === 'rejected').length;
+  if (failedCount > 0) {
+    console.warn(`${failedCount} negotiation(s) failed`);
+  }
+  updateStatus();
 }
 
-async function negotiate(localPc, remotePc) {
-  localPc.onicecandidate = e => remotePc.addIceCandidate(e.candidate);
-  remotePc.onicecandidate = e => localPc.addIceCandidate(e.candidate);
+async function negotiate(localPc, remotePc, index) {
+  localPc.onicecandidate = e => {
+    if (e.candidate) {
+      remotePc.addIceCandidate(e.candidate).catch(err => {
+        console.warn(`pc${index}: remote addIceCandidate failed`, err);
+      });
+    }
+  };
+  remotePc.onicecandidate = e => {
+    if (e.candidate) {
+      localPc.addIceCandidate(e.candidate).catch(err => {
+        console.warn(`pc${index}: local addIceCandidate failed`, err);
+      });
+    }
+  };
 
   await localPc.setLocalDescription();
   await remotePc.setRemoteDescription(localPc.localDescription);
   await remotePc.setLocalDescription();
   await localPc.setRemoteDescription(remotePc.localDescription);
+  console.log(`pc${index}: negotiation completed`);
 }
 
 function hangup() {
   console.log('Ending calls');
-  pc1Local.close();
-  pc1Remote.close();
-  pc2Local.close();
-  pc2Remote.close();
-  pc1Local = pc1Remote = null;
-  pc2Local = pc2Remote = null;
+  peerPairs.forEach(pair => {
+    pair.localPc.close();
+    pair.remotePc.close();
+  });
+  peerPairs = [];
+  resetRemoteVideos(0);
+  connectionStates = [];
+  statusDiv.textContent = '';
   hangupButton.disabled = true;
   callButton.disabled = false;
+  videoCountInput.disabled = false;
 }
 
-function gotRemoteStream(e, videoObject) {
+function gotRemoteStream(e, videoObject, index) {
   maybeSetCodecPreferences(e);
   if (videoObject.srcObject !== e.streams[0]) {
     videoObject.srcObject = e.streams[0];
+    console.log(`pc${index}: received remote stream`);
   }
+}
+
+function getRequestedVideoCount() {
+  const min = Number(videoCountInput.min) || 1;
+  const max = Number(videoCountInput.max) || 16;
+  const parsed = Number(videoCountInput.value);
+  const safeValue = Number.isFinite(parsed) ? parsed : 2;
+  return Math.max(min, Math.min(max, Math.trunc(safeValue)));
+}
+
+function resetRemoteVideos(count) {
+  remoteVideos.forEach(video => {
+    video.srcObject = null;
+  });
+  remoteVideos = [];
+  remoteVideosDiv.textContent = '';
+  for (let i = 0; i < count; i++) {
+    const video = document.createElement('video');
+    video.id = `remoteVideo${i + 1}`;
+    video.autoplay = true;
+    video.playsInline = true;
+    remoteVideos.push(video);
+    remoteVideosDiv.appendChild(video);
+  }
+}
+
+function setConnectionState(index, state) {
+  connectionStates[index] = state;
+  console.log(`pc${index + 1}: remote connection state ${state}`);
+  updateStatus();
+}
+
+function updateStatus() {
+  statusDiv.textContent = connectionStates.map((state, i) => `#${i + 1}:${state}`).join(' ');
 }

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -75,19 +75,19 @@ async function call() {
   updateStatus();
   const negotiationPromises = [];
   for (let i = 0; i < receiveVideoCount; i++) {
-    const index = i + 1;
+    const displayIndex = i + 1;
     const localPc = new RTCPeerConnection();
     const remotePc = new RTCPeerConnection();
-    remotePc.ontrack = e => gotRemoteStream(e, remoteVideos[i], index);
+    remotePc.ontrack = e => gotRemoteStream(e, remoteVideos[i], displayIndex);
     remotePc.onconnectionstatechange = () => {
       setConnectionState(i, remotePc.connectionState);
     };
     localStream.getTracks().forEach(track => {
       localPc.addTrack(track, localStream);
     });
-    console.log(`pc${index}: created local and remote peer connection objects`);
+    console.log(`pc${displayIndex}: created local and remote peer connection objects`);
     peerPairs.push({localPc, remotePc});
-    negotiationPromises.push(negotiate(localPc, remotePc, index));
+    negotiationPromises.push(negotiate(localPc, remotePc, displayIndex));
   }
   const results = await Promise.allSettled(negotiationPromises);
   const failedCount = results.filter(result => result.status === 'rejected').length;

--- a/src/content/peerconnection/multiple/js/main.js
+++ b/src/content/peerconnection/multiple/js/main.js
@@ -12,6 +12,7 @@ const startButton = document.getElementById('startButton');
 const callButton = document.getElementById('callButton');
 const hangupButton = document.getElementById('hangupButton');
 const videoCountInput = document.getElementById('videoCountInput');
+const videoCodecSelect = document.getElementById('videoCodecSelect');
 const remoteVideosDiv = document.getElementById('remoteVideos');
 const statusDiv = document.getElementById('status');
 callButton.disabled = true;
@@ -22,8 +23,7 @@ hangupButton.onclick = hangup;
 
 const video1 = document.querySelector('video#video1');
 
-// eslint-disable-next-line prefer-const
-let preferredVideoCodecMimeType = 'video/VP8';
+let preferredVideoCodecMimeType;
 
 let localStream;
 let peerPairs = [];
@@ -32,16 +32,83 @@ let connectionStates = [];
 
 const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
   'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
-function maybeSetCodecPreferences(trackEvent) {
-  if (!supportsSetCodecPreferences) return;
-  if (trackEvent.track.kind === 'video' && preferredVideoCodecMimeType) {
-    const {codecs} = RTCRtpReceiver.getCapabilities('video');
-    const selectedCodecIndex = codecs.findIndex(c => c.mimeType === preferredVideoCodecMimeType);
-    const selectedCodec = codecs[selectedCodecIndex];
-    codecs.splice(selectedCodecIndex, 1);
-    codecs.unshift(selectedCodec);
-    trackEvent.transceiver.setCodecPreferences(codecs);
+initCodecSelect();
+videoCodecSelect.onchange = () => {
+  preferredVideoCodecMimeType = videoCodecSelect.value;
+};
+
+function initCodecSelect() {
+  const codecMimeTypes = getSupportedVideoCodecMimeTypes();
+  videoCodecSelect.textContent = '';
+  if (codecMimeTypes.length === 0) {
+    videoCodecSelect.disabled = true;
+    preferredVideoCodecMimeType = undefined;
+    return;
   }
+  codecMimeTypes.forEach(mimeType => {
+    const option = document.createElement('option');
+    option.value = mimeType;
+    option.textContent = mimeType;
+    videoCodecSelect.appendChild(option);
+  });
+  const h264MimeType = codecMimeTypes.find(mimeType => mimeType.toLowerCase() === 'video/h264');
+  preferredVideoCodecMimeType = h264MimeType || codecMimeTypes[0];
+  videoCodecSelect.value = preferredVideoCodecMimeType;
+}
+
+function getSupportedVideoCodecMimeTypes() {
+  if (!window.RTCRtpSender || !RTCRtpSender.getCapabilities) {
+    return [];
+  }
+  const capabilities = RTCRtpSender.getCapabilities('video');
+  if (!capabilities || !capabilities.codecs) {
+    return [];
+  }
+  const seen = new Set();
+  return capabilities.codecs
+      .map(codec => codec.mimeType)
+      .filter(mimeType => {
+        if (!mimeType) return false;
+        const normalizedMimeType = mimeType.toLowerCase();
+        if (normalizedMimeType === 'video/rtx' ||
+            normalizedMimeType === 'video/red' ||
+            normalizedMimeType === 'video/ulpfec' ||
+            normalizedMimeType === 'video/flexfec-03') {
+          return false;
+        }
+        if (seen.has(normalizedMimeType)) return false;
+        seen.add(normalizedMimeType);
+        return true;
+      });
+}
+
+function maybeSetCodecPreferences(pc, displayIndex) {
+  if (!supportsSetCodecPreferences || !preferredVideoCodecMimeType) {
+    return;
+  }
+  const videoTransceiver = pc.getTransceivers().find(transceiver =>
+    transceiver.sender &&
+    transceiver.sender.track &&
+    transceiver.sender.track.kind === 'video');
+  if (!videoTransceiver) {
+    return;
+  }
+  const capabilities = RTCRtpSender.getCapabilities('video');
+  if (!capabilities || !capabilities.codecs) {
+    return;
+  }
+  const codecs = capabilities.codecs.slice();
+  const selectedCodecIndex = codecs.findIndex(codec =>
+    codec.mimeType &&
+    codec.mimeType.toLowerCase() === preferredVideoCodecMimeType.toLowerCase());
+  if (selectedCodecIndex < 0) {
+    return;
+  }
+  const selectedCodec = codecs[selectedCodecIndex];
+  codecs.splice(selectedCodecIndex, 1);
+  codecs.unshift(selectedCodec);
+  videoTransceiver.setCodecPreferences(codecs);
+  console.log(`pc${displayIndex}: preferred video codec ${preferredVideoCodecMimeType}`);
 }
 
 async function start() {
@@ -59,6 +126,7 @@ async function call() {
   callButton.disabled = true;
   hangupButton.disabled = false;
   videoCountInput.disabled = true;
+  videoCodecSelect.disabled = true;
   const receiveVideoCount = getRequestedVideoCount();
   console.log(`Starting ${receiveVideoCount} call(s)`);
   const audioTracks = localStream.getAudioTracks();
@@ -85,6 +153,7 @@ async function call() {
     localStream.getTracks().forEach(track => {
       localPc.addTrack(track, localStream);
     });
+    maybeSetCodecPreferences(localPc, displayIndex);
     console.log(`pc${displayIndex}: created local and remote peer connection objects`);
     peerPairs.push({localPc, remotePc});
     negotiationPromises.push(negotiate(localPc, remotePc, displayIndex));
@@ -133,10 +202,10 @@ function hangup() {
   hangupButton.disabled = true;
   callButton.disabled = false;
   videoCountInput.disabled = false;
+  videoCodecSelect.disabled = false;
 }
 
 function gotRemoteStream(e, videoObject, index) {
-  maybeSetCodecPreferences(e);
   if (videoObject.srcObject !== e.streams[0]) {
     videoObject.srcObject = e.streams[0];
     console.log(`pc${index}: received remote stream`);

--- a/src/content/peerconnection/multiple/js/test.js
+++ b/src/content/peerconnection/multiple/js/test.js
@@ -31,6 +31,9 @@ describe('multiple peerconnections', () => {
     await driver.wait(() => driver.executeScript(() => {
       return document.getElementById('videoCountInput').value === '2';
     }));
+    await driver.wait(() => driver.executeScript(() => {
+      return document.getElementById('videoCodecSelect').options.length > 0;
+    }));
 
     await driver.findElement(webdriver.By.id('startButton')).click();
 
@@ -38,7 +41,10 @@ describe('multiple peerconnections', () => {
       return localStream !== null; // eslint-disable-line no-undef
     }));
     await driver.wait(() => driver.findElement(webdriver.By.id('callButton')).isEnabled());
+    await driver.wait(() => driver.findElement(webdriver.By.id('videoCodecSelect')).isEnabled());
     await driver.findElement(webdriver.By.id('callButton')).click();
+    await driver.wait(() => driver.findElement(webdriver.By.id('videoCodecSelect')).isEnabled()
+        .then(enabled => !enabled));
 
     await driver.wait(() => driver.executeScript(() => {
       return peerPairs.length === 2; // eslint-disable-line no-undef
@@ -61,5 +67,6 @@ describe('multiple peerconnections', () => {
     await driver.wait(() => driver.executeScript(() => {
       return peerPairs.length === 0; // eslint-disable-line no-undef
     }));
+    await driver.wait(() => driver.findElement(webdriver.By.id('videoCodecSelect')).isEnabled());
   });
 });

--- a/src/content/peerconnection/multiple/js/test.js
+++ b/src/content/peerconnection/multiple/js/test.js
@@ -28,6 +28,10 @@ describe('multiple peerconnections', () => {
   });
 
   it('establishes multiple connections and hangs up', async () => {
+    await driver.wait(() => driver.executeScript(() => {
+      return document.getElementById('videoCountInput').value === '2';
+    }));
+
     await driver.findElement(webdriver.By.id('startButton')).click();
 
     await driver.wait(() => driver.executeScript(() => {

--- a/src/content/peerconnection/multiple/js/test.js
+++ b/src/content/peerconnection/multiple/js/test.js
@@ -44,10 +44,10 @@ describe('multiple peerconnections', () => {
     }));
 
     await Promise.all([
-      await driver.wait(() => driver.executeScript(() => {
+      driver.wait(() => driver.executeScript(() => {
         return document.getElementById('remoteVideo1').readyState === HTMLMediaElement.HAVE_ENOUGH_DATA;
       })),
-      await driver.wait(() => driver.executeScript(() => {
+      driver.wait(() => driver.executeScript(() => {
         return document.getElementById('remoteVideo2').readyState === HTMLMediaElement.HAVE_ENOUGH_DATA;
       })),
     ]);

--- a/src/content/peerconnection/multiple/js/test.js
+++ b/src/content/peerconnection/multiple/js/test.js
@@ -36,34 +36,26 @@ describe('multiple peerconnections', () => {
     await driver.wait(() => driver.findElement(webdriver.By.id('callButton')).isEnabled());
     await driver.findElement(webdriver.By.id('callButton')).click();
 
-    await Promise.all([
-      driver.wait(() => driver.executeScript(() => {
-        return pc1Remote && pc1Remote.connectionState === 'connected'; // eslint-disable-line no-undef
-      })),
-      await driver.wait(() => driver.executeScript(() => {
-        return pc2Remote && pc2Remote.connectionState === 'connected'; // eslint-disable-line no-undef
-      })),
-    ]);
+    await driver.wait(() => driver.executeScript(() => {
+      return peerPairs.length === 2; // eslint-disable-line no-undef
+    }));
+    await driver.wait(() => driver.executeScript(() => {
+      return peerPairs.every(pair => pair.remotePc && pair.remotePc.connectionState === 'connected'); // eslint-disable-line no-undef
+    }));
 
     await Promise.all([
       await driver.wait(() => driver.executeScript(() => {
-        return document.getElementById('video2').readyState === HTMLMediaElement.HAVE_ENOUGH_DATA;
+        return document.getElementById('remoteVideo1').readyState === HTMLMediaElement.HAVE_ENOUGH_DATA;
       })),
       await driver.wait(() => driver.executeScript(() => {
-        return document.getElementById('video3').readyState === HTMLMediaElement.HAVE_ENOUGH_DATA;
+        return document.getElementById('remoteVideo2').readyState === HTMLMediaElement.HAVE_ENOUGH_DATA;
       })),
     ]);
 
     await driver.findElement(webdriver.By.id('hangupButton')).click();
 
-    await Promise.all([
-      await driver.wait(() => driver.executeScript(() => {
-        return pc1Remote === null; // eslint-disable-line no-undef
-      })),
-      await driver.wait(() => driver.executeScript(() => {
-        return pc2Remote === null; // eslint-disable-line no-undef
-      })),
-    ]);
+    await driver.wait(() => driver.executeScript(() => {
+      return peerPairs.length === 0; // eslint-disable-line no-undef
+    }));
   });
 });
-


### PR DESCRIPTION
## Summary
This PR updates the `peerconnection/multiple` sample with configurable receive-side fan-out and codec preference selection, and adds a workflow to publish Copilot branch snapshots to preview branches.

## Changes
- Add configurable "Number of receive videos" control.
- Add video codec selector from sender capabilities, with H.264 preferred by default when available.
- Dynamically create peer pairs and remote video elements based on requested count.
- Track/display per-connection state and improve ICE candidate error logging clarity.
- Update Selenium test assertions for new controls and connection lifecycle.
- Add `publish-working-branch` workflow to deploy `copilot/**` snapshots to sanitized `copilot-preview-*` branches using worktrees.

## Files changed
- `.github/workflows/publish-working-branch.yml` (new)
- `src/content/peerconnection/multiple/index.html`
- `src/content/peerconnection/multiple/js/main.js`
- `src/content/peerconnection/multiple/js/test.js`
- `src/content/peerconnection/multiple/css/main.css`

## Impact
- Functional: multiple sample now supports configurable receiver count and codec preference.
- CI/CD: preview deployment is isolated to per-branch preview targets and avoids mutating `gh-pages` directly.